### PR TITLE
fix: PCRE lookahead-in-capturing-group and optional-quantifier backtrack (#36)

### DIFF
--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
@@ -413,7 +413,19 @@ public class PatternAnalyzer {
         SubsetConstructor constructor = new SubsetConstructor();
         DFA dfa = constructor.buildDFAWithAssertions(nfa);
 
-        // Success! Assertions are simple literals, use DFA
+        // Success! Assertions are simple literals, use DFA.
+        // However, when a lookahead appears inside a capturing group, the DFA path
+        // uses match(substring) for group extraction which breaks lookaheads that
+        // need to inspect characters beyond the match boundary. Route to NFA instead.
+        if (!ignoreGroupCount && hasLookaheadInsideCapturingGroup(ast)) {
+          return new MatchingStrategyResult(
+              MatchingStrategy.OPTIMIZED_NFA_WITH_LOOKAROUND,
+              null,
+              null,
+              false,
+              requiredLiterals,
+              lookaheadGreedyInfo);
+        }
         int stateCount = dfa.getStateCount();
         if (stateCount < 20) {
           return new MatchingStrategyResult(
@@ -789,6 +801,45 @@ public class PatternAnalyzer {
     return node.accept(detector);
   }
 
+  // DFA path uses match(substring) for group extraction, cutting lookahead context at the boundary.
+  private boolean hasLookaheadInsideCapturingGroup(RegexNode node) {
+    return hasLookaheadInsideCapturingGroupHelper(node, false);
+  }
+
+  private boolean hasLookaheadInsideCapturingGroupHelper(RegexNode node, boolean insideCapturing) {
+    if (node instanceof AssertionNode) {
+      AssertionNode a = (AssertionNode) node;
+      // Only positive/negative lookaheads matter (not lookbehinds)
+      if ((a.type == AssertionNode.Type.POSITIVE_LOOKAHEAD
+              || a.type == AssertionNode.Type.NEGATIVE_LOOKAHEAD)
+          && insideCapturing) {
+        return true;
+      }
+      return hasLookaheadInsideCapturingGroupHelper(a.subPattern, insideCapturing);
+    }
+    if (node instanceof GroupNode) {
+      GroupNode g = (GroupNode) node;
+      boolean nowInCapturing = insideCapturing || g.capturing;
+      return hasLookaheadInsideCapturingGroupHelper(g.child, nowInCapturing);
+    }
+    if (node instanceof ConcatNode) {
+      for (RegexNode child : ((ConcatNode) node).children) {
+        if (hasLookaheadInsideCapturingGroupHelper(child, insideCapturing)) return true;
+      }
+      return false;
+    }
+    if (node instanceof AlternationNode) {
+      for (RegexNode alt : ((AlternationNode) node).alternatives) {
+        if (hasLookaheadInsideCapturingGroupHelper(alt, insideCapturing)) return true;
+      }
+      return false;
+    }
+    if (node instanceof QuantifierNode) {
+      return hasLookaheadInsideCapturingGroupHelper(((QuantifierNode) node).child, insideCapturing);
+    }
+    return false;
+  }
+
   /**
    * Check if any backref references a capturing group defined inside a lookahead assertion. This
    * requires falling back to NFA-based matching since DFA can't track groups.
@@ -965,16 +1016,33 @@ public class PatternAnalyzer {
       return null;
     }
     GroupNode group = (GroupNode) node;
-    if (!group.capturing || !(group.child instanceof QuantifierNode)) {
+    if (!group.capturing) {
       return null;
     }
-    QuantifierNode quant = (QuantifierNode) group.child;
-    // Check if quantifier is greedy and variable (min != max)
-    if (!quant.greedy || quant.min == quant.max) {
-      return null;
+    // Direct quantifier child: (x*)
+    if (group.child instanceof QuantifierNode) {
+      QuantifierNode quant = (QuantifierNode) group.child;
+      if (!quant.greedy || quant.min == quant.max) {
+        return null;
+      }
+      return getNodeCharSet(quant.child);
     }
-    // Extract CharSet from the quantifier's child
-    return getNodeCharSet(quant.child);
+    // ConcatNode child: inspect its last element for a trailing optional greedy quantifier
+    // e.g., (\.\d\d[1-9]?) where the last element [1-9]? is an optional greedy quantifier
+    if (group.child instanceof ConcatNode) {
+      ConcatNode concat = (ConcatNode) group.child;
+      if (concat.children.isEmpty()) {
+        return null;
+      }
+      RegexNode last = concat.children.get(concat.children.size() - 1);
+      if (last instanceof QuantifierNode) {
+        QuantifierNode quant = (QuantifierNode) last;
+        if (quant.min == 0 && quant.max > 0 && quant.greedy) {
+          return getNodeCharSet(quant.child);
+        }
+      }
+    }
+    return null;
   }
 
   /** Get the CharSet that a node can match. Returns null if the CharSet cannot be determined. */

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
@@ -417,7 +417,7 @@ public class PatternAnalyzer {
         // However, when a lookahead appears inside a capturing group, the DFA path
         // uses match(substring) for group extraction which breaks lookaheads that
         // need to inspect characters beyond the match boundary. Route to NFA instead.
-        if (!ignoreGroupCount && hasLookaheadInsideCapturingGroup(ast)) {
+        if (hasLookaheadInsideCapturingGroup(ast)) {
           return new MatchingStrategyResult(
               MatchingStrategy.OPTIMIZED_NFA_WITH_LOOKAROUND,
               null,
@@ -1037,7 +1037,7 @@ public class PatternAnalyzer {
       RegexNode last = concat.children.get(concat.children.size() - 1);
       if (last instanceof QuantifierNode) {
         QuantifierNode quant = (QuantifierNode) last;
-        if (quant.min == 0 && quant.max > 0 && quant.greedy) {
+        if (quant.min == 0 && quant.max == 1 && quant.greedy) {
           return getNodeCharSet(quant.child);
         }
       }

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
@@ -994,8 +994,9 @@ public class PatternAnalyzer {
     for (int i = 0; i < concat.children.size() - 1; i++) {
       CharSet greedyCharSet = getGreedyGroupCharSet(concat.children.get(i));
       if (greedyCharSet != null) {
-        // Found a greedy group - check if it overlaps with the next element
-        CharSet nextFirstCharSet = getFirstCharSet(concat.children.get(i + 1));
+        // Found a greedy group - check if it overlaps with the suffix, looking through
+        // nullable nodes (e.g. -? in ([1-9]?)-?\d+ can be skipped when [1-9] gives back).
+        CharSet nextFirstCharSet = getSuffixFirstCharSetSkippingNullable(concat, i + 1);
         if (nextFirstCharSet == null || greedyCharSet.intersects(nextFirstCharSet)) {
           // Overlap detected (or can't determine) - needs backtracking
           return true;
@@ -1112,6 +1113,43 @@ public class PatternAnalyzer {
       return result;
     }
     return null; // Unknown node type - be conservative
+  }
+
+  private boolean isNullable(RegexNode node) {
+    if (node instanceof QuantifierNode) {
+      return ((QuantifierNode) node).min == 0;
+    }
+    if (node instanceof GroupNode) {
+      return isNullable(((GroupNode) node).child);
+    }
+    if (node instanceof ConcatNode) {
+      for (RegexNode child : ((ConcatNode) node).children) {
+        if (!isNullable(child)) return false;
+      }
+      return true;
+    }
+    if (node instanceof AlternationNode) {
+      for (RegexNode alt : ((AlternationNode) node).alternatives) {
+        if (isNullable(alt)) return true;
+      }
+      return false;
+    }
+    return false;
+  }
+
+  private CharSet getSuffixFirstCharSetSkippingNullable(ConcatNode concat, int fromIndex) {
+    CharSet result = CharSet.empty();
+    for (int j = fromIndex; j < concat.children.size(); j++) {
+      CharSet firstChars = getFirstCharSet(concat.children.get(j));
+      if (firstChars == null) {
+        return null;
+      }
+      result = result.union(firstChars);
+      if (!isNullable(concat.children.get(j))) {
+        break;
+      }
+    }
+    return result.isEmpty() ? null : result;
   }
 
   /** Check if node contains a capturing group with a greedy quantifier. */

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/RecursiveDescentBytecodeGenerator.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/RecursiveDescentBytecodeGenerator.java
@@ -3108,7 +3108,8 @@ public class RecursiveDescentBytecodeGenerator {
           GroupNode g = (GroupNode) child;
           if (g.groupNumber > 0
               && !PatternAnalyzer.hasSelfReferencingBackref(g)
-              && extractTrailingOptionalBackref(g.child) != null) {
+              && (extractTrailingOptionalBackref(g.child) != null
+                  || hasTrailingOptionalQuantifier(g.child))) {
             nextBacktrackIdx = i;
             nextBacktrackGroup = g;
             break;

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/RecursiveDescentBytecodeGenerator.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/RecursiveDescentBytecodeGenerator.java
@@ -2079,8 +2079,32 @@ public class RecursiveDescentBytecodeGenerator {
           if (extractTrailingOptionalBackref(g.child) != null) {
             return true;
           }
+          // Trailing optional greedy quantifier changes the group boundary, requiring
+          // the same two-path backtracking as a trailing optional backref.
+          if (hasTrailingOptionalQuantifier(g.child)) {
+            return true;
+          }
         }
         return containsBacktrackingQuantifier(g.child);
+      }
+      return false;
+    }
+
+    private boolean hasTrailingOptionalQuantifier(RegexNode node) {
+      if (node instanceof QuantifierNode) {
+        QuantifierNode q = (QuantifierNode) node;
+        return q.min == 0 && q.max == 1 && q.greedy;
+      }
+      if (node instanceof ConcatNode) {
+        ConcatNode concat = (ConcatNode) node;
+        if (concat.children.isEmpty()) {
+          return false;
+        }
+        RegexNode last = concat.children.get(concat.children.size() - 1);
+        if (last instanceof QuantifierNode) {
+          QuantifierNode q = (QuantifierNode) last;
+          return q.min == 0 && q.max == 1 && q.greedy;
+        }
       }
       return false;
     }
@@ -2233,13 +2257,13 @@ public class RecursiveDescentBytecodeGenerator {
       }
 
       if (quantNode == null) {
-        // Check if the child is a GroupNode with a trailing optional backref.
-        // e.g. (a\1?) where the group can match "a" or "aa" depending on \1.
         // Generate two-path backtracking: try full group first, then mandatory-only.
         if (greedyChild instanceof GroupNode) {
           GroupNode backtrackGroup = (GroupNode) greedyChild;
           QuantifierNode trailingOpt = extractTrailingOptionalBackref(backtrackGroup.child);
-          if (trailingOpt != null) {
+          boolean needsTwoPathBacktrack =
+              trailingOpt != null || hasTrailingOptionalQuantifier(backtrackGroup.child);
+          if (needsTwoPathBacktrack) {
             // Emit a local fail label that returns -1
             Label localFail = new Label();
             generateGroupWithOptionalBacktracking(

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/RecursiveDescentBytecodeGenerator.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/RecursiveDescentBytecodeGenerator.java
@@ -2631,6 +2631,34 @@ public class RecursiveDescentBytecodeGenerator {
       QuantifierNode nestedQuantNode = extractQuantifier(nestedChild);
 
       if (nestedQuantNode == null) {
+        // Apply two-path backtracking when a non-quantified GroupNode has a trailing optional
+        // quantifier. Reuse slotBase+0..1 (unused in this path) for pos/groups snapshot.
+        if (nestedChild instanceof GroupNode) {
+          GroupNode nestedGroup = (GroupNode) nestedChild;
+          if (hasTrailingOptionalQuantifier(nestedGroup.child)) {
+            int savedPosBefore = slotBase;
+            int savedGroupsBefore = slotBase + 1;
+            mv.visitVarInsn(ILOAD, 5);
+            mv.visitVarInsn(ISTORE, savedPosBefore);
+            generateGroupArraySave(4, savedGroupsBefore);
+            Label localFail = new Label();
+            Label successDone = new Label();
+            generateGroupWithOptionalBacktracking(
+                node,
+                nestedIndex,
+                nestedGroup,
+                slotBase + 2,
+                savedGroupsBefore,
+                savedPosBefore,
+                localFail);
+            mv.visitJumpInsn(GOTO, successDone);
+            mv.visitLabel(localFail);
+            mv.visitIincInsn(outerTryMatchCountSlot, outerBacktrackDelta);
+            mv.visitJumpInsn(GOTO, outerBacktrackLoop);
+            mv.visitLabel(successDone);
+            return;
+          }
+        }
         // Not a quantifier - process normally and continue
         generateParserMethod(cw, className, nestedChild);
         String childMethod = getMethodNameForNode(nestedChild);

--- a/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzerGreedyGroupCharSetTest.java
+++ b/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzerGreedyGroupCharSetTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.codegen.analysis;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.datadoghq.reggie.codegen.ast.RegexNode;
+import com.datadoghq.reggie.codegen.automaton.NFA;
+import com.datadoghq.reggie.codegen.automaton.ThompsonBuilder;
+import com.datadoghq.reggie.codegen.parsing.RegexParser;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that {@code PatternAnalyzer} correctly identifies capturing groups whose ConcatNode child
+ * ends with an optional greedy quantifier as requiring backtracking when the following element
+ * overlaps the optional's charset.
+ */
+class PatternAnalyzerGreedyGroupCharSetTest {
+
+  private PatternAnalyzer.MatchingStrategyResult analyze(String pattern) throws Exception {
+    RegexParser parser = new RegexParser();
+    RegexNode ast = parser.parse(pattern);
+    ThompsonBuilder builder = new ThompsonBuilder();
+    int groupCount = countCapturingGroups(pattern);
+    NFA nfa = builder.build(ast, groupCount);
+    PatternAnalyzer analyzer = new PatternAnalyzer(ast, nfa);
+    return analyzer.analyzeAndRecommend();
+  }
+
+  /** Count capturing groups by scanning for unescaped {@code (} not followed by {@code ?}. */
+  private int countCapturingGroups(String pattern) {
+    int count = 0;
+    boolean escaped = false;
+    for (int i = 0; i < pattern.length(); i++) {
+      char c = pattern.charAt(i);
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (c == '\\') {
+        escaped = true;
+      } else if (c == '(' && i + 1 < pattern.length() && pattern.charAt(i + 1) != '?') {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  @Test
+  void testConcatGroupWithTrailingOptionalOverlappingNext() throws Exception {
+    // (\.\d\d[1-9]?)\d+ — group has ConcatNode child ending in optional [1-9]?,
+    // and \d+ overlaps [1-9]. Must route to RECURSIVE_DESCENT.
+    PatternAnalyzer.MatchingStrategyResult result = analyze("(\\.\\d\\d[1-9]?)\\d+");
+    assertEquals(
+        PatternAnalyzer.MatchingStrategy.RECURSIVE_DESCENT,
+        result.strategy,
+        "Group with trailing optional greedy quantifier overlapping next element must use RECURSIVE_DESCENT");
+  }
+
+  @Test
+  void testConcatGroupWithTrailingOptionalNonOverlapping() throws Exception {
+    // (\.\d\d[a-z]?)\d+ — [a-z] and \d are disjoint; no backtracking needed.
+    // Should NOT route to RECURSIVE_DESCENT.
+    PatternAnalyzer.MatchingStrategyResult result = analyze("(\\.\\d\\d[a-z]?)\\d+");
+    assertNotEquals(
+        PatternAnalyzer.MatchingStrategy.RECURSIVE_DESCENT,
+        result.strategy,
+        "Group with trailing optional greedy quantifier NOT overlapping next element must not use RECURSIVE_DESCENT");
+  }
+}

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/GreedyOptionalBacktrackTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/GreedyOptionalBacktrackTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.datadoghq.reggie.Reggie;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Oracle tests for capturing groups with a trailing optional greedy quantifier followed by an
+ * overlapping element. The group must give back the optional match when the continuation requires
+ * it.
+ */
+public class GreedyOptionalBacktrackTest {
+
+  @Test
+  public void testDecimalGroupOptionalDigit() {
+    // (\.\d\d[1-9]?)\d+ on "1.235":
+    // Group wants to match ".23" and let \d+ take "5"
+    // because [1-9]? greedily takes "5" but then \d+ has nothing left
+    ReggieMatcher m = Reggie.compile("(\\.\\d\\d[1-9]?)\\d+");
+    MatchResult mr = m.findMatch("1.235");
+
+    assertNotNull(mr, "Should find match");
+    assertEquals(".235", mr.group(0), "Full match should be '.235'");
+    assertEquals(1, mr.groupCount(), "Should have 1 capturing group");
+    assertEquals(".23", mr.group(1), "Group 1 must backtrack: [1-9]? gives back '5' to \\d+");
+  }
+}

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LookaheadGroupCaptureTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LookaheadGroupCaptureTest.java
@@ -92,6 +92,22 @@ public class LookaheadGroupCaptureTest {
     assertEquals("a", mr.group(2), "Group 2 should capture 'a' from second alternative");
   }
 
+  @Test
+  public void testLookaheadNestedAlternationGroupCapture() {
+    // Pattern (\.\d\d((?=0)|\d(?=\d))) on "1.875000282":
+    //   Group 1: the outer capturing group (\.\d\d((?=0)|\d(?=\d)))
+    //   Group 2: the inner alternation group ((?=0)|\d(?=\d))
+    // The second alternative \d(?=\d) matches "5" and the lookahead confirms "5" is followed by "0"
+    ReggieMatcher m = Reggie.compile("(\\.\\d\\d((?=0)|\\d(?=\\d)))");
+    MatchResult mr = m.findMatch("1.875000282");
+
+    assertNotNull(mr, "Should find match");
+    assertEquals(".875", mr.group(0), "Full match should be '.875'");
+    assertEquals(2, mr.groupCount(), "Should have 2 capturing groups");
+    assertEquals(".875", mr.group(1), "Group 1 should capture '.875'");
+    assertEquals("5", mr.group(2), "Group 2 should capture '5' from \\d(?=\\d) branch");
+  }
+
   // TODO: This test is disabled due to a known limitation in DFA-based assertion handling.
   // In pattern "(?=(a))ab|c", the lookahead assertion is at the DFA start state and
   // affects ALL transitions, not just the 'a' transition. When assertion fails on 'c',


### PR DESCRIPTION
### What does this PR do?

Fix two PCRE conformance bugs where lookahead assertions and optional greedy quantifiers inside capturing groups produce wrong results.

**Bug 1** — Pattern `(\.\d\d((?=0)|\d(?=\d)))` on `1.875000282`: group(2) returned the wrong value because the DFA strategy calls `match(substring)` for group extraction, truncating the lookahead context at the group boundary. Fix: detect lookahead-inside-capturing-group at analysis time and route to `OPTIMIZED_NFA_WITH_LOOKAROUND`.

**Bug 2** — Pattern `(\.\d\d[1-9]?)\d+` on `1.235`: group(1) returned `.235` instead of `.23` because the optional `[1-9]?` consumed `5` without backtracking when the continuation `\d+` needed it. Fix: extend `getGreedyGroupCharSet` to unwrap `ConcatNode` children and detect trailing optional quantifiers; teach the bytecode generator to emit two-path backtracking for those groups.

### Motivation

Conformance with the PCRE test suite — these were two remaining failures in category 6 after Phase 2.1.

### Related Issue(s)

Fixes #36

### Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [x] Test improvement
- [ ] Build/CI change

### Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] All existing tests pass (`./gradlew build`)
- [x] I have added tests for my changes
- [ ] I have updated documentation (if applicable)
- [x] My commits are signed

### Performance Impact

No runtime impact — the new `hasLookaheadInsideCapturingGroup` check runs once per pattern compilation, not per match. The two-path backtracking path was already present for backref-trailing groups; extending it to quantifier-trailing groups adds no new code paths at match time.

### Additional Notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)