### PR TITLE
ci: remove VAULT_ADDR override, fix stale create_key comment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,8 @@ variables:
   BUILDER_IMAGE: "registry.ddbuild.io/images/mirror/dd-trace-java-docker-build:ci-base"
   # Route external Maven/Gradle resolution through Datadog's internal proxy.
   MAVEN_REPOSITORY_PROXY: "https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/"
-  VAULT_ADDR: "https://vault.us1.ddbuild.io"
+  # NOTE: do NOT set VAULT_ADDR here. The CI runner injects it via Emissary.
+  # Overriding it bypasses Emissary and removes the Vault token, causing auth failures.
 
 default:
   tags: ["arch:amd64"]
@@ -67,8 +68,8 @@ publish_snapshot:
     - export ORG_GRADLE_PROJECT_signingInMemoryKeyPassword=$(vault kv get -field=gpg_passphrase kv/k8s/gitlab-runner/java-reggie/signing)
     - ./gradlew :reggie-runtime:publishToSonatype $GRADLE_ARGS
 
-# Run once manually to generate the GPG signing key and store it in AWS SSM
-# under ci.java-reggie.signing.*. The public key is exported as a job artifact
+# Run once manually to generate the GPG signing key and store it in Vault
+# at kv/k8s/gitlab-runner/java-reggie/signing. The public key is exported as a job artifact
 # and uploaded to the public keyserver if EXPORT_TO_KEYSERVER=true.
 create_key:
   stage: generate-signing-key


### PR DESCRIPTION
### What does this PR do?

Removes the global `VAULT_ADDR` variable from `.gitlab-ci.yml` and replaces it with an explanatory comment.
Also corrects a stale comment on the `create_key` job that still referenced AWS SSM.

### Motivation

The CI secrets documentation explicitly warns:

> When reading Vault secrets from a GitLab CI job using the Vault CLI or Vault SDK, be careful to **not** set the `VAULT_ADDR` environment variable. A `VAULT_ADDR` environment variable is already injected in the environment of your CI job, and overwriting it will cause clients to skip Emissary and not have a vault token attached to their request, causing requests to fail.

The global `VAULT_ADDR: "https://vault.us1.ddbuild.io"` was bypassing Emissary and would prevent the `vault kv get` calls in `publish_snapshot` and `publish_to_maven_central` from authenticating.

Companion to DataDog/vault-config#9548 (admin Vault policy for java-reggie CI secrets).

### Related Issue(s)

DataDog/vault-config#9548

### Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [ ] Test improvement
- [x] Build/CI change

### Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] All existing tests pass (`./gradlew build`)
- [ ] I have added tests for my changes
- [x] I have updated documentation (if applicable)
- [x] My commits are signed

### Performance Impact

N/A

### Additional Notes

The `update-maven-central-secrets.sh` local script is unaffected — it uses `${VAULT_ADDR:-https://vault.us1.ddbuild.io}` with a safe fallback that does not override a pre-existing value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)