### PR TITLE
perf: O(n) single-pass IAST drain + capture routing (Class A/E, MGG give-back)

### DIFF
--- a/reggie-benchmark/src/main/java/com/datadoghq/reggie/benchmark/IastRegexpBenchmark.java
+++ b/reggie-benchmark/src/main/java/com/datadoghq/reggie/benchmark/IastRegexpBenchmark.java
@@ -276,6 +276,17 @@ public class IastRegexpBenchmark {
     return sum;
   }
 
+  private static long sumGroupOffsets(com.google.re2j.Matcher m, int maxGroup) {
+    long sum = 0;
+    for (int g = 1; g <= maxGroup; g++) {
+      int s = m.start(g);
+      if (s >= 0) {
+        sum += s + m.end(g);
+      }
+    }
+    return sum;
+  }
+
   @Benchmark
   public long reggieUrlAuthCapture() {
     MatchResult r = reggieUrl.findMatch(URL_AUTH_MATCH);
@@ -306,6 +317,24 @@ public class IastRegexpBenchmark {
   @Benchmark
   public long jdkUrlQueryCapture() {
     java.util.regex.Matcher m = jdkUrl.matcher(URL_QUERY_MATCH);
+    if (!m.find()) {
+      return -1L;
+    }
+    return sumGroupOffsets(m, 3);
+  }
+
+  @Benchmark
+  public long re2jUrlAuthCapture() {
+    com.google.re2j.Matcher m = re2jUrl.matcher(URL_AUTH_MATCH);
+    if (!m.find()) {
+      return -1L;
+    }
+    return sumGroupOffsets(m, 3);
+  }
+
+  @Benchmark
+  public long re2jUrlQueryCapture() {
+    com.google.re2j.Matcher m = re2jUrl.matcher(URL_QUERY_MATCH);
     if (!m.find()) {
       return -1L;
     }

--- a/reggie-benchmark/src/main/java/com/datadoghq/reggie/benchmark/IastTokenizerDrainBenchmark.java
+++ b/reggie-benchmark/src/main/java/com/datadoghq/reggie/benchmark/IastTokenizerDrainBenchmark.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.benchmark;
+
+import com.datadoghq.reggie.runtime.MatchResult;
+import com.datadoghq.reggie.runtime.ReggieMatcher;
+import com.datadoghq.reggie.runtime.RuntimeCompiler;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import org.openjdk.jmh.annotations.*;
+
+/**
+ * Representative IAST tokenizer benchmark mirroring dd-trace-java's SensitiveTokenizerBenchmark:
+ * MALFORMED payloads (512/1024/2048 bytes) that are FULLY DRAINED (find ALL matches across the
+ * payload, advancing past each). This exercises JDK's catastrophic backtracking, which the
+ * tiny-input single-find() {@link IastRegexpBenchmark} hides.
+ *
+ * <p>Compares Reggie vs RE2J vs JDK. Each drain body is wrapped in a try/catch returning -1 on any
+ * Throwable (JDK may stack-overflow / blow up on pathological scenarios — same as dd-trace).
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class IastTokenizerDrainBenchmark {
+
+  // --- Pattern strings (verbatim from IastRegexpBenchmark) ---
+  private static final String COMMAND = "(?s)(?m)^(?:\\s*(?:sudo|doas)\\s+)?\\b\\S+\\b\\s*(.*)";
+
+  private static final String URL_JDK =
+      "^(?:[^:]+:)?//(?<AUTHORITY>[^@]+)@|[?#&]([^=&;]+)=(?<QUERY>[^?#&]+)";
+  private static final String URL_RE2J =
+      "^(?:[^:]+:)?//(?P<AUTHORITY>[^@]+)@|[?#&]([^=&;]+)=(?P<QUERY>[^?#&]+)";
+
+  private static final String SQL_ANSI =
+      "(?i)(?m)[-+]?(?:x'[0-9a-f]+'|0x[0-9a-f]+|b'[0-9a-f]+'|0b[0-9a-f]+"
+          + "|\\d*\\.\\d+(?:E[-+]?\\d+[fd]?)?|\\b\\d+(?:E[-+]?\\d+[fd]?)?)"
+          + "|'(?:''|[^'])*'|--.*$|/\\*[\\s\\S]*\\*/";
+
+  private static final String SQL_MYSQL =
+      "(?i)(?m)[-+]?(?:x'[0-9a-f]+'|0x[0-9a-f]+|b'[0-9a-f]+'|0b[0-9a-f]+"
+          + "|\\d*\\.\\d+(?:E[-+]?\\d+[fd]?)?|\\b\\d+(?:E[-+]?\\d+[fd]?)?)"
+          + "|\"(?:\\\\\"|[^\"])*\"|'(?:\\\\'|[^'])*'|--.*$|/\\*[\\s\\S]*\\*/";
+
+  // LDAP tokenizer: lazy literal extraction. JDK/Reggie use (?<name>); re2j uses (?P<name>).
+  private static final String LDAP_JDK = "\\(.*?(?:~=|=|<=|>=)(?<LITERAL>[^)]+)\\)";
+  private static final String LDAP_RE2J = "\\(.*?(?:~=|=|<=|>=)(?P<LITERAL>[^)]+)\\)";
+
+  public enum Scenario {
+    LDAP_UNCLOSED_FILTER,
+    LDAP_NESTED_OPEN_EQ,
+    SQL_ANSI_UNTERMINATED,
+    SQL_MYSQL_UNTERMINATED,
+    URL_QUERY,
+    URL_QUESTION_RUN,
+    URL_AUTHORITY,
+    COMMAND_SINGLE_TOKEN,
+    COMMAND_BLANK_LINES
+  }
+
+  @Param({"512", "1024", "2048"})
+  int size;
+
+  @Param({
+    "LDAP_UNCLOSED_FILTER",
+    "LDAP_NESTED_OPEN_EQ",
+    "SQL_ANSI_UNTERMINATED",
+    "SQL_MYSQL_UNTERMINATED",
+    "URL_QUERY",
+    "URL_QUESTION_RUN",
+    "URL_AUTHORITY",
+    "COMMAND_SINGLE_TOKEN",
+    "COMMAND_BLANK_LINES"
+  })
+  Scenario scenario;
+
+  private String payload;
+  private Pattern jdkPat;
+  private com.google.re2j.Pattern re2jPat;
+  private ReggieMatcher reggieMatcher;
+
+  private static String repeat(char c, int count) {
+    return String.valueOf(c).repeat(Math.max(0, count));
+  }
+
+  private static String buildPayload(Scenario s, int n) {
+    switch (s) {
+      case LDAP_UNCLOSED_FILTER:
+        return "(" + repeat('=', n - 1);
+      case LDAP_NESTED_OPEN_EQ:
+        return "(=".repeat((n + 1) / 2).substring(0, n);
+      case SQL_ANSI_UNTERMINATED:
+        return "'" + repeat('a', n - 1);
+      case SQL_MYSQL_UNTERMINATED:
+        return "\"" + repeat('a', n - 1);
+      case URL_QUERY:
+        return "http://h/p?" + repeat('a', n - 11);
+      case URL_QUESTION_RUN:
+        return repeat('?', n);
+      case URL_AUTHORITY:
+        return "//" + repeat('a', n - 2);
+      case COMMAND_SINGLE_TOKEN:
+        return "cmd " + repeat('a', n - 4);
+      case COMMAND_BLANK_LINES:
+        return repeat('\n', n);
+      default:
+        throw new IllegalArgumentException(s.name());
+    }
+  }
+
+  private static String jdkPatternFor(Scenario s) {
+    switch (s) {
+      case LDAP_UNCLOSED_FILTER:
+      case LDAP_NESTED_OPEN_EQ:
+        return LDAP_JDK;
+      case SQL_ANSI_UNTERMINATED:
+        return SQL_ANSI;
+      case SQL_MYSQL_UNTERMINATED:
+        return SQL_MYSQL;
+      case URL_QUERY:
+      case URL_QUESTION_RUN:
+      case URL_AUTHORITY:
+        return URL_JDK;
+      case COMMAND_SINGLE_TOKEN:
+      case COMMAND_BLANK_LINES:
+        return COMMAND;
+      default:
+        throw new IllegalArgumentException(s.name());
+    }
+  }
+
+  private static String re2jPatternFor(Scenario s) {
+    switch (s) {
+      case LDAP_UNCLOSED_FILTER:
+      case LDAP_NESTED_OPEN_EQ:
+        return LDAP_RE2J;
+      case URL_QUERY:
+      case URL_QUESTION_RUN:
+      case URL_AUTHORITY:
+        return URL_RE2J;
+      default:
+        return jdkPatternFor(s);
+    }
+  }
+
+  // LDAP is MULTILINE-compiled per the task; the others carry inline flags already.
+  private static boolean isLdap(Scenario s) {
+    return s == Scenario.LDAP_UNCLOSED_FILTER || s == Scenario.LDAP_NESTED_OPEN_EQ;
+  }
+
+  private static boolean printed = false;
+
+  @Setup
+  public void setup() {
+    payload = buildPayload(scenario, size);
+
+    String jp = jdkPatternFor(scenario);
+    String rp = re2jPatternFor(scenario);
+    if (isLdap(scenario)) {
+      jdkPat = Pattern.compile(jp, Pattern.MULTILINE);
+      re2jPat = com.google.re2j.Pattern.compile(rp, com.google.re2j.Pattern.MULTILINE);
+      reggieMatcher = RuntimeCompiler.compile("(?m)" + jp);
+    } else {
+      jdkPat = Pattern.compile(jp);
+      re2jPat = com.google.re2j.Pattern.compile(rp);
+      reggieMatcher = RuntimeCompiler.compile(jp);
+    }
+
+    synchronized (IastTokenizerDrainBenchmark.class) {
+      if (!printed) {
+        printed = true;
+        System.out.println("=== Reggie matcher class per pattern ===");
+        report("COMMAND", COMMAND);
+        report("URL", URL_JDK);
+        report("SQL_ANSI", SQL_ANSI);
+        report("SQL_MYSQL", SQL_MYSQL);
+        report("LDAP", "(?m)" + LDAP_JDK);
+        System.out.println("=========================================");
+      }
+    }
+  }
+
+  private static void report(String name, String pattern) {
+    try {
+      String cls = RuntimeCompiler.compile(pattern).getClass().getSimpleName();
+      System.out.println("  " + name + " -> " + cls);
+    } catch (Throwable t) {
+      System.out.println("  " + name + " -> COMPILE_ERROR: " + t);
+    }
+  }
+
+  @Benchmark
+  public long jdkDrain() {
+    try {
+      java.util.regex.Matcher m = jdkPat.matcher(payload);
+      long c = 0;
+      while (m.find()) {
+        c++;
+      }
+      return c;
+    } catch (Throwable t) {
+      return -1;
+    }
+  }
+
+  @Benchmark
+  public long re2jDrain() {
+    try {
+      com.google.re2j.Matcher m = re2jPat.matcher(payload);
+      long c = 0;
+      while (m.find()) {
+        c++;
+      }
+      return c;
+    } catch (Throwable t) {
+      return -1;
+    }
+  }
+
+  @Benchmark
+  public long reggieDrain() {
+    try {
+      int len = payload.length();
+      int pos = 0;
+      long c = 0;
+      while (pos <= len) {
+        MatchResult r = reggieMatcher.findMatchFrom(payload, pos);
+        if (r == null) {
+          break;
+        }
+        c++;
+        pos = r.end() > r.start() ? r.end() : r.end() + 1;
+      }
+      return c;
+    } catch (Throwable t) {
+      return -1;
+    }
+  }
+}

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/FallbackPatternDetector.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/FallbackPatternDetector.java
@@ -1081,6 +1081,65 @@ public final class FallbackPatternDetector {
   }
 
   /**
+   * Class A: returns true if any {@link AlternationNode} has a branch containing a NULLABLE
+   * capturing group — a capturing group whose body can match the empty string, sitting in an
+   * alternation branch that other branches can bypass (e.g. {@code 1|()b}, {@code ()b|x}). The TDFA
+   * / group-action capture path commits such a zero-width group even when the priority-winning
+   * branch bypassed it (binds {@code g1=[0,0)} where JDK leaves it {@code -1}). PikeVM gives
+   * correct spans. A non-nullable group such as {@code (a)} in {@code (a)|b} never leaks (its
+   * enter/exit straddle a consumed character) and stays on the fast DFA path.
+   */
+  static boolean hasNullableCapturingGroupInAlternationBranch(RegexNode ast) {
+    if (ast instanceof AlternationNode) {
+      for (RegexNode branch : ((AlternationNode) ast).alternatives) {
+        if (containsNullableCapturingGroup(branch)) return true;
+      }
+      for (RegexNode branch : ((AlternationNode) ast).alternatives) {
+        if (hasNullableCapturingGroupInAlternationBranch(branch)) return true;
+      }
+      return false;
+    }
+    if (ast instanceof GroupNode) {
+      return hasNullableCapturingGroupInAlternationBranch(((GroupNode) ast).child);
+    }
+    if (ast instanceof ConcatNode) {
+      for (RegexNode c : ((ConcatNode) ast).children) {
+        if (hasNullableCapturingGroupInAlternationBranch(c)) return true;
+      }
+      return false;
+    }
+    if (ast instanceof QuantifierNode) {
+      return hasNullableCapturingGroupInAlternationBranch(((QuantifierNode) ast).child);
+    }
+    return false;
+  }
+
+  /** True if the subtree contains a capturing group whose body is nullable (can match empty). */
+  private static boolean containsNullableCapturingGroup(RegexNode node) {
+    if (node instanceof GroupNode) {
+      GroupNode g = (GroupNode) node;
+      if (g.capturing && subtreeIsNullable(g.child)) return true;
+      return containsNullableCapturingGroup(g.child);
+    }
+    if (node instanceof ConcatNode) {
+      for (RegexNode c : ((ConcatNode) node).children) {
+        if (containsNullableCapturingGroup(c)) return true;
+      }
+      return false;
+    }
+    if (node instanceof QuantifierNode) {
+      return containsNullableCapturingGroup(((QuantifierNode) node).child);
+    }
+    if (node instanceof AlternationNode) {
+      for (RegexNode a : ((AlternationNode) node).alternatives) {
+        if (containsNullableCapturingGroup(a)) return true;
+      }
+      return false;
+    }
+    return false;
+  }
+
+  /**
    * Returns true if any capturing GroupNode is directly wrapped by a QuantifierNode with min=0 AND
    * the group's content is itself nullable (can match the empty string). Example: {@code
    * (0*-?){0,}} — group content {@code 0*-?} is nullable, outer quantifier {@code {0,}} is

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
@@ -380,8 +380,14 @@ public class PatternAnalyzer {
           MatchingStrategy.GREEDY_BACKTRACK, null, greedyBacktrackInfo, false, requiredLiterals);
     }
 
-    // Check for multi-group greedy patterns
-    MultiGroupGreedyInfo multiGroupInfo = detectMultiGroupGreedyPattern(ast);
+    // Check for multi-group greedy patterns. Decline give-back patterns: a greedy quantified
+    // capturing group whose charset overlaps what must follow needs character give-back that the
+    // non-backtracking MULTI_GROUP_GREEDY strategy cannot do — it returns NO_MATCH (e.g. (\w+)0 on
+    // "ab00"). Declining lets such patterns fall through to the backtracking-capable routing
+    // (the :753 requiresBacktrackingForGroups guard → RECURSIVE_DESCENT), which produces correct
+    // spans. (GREEDY_BACKTRACK above already handles the (.*)literal shape.)
+    MultiGroupGreedyInfo multiGroupInfo =
+        requiresBacktrackingForGroups(ast) ? null : detectMultiGroupGreedyPattern(ast);
     if (multiGroupInfo != null) {
       return new MatchingStrategyResult(
           MatchingStrategy.SPECIALIZED_MULTI_GROUP_GREEDY,

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
@@ -1034,6 +1034,24 @@ public class PatternAnalyzer {
               null,
               needsPosixSemantics);
         }
+        // Class E: two interacting variable-length capturing alternations (e.g. (a|ab)(c|bcd)). The
+        // first alternation's branches share a prefix, so its capture span is ambiguous until the
+        // second alternation resolves it — which the single-register TDFA cannot track
+        // ((a|ab)(c|bcd)
+        // on "abcd" → g1=[0,2) vs JDK [0,1)). PikeVM gives correct spans. A single capturing
+        // alternation followed by a fixed element (e.g. (a|ab)\d) is disambiguated
+        // deterministically
+        // and stays on the DFA.
+        if (hasInteractingCapturingAlternations(ast)) {
+          return new MatchingStrategyResult(
+              MatchingStrategy.PIKEVM_CAPTURE,
+              null,
+              null,
+              false,
+              requiredLiterals,
+              null,
+              needsPosixSemantics);
+        }
         int stateCount = dfa.getStateCount();
         if (stateCount < DFA_UNROLLED_STATE_LIMIT) {
           return new MatchingStrategyResult(
@@ -1887,6 +1905,68 @@ public class PatternAnalyzer {
    * '@', so no backtracking needed - ([bc]*)(c+d) : [bc] overlaps with 'c', so backtracking IS
    * needed
    */
+  /**
+   * Class E detector: a {@link ConcatNode} containing two or more capturing groups that each wrap
+   * an alternation, where at least one of those alternations has branches with overlapping
+   * first-sets (a shared prefix, e.g. {@code a|ab}). Such a pair, e.g. {@code (a|ab)(c|bcd)}, is
+   * mis-captured by the single-register TDFA (g1=[0,2) vs JDK [0,1) on "abcd"). A lone capturing
+   * alternation, or one followed by a fixed element, is fine and stays on the DFA.
+   */
+  private boolean hasInteractingCapturingAlternations(RegexNode node) {
+    if (node instanceof GroupNode) {
+      return hasInteractingCapturingAlternations(((GroupNode) node).child);
+    }
+    if (node instanceof QuantifierNode) {
+      return hasInteractingCapturingAlternations(((QuantifierNode) node).child);
+    }
+    if (node instanceof AlternationNode) {
+      for (RegexNode a : ((AlternationNode) node).alternatives) {
+        if (hasInteractingCapturingAlternations(a)) return true;
+      }
+      return false;
+    }
+    if (!(node instanceof ConcatNode)) {
+      return false;
+    }
+    ConcatNode concat = (ConcatNode) node;
+    int capturingAltGroups = 0;
+    boolean anyOverlapping = false;
+    for (RegexNode child : concat.children) {
+      AlternationNode alt = capturingGroupAlternation(child);
+      if (alt != null) {
+        capturingAltGroups++;
+        if (hasOverlappingBranchFirstSets(alt)) anyOverlapping = true;
+      }
+      if (hasInteractingCapturingAlternations(child)) return true; // nested
+    }
+    return capturingAltGroups >= 2 && anyOverlapping;
+  }
+
+  /** If {@code node} is a capturing group whose body is directly an alternation, return it. */
+  private AlternationNode capturingGroupAlternation(RegexNode node) {
+    if (node instanceof GroupNode) {
+      GroupNode g = (GroupNode) node;
+      if (g.capturing && g.child instanceof AlternationNode) {
+        return (AlternationNode) g.child;
+      }
+    }
+    return null;
+  }
+
+  /** True if two branches of {@code alt} have intersecting first-sets (a shared leading char). */
+  private boolean hasOverlappingBranchFirstSets(AlternationNode alt) {
+    List<RegexNode> alts = alt.alternatives;
+    for (int i = 0; i < alts.size(); i++) {
+      CharSet fi = getFirstCharSet(alts.get(i));
+      if (fi == null) continue;
+      for (int j = i + 1; j < alts.size(); j++) {
+        CharSet fj = getFirstCharSet(alts.get(j));
+        if (fj != null && fi.intersects(fj)) return true;
+      }
+    }
+    return false;
+  }
+
   private boolean requiresBacktrackingForGroups(RegexNode node) {
     if (!(node instanceof ConcatNode)) {
       return false;

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
@@ -6697,6 +6697,11 @@ public class PatternAnalyzer {
     // Handle anchors - support START and END
     if (node instanceof AnchorNode) {
       AnchorNode anchor = (AnchorNode) node;
+      // Multiline ^ / $ match line boundaries; the MGG generator only models pos==0 and pos==len.
+      // Decline both so these patterns are routed to a correct strategy.
+      if (anchor.multiline) {
+        return null;
+      }
       return new AnchorSegment(anchor.type);
     }
 

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
@@ -912,6 +912,13 @@ public class PatternAnalyzer {
           // handles all anchor types natively (since commit 0acfc66), and RuntimeCompiler wraps
           // the result in NameEnrichingMatcher when named groups are present.
           if (!hasNamedGroups(ast) && !hasAnchorInNfa(nfa)) {
+            // INVARIANT for any new Class A route that returns PIKEVM_CAPTURE for patterns
+            // containing nullable capturing groups in alternation branches:
+            // always guard with
+            // !FallbackPatternDetector.hasNullableGroupContentWithNullableQuantifier(ast)
+            // before returning PIKEVM_CAPTURE, as PikeVM diverges for nullable-content groups
+            // (e.g. (0*-?){0,}). RuntimeCompiler also enforces this via needsFallback(), but
+            // the PatternAnalyzer guard is the first line of defence.
             // B16: nullable outer quantifier on non-nullable capturing group — TDFA POSIX
             // last-match span wrong. PIKEVM gives correct spans when the group content itself is
             // non-nullable; nullable-content groups (e.g. (0*-?){0,}) are left on the TDFA path
@@ -955,7 +962,8 @@ public class PatternAnalyzer {
             // priority-winning branch bypasses it (binds g1=[0,0); JDK leaves it -1). PikeVM gives
             // correct spans. A non-nullable group like (a) in (a)|b never leaks and stays on the
             // DFA.
-            if (FallbackPatternDetector.hasNullableCapturingGroupInAlternationBranch(ast)) {
+            if (FallbackPatternDetector.hasNullableCapturingGroupInAlternationBranch(ast)
+                && !FallbackPatternDetector.hasNullableGroupContentWithNullableQuantifier(ast)) {
               return new MatchingStrategyResult(
                   MatchingStrategy.PIKEVM_CAPTURE,
                   null,

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
@@ -950,6 +950,21 @@ public class PatternAnalyzer {
                   null,
                   needsPosixSemantics);
             }
+            // Class A: a NULLABLE capturing group in an alternation branch (e.g. 1|()b, ()b|x). The
+            // TDFA/group-action capture path commits the zero-width group even when the
+            // priority-winning branch bypasses it (binds g1=[0,0); JDK leaves it -1). PikeVM gives
+            // correct spans. A non-nullable group like (a) in (a)|b never leaks and stays on the
+            // DFA.
+            if (FallbackPatternDetector.hasNullableCapturingGroupInAlternationBranch(ast)) {
+              return new MatchingStrategyResult(
+                  MatchingStrategy.PIKEVM_CAPTURE,
+                  null,
+                  null,
+                  false,
+                  requiredLiterals,
+                  null,
+                  needsPosixSemantics);
+            }
             // Pure-regular, anchor-free: C2 priority-ordered TDFA gives correct spans.
             int stateCount = dfa.getStateCount();
             if (stateCount < DFA_UNROLLED_STATE_LIMIT) {

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
@@ -1950,12 +1950,21 @@ public class PatternAnalyzer {
     return capturingAltGroups >= 2 && anyOverlapping;
   }
 
-  /** If {@code node} is a capturing group whose body is directly an alternation, return it. */
+  /**
+   * If {@code node} is a capturing group whose body is (after unwrapping any transparent
+   * non-capturing groups) an alternation, return that alternation.
+   */
   private AlternationNode capturingGroupAlternation(RegexNode node) {
     if (node instanceof GroupNode) {
       GroupNode g = (GroupNode) node;
-      if (g.capturing && g.child instanceof AlternationNode) {
-        return (AlternationNode) g.child;
+      if (g.capturing) {
+        RegexNode body = g.child;
+        while (body instanceof GroupNode && !((GroupNode) body).capturing) {
+          body = ((GroupNode) body).child;
+        }
+        if (body instanceof AlternationNode) {
+          return (AlternationNode) body;
+        }
       }
     }
     return null;

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/BoundedQuantifierBytecodeGenerator.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/BoundedQuantifierBytecodeGenerator.java
@@ -214,6 +214,14 @@ public class BoundedQuantifierBytecodeGenerator {
     mv.visitInsn(ARETURN);
     mv.visitLabel(notNull);
 
+    // if (start < 0) start = 0;
+    Label startNotNeg = new Label();
+    mv.visitVarInsn(ILOAD, 2);
+    mv.visitJumpInsn(IFGE, startNotNeg);
+    mv.visitInsn(ICONST_0);
+    mv.visitVarInsn(ISTORE, 2);
+    mv.visitLabel(startNotNeg);
+
     // int len = input.length();
     mv.visitVarInsn(ALOAD, 1);
     mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "length", "()I", false);
@@ -509,6 +517,14 @@ public class BoundedQuantifierBytecodeGenerator {
     mv.visitInsn(ICONST_M1); // -1
     mv.visitInsn(IRETURN);
     mv.visitLabel(notNull);
+
+    // if (start < 0) start = 0;
+    Label startNotNeg = new Label();
+    mv.visitVarInsn(ILOAD, 2);
+    mv.visitJumpInsn(IFGE, startNotNeg);
+    mv.visitInsn(ICONST_0);
+    mv.visitVarInsn(ISTORE, 2);
+    mv.visitLabel(startNotNeg);
 
     // int len = input.length();
     mv.visitVarInsn(ALOAD, 1);

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/ConcatGreedyGroupBytecodeGenerator.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/ConcatGreedyGroupBytecodeGenerator.java
@@ -325,6 +325,14 @@ public class ConcatGreedyGroupBytecodeGenerator {
     mv.visitInsn(ARETURN);
     mv.visitLabel(notNull);
 
+    // if (start < 0) start = 0;
+    Label startNotNeg = new Label();
+    mv.visitVarInsn(ILOAD, startVar);
+    mv.visitJumpInsn(IFGE, startNotNeg);
+    mv.visitInsn(ICONST_0);
+    mv.visitVarInsn(ISTORE, startVar);
+    mv.visitLabel(startNotNeg);
+
     // int len = input.length();
     mv.visitVarInsn(ALOAD, inputVar);
     mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "length", "()I", false);

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/ConcatQuantifiedGroupsBytecodeGenerator.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/ConcatQuantifiedGroupsBytecodeGenerator.java
@@ -626,6 +626,14 @@ public class ConcatQuantifiedGroupsBytecodeGenerator {
     mv.visitInsn(ARETURN);
     mv.visitLabel(notNull);
 
+    // if (startPos < 0) startPos = 0;
+    Label startNotNeg = new Label();
+    mv.visitVarInsn(ILOAD, startPosVar);
+    mv.visitJumpInsn(IFGE, startNotNeg);
+    mv.visitInsn(ICONST_0);
+    mv.visitVarInsn(ISTORE, startPosVar);
+    mv.visitLabel(startNotNeg);
+
     // int len = input.length();
     mv.visitVarInsn(ALOAD, inputVar);
     mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "length", "()I", false);

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/FixedSequenceBytecodeGenerator.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/FixedSequenceBytecodeGenerator.java
@@ -395,7 +395,15 @@ public class FixedSequenceBytecodeGenerator {
     mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "length", "()I", false);
     mv.visitVarInsn(ISTORE, lenVar);
 
-    // int i = start;
+    // Clamp start to 0 if negative
+    Label startNotNeg = new Label();
+    mv.visitVarInsn(ILOAD, 2);
+    mv.visitJumpInsn(IFGE, startNotNeg);
+    mv.visitInsn(ICONST_0);
+    mv.visitVarInsn(ISTORE, 2);
+    mv.visitLabel(startNotNeg);
+
+    // int i = start; (clamped)
     int iVar = allocator.allocate();
     mv.visitVarInsn(ILOAD, 2);
     mv.visitVarInsn(ISTORE, iVar);

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/MultiGroupGreedyBytecodeGenerator.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/MultiGroupGreedyBytecodeGenerator.java
@@ -1663,17 +1663,12 @@ public class MultiGroupGreedyBytecodeGenerator {
       int posVar,
       int lenVar,
       int startOffsetVar) {
-    if (seg.type == AnchorNode.Type.START) {
-      // if (pos != startOffset) return null;
-      Label isStart = new Label();
-      mv.visitVarInsn(ILOAD, posVar);
-      mv.visitVarInsn(ILOAD, startOffsetVar);
-      mv.visitJumpInsn(IF_ICMPEQ, isStart);
-      mv.visitInsn(ACONST_NULL);
-      mv.visitInsn(ARETURN);
-      mv.visitLabel(isStart);
-    } else if (seg.type == AnchorNode.Type.STRING_START) {
-      // \A always requires pos == 0
+    if (seg.type == AnchorNode.Type.START || seg.type == AnchorNode.Type.STRING_START) {
+      // ^ (non-multiline) and \A both anchor to the ABSOLUTE input start (pos == 0), independent of
+      // the scan start. Comparing pos to startOffset re-anchored ^ at every scan position, so a
+      // findAll/findMatchFrom(start>0) over e.g. `^([-]*)` wrongly produced a match at start>0;
+      // java.util.regex.Matcher.find(start) anchors ^/\A at input start (0). (match() at :1610
+      // already does this.)
       Label isStart = new Label();
       mv.visitVarInsn(ILOAD, posVar);
       mv.visitJumpInsn(IFEQ, isStart);
@@ -1722,17 +1717,10 @@ public class MultiGroupGreedyBytecodeGenerator {
       int posVar,
       int lenVar,
       int startOffsetVar) {
-    if (seg.type == AnchorNode.Type.START) {
-      // if (pos != startOffset) return false;
-      Label isStart = new Label();
-      mv.visitVarInsn(ILOAD, posVar);
-      mv.visitVarInsn(ILOAD, startOffsetVar);
-      mv.visitJumpInsn(IF_ICMPEQ, isStart);
-      mv.visitInsn(ICONST_0);
-      mv.visitInsn(IRETURN);
-      mv.visitLabel(isStart);
-    } else if (seg.type == AnchorNode.Type.STRING_START) {
-      // \A always requires pos == 0
+    if (seg.type == AnchorNode.Type.START || seg.type == AnchorNode.Type.STRING_START) {
+      // ^ (non-multiline) and \A both anchor to the ABSOLUTE input start (pos == 0), not the scan
+      // start — see generateAnchorMatchInline. Comparing pos to startOffset re-anchored ^ at every
+      // scan position (spurious findAll matches for `^...`).
       Label isStart = new Label();
       mv.visitVarInsn(ILOAD, posVar);
       mv.visitJumpInsn(IFEQ, isStart);

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/QuantifiedGroupBytecodeGenerator.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/QuantifiedGroupBytecodeGenerator.java
@@ -977,6 +977,14 @@ public class QuantifiedGroupBytecodeGenerator {
     mv.visitInsn(ARETURN);
     mv.visitLabel(notNull);
 
+    // if (startPos < 0) startPos = 0;
+    Label startNotNeg = new Label();
+    mv.visitVarInsn(ILOAD, startPosVar);
+    mv.visitJumpInsn(IFGE, startNotNeg);
+    mv.visitInsn(ICONST_0);
+    mv.visitVarInsn(ISTORE, startPosVar);
+    mv.visitLabel(startNotNeg);
+
     // int len = input.length();
     mv.visitVarInsn(ALOAD, inputVar);
     mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "length", "()I", false);

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/RecursiveDescentBytecodeGenerator.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/RecursiveDescentBytecodeGenerator.java
@@ -858,7 +858,16 @@ public class RecursiveDescentBytecodeGenerator {
     Label foundMatch = new Label();
     Label firstCharOptimizationSkip = new Label();
 
-    // pos starts at fromIndex
+    // if (fromIndex < 0) fromIndex = 0;
+    // S: []
+    Label startNotNeg = new Label();
+    mv.visitVarInsn(ILOAD, 2); // fromIndex
+    mv.visitJumpInsn(IFGE, startNotNeg);
+    mv.visitInsn(ICONST_0);
+    mv.visitVarInsn(ISTORE, 2);
+    mv.visitLabel(startNotNeg);
+
+    // pos starts at fromIndex (clamped)
     // S: []
     mv.visitVarInsn(ILOAD, 2); // fromIndex
     // S: [I]

--- a/reggie-integration-tests/src/main/java/com/datadoghq/reggie/integration/fuzz/RegexFuzzOracle.java
+++ b/reggie-integration-tests/src/main/java/com/datadoghq/reggie/integration/fuzz/RegexFuzzOracle.java
@@ -178,6 +178,52 @@ public final class RegexFuzzOracle {
       return Result.skipped("find() threw: " + t);
     }
 
+    // findAll() — every non-overlapping match with all group spans (the IAST tokenizer "drain"
+    // path). JDK is the oracle: iterating Matcher.find() yields non-overlapping leftmost matches
+    // with its own empty-match advance, which is the semantics findAll must reproduce.
+    try {
+      Matcher jm = jdk.matcher(input);
+      List<int[]> jdkAll = new ArrayList<>();
+      while (jm.find()) {
+        int gc = jm.groupCount();
+        int[] spans = new int[2 * (gc + 1)];
+        for (int g = 0; g <= gc; g++) {
+          spans[2 * g] = jm.start(g);
+          spans[2 * g + 1] = jm.end(g);
+        }
+        jdkAll.add(spans);
+      }
+      List<MatchResult> reggieAll = reggie.findAll(input);
+      if (jdkAll.size() != reggieAll.size()) {
+        findings.add(
+            new Finding(
+                pattern,
+                input,
+                String.format(
+                    "findAll() count differs: jdk=%d reggie=%d", jdkAll.size(), reggieAll.size())));
+      } else {
+        for (int i = 0; i < jdkAll.size(); i++) {
+          int[] j = jdkAll.get(i);
+          MatchResult r = reggieAll.get(i);
+          int gc = (j.length / 2) - 1;
+          for (int g = 0; g <= gc; g++) {
+            if (j[2 * g] != r.start(g) || j[2 * g + 1] != r.end(g)) {
+              findings.add(
+                  new Finding(
+                      pattern,
+                      input,
+                      String.format(
+                          "findAll() match %d group %d span differs: jdk=[%d,%d) reggie=[%d,%d)",
+                          i, g, j[2 * g], j[2 * g + 1], r.start(g), r.end(g))));
+              break; // one finding per match is enough signal
+            }
+          }
+        }
+      }
+    } catch (Throwable t) {
+      return Result.skipped("findAll() threw: " + t);
+    }
+
     return Result.ran(findings);
   }
 

--- a/reggie-integration-tests/src/test/java/com/datadoghq/reggie/integration/AlgorithmicFuzzTest.java
+++ b/reggie-integration-tests/src/test/java/com/datadoghq/reggie/integration/AlgorithmicFuzzTest.java
@@ -57,10 +57,11 @@ public class AlgorithmicFuzzTest {
    * checks per-match group spans (≥1) on the FIND path — the first oracle to do so. It surfaced
    * pre-existing find-path group-capture bugs in the codegen TDFA / PikeVM (untaken-branch group
    * not reset to −1; empty-iteration binding; greedy give-back inner-span). These are tracked as
-   * the capture-correctness effort and will ratchet this budget back toward 0 as each root-cause
-   * class is fixed.
+   * the capture-correctness effort and ratchet this budget back toward 0 as each root-cause class
+   * is fixed. Ratcheted 78→69: Class A (nullable capturing group in an alternation branch, e.g.
+   * {@code 1|()b}) now routes to PIKEVM_CAPTURE for correct spans.
    */
-  private static final int KNOWN_FINDINGS_BUDGET = 78;
+  private static final int KNOWN_FINDINGS_BUDGET = 69;
 
   @Test
   @Timeout(value = 300, unit = TimeUnit.SECONDS)

--- a/reggie-integration-tests/src/test/java/com/datadoghq/reggie/integration/AlgorithmicFuzzTest.java
+++ b/reggie-integration-tests/src/test/java/com/datadoghq/reggie/integration/AlgorithmicFuzzTest.java
@@ -52,8 +52,15 @@ public class AlgorithmicFuzzTest {
    * native strategy — not a regression. When this count changes, update the budget and document the
    * new/fixed finding in {@code doc/temp/prod-readiness/fuzz-inventory.md}. Override via {@code
    * -Dreggie.fuzz.maxFindings=N} for stricter local runs.
+   *
+   * <p>Raised 18→78 when {@link RegexFuzzOracle} gained a {@code findAll()} differential that
+   * checks per-match group spans (≥1) on the FIND path — the first oracle to do so. It surfaced
+   * pre-existing find-path group-capture bugs in the codegen TDFA / PikeVM (untaken-branch group
+   * not reset to −1; empty-iteration binding; greedy give-back inner-span). These are tracked as
+   * the capture-correctness effort and will ratchet this budget back toward 0 as each root-cause
+   * class is fixed.
    */
-  private static final int KNOWN_FINDINGS_BUDGET = 18;
+  private static final int KNOWN_FINDINGS_BUDGET = 78;
 
   @Test
   @Timeout(value = 300, unit = TimeUnit.SECONDS)

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/JavaRegexFallbackMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/JavaRegexFallbackMatcher.java
@@ -77,8 +77,10 @@ public final class JavaRegexFallbackMatcher extends ReggieMatcher {
 
   @Override
   public int findFrom(String input, int start) {
+    int s = Math.max(0, start);
+    if (s > input.length()) return -1;
     java.util.regex.Matcher m = javaPattern.matcher(input);
-    return m.find(start) ? m.start() : -1;
+    return m.find(s) ? m.start() : -1;
   }
 
   @Override
@@ -111,8 +113,10 @@ public final class JavaRegexFallbackMatcher extends ReggieMatcher {
 
   @Override
   public MatchResult findMatchFrom(String input, int start) {
+    int s = Math.max(0, start);
+    if (s > input.length()) return null;
     java.util.regex.Matcher m = javaPattern.matcher(input);
-    return m.find(start) ? toMatchResult(input, m) : null;
+    return m.find(s) ? toMatchResult(input, m) : null;
   }
 
   @Override
@@ -127,8 +131,10 @@ public final class JavaRegexFallbackMatcher extends ReggieMatcher {
 
   @Override
   public boolean findMatchInto(String input, int start, int[] groupStarts, int[] groupEnds) {
+    int s = Math.max(0, start);
+    if (s > input.length()) return false;
     java.util.regex.Matcher m = javaPattern.matcher(input);
-    if (!m.find(start)) {
+    if (!m.find(s)) {
       return false;
     }
     copyGroups(m, groupStarts, groupEnds);

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
@@ -537,9 +537,56 @@ public final class PikeVMMatcher extends ReggieMatcher {
   // Core PikeVM — find() semantics (match anywhere)
   // -------------------------------------------------------------------------
 
+  /**
+   * Allocation-free variant of {@link #findMatchResultFrom}: returns the start position of the
+   * leftmost match at or after {@code fromPos}, or {@code -1}. Mirrors the full find loop but reads
+   * {@code clistCaptures[t][0]} directly — no {@code Arrays.copyOf}, no {@code MatchResult}.
+   */
+  private int findPosFrom(String input, int fromPos) {
+    int regionEnd = input.length();
+    if (findDfa != null && !findCanMatchEmpty) {
+      if (findDfa.findFrom(input, fromPos, findStep) < 0) return -1;
+    } else if (rejectDfa != null && rejectDfa.findFrom(input, fromPos, rejectStep) < 0) {
+      return -1;
+    }
+    resetClist();
+    int bestStart = -1;
+
+    for (int pos = fromPos; pos <= regionEnd; pos++) {
+      if (bestStart < 0) {
+        boolean skipSeed = false;
+        if (prefilterUsable && pos < regionEnd) {
+          char c = input.charAt(pos);
+          skipSeed = c < 128 && !firstByteAscii[c];
+        }
+        if (!skipSeed) {
+          seedStart(input, pos, regionEnd);
+        }
+      }
+
+      int t = clistFirstAccept;
+      if (t >= 0) {
+        bestStart = clistCaptures[t][0];
+        if (pos == clistCaptures[t][0]) {
+          pruneAnchorDerivedAtStart(t, false);
+        } else {
+          clistSize = t;
+          clistFirstAccept = -1;
+        }
+      }
+      if (pos == regionEnd) break;
+
+      char ch = input.charAt(pos);
+      resetNlist();
+      stepChar(ch, pos + 1, input, 0, regionEnd);
+      swapLists();
+      if (bestStart >= 0 && clistSize == 0) break;
+    }
+    return bestStart;
+  }
+
   private int findStartFrom(String input, int fromPos) {
-    MatchResult r = findMatchResultFrom(input, fromPos);
-    return r == null ? -1 : r.start();
+    return findPosFrom(input, fromPos);
   }
 
   /**

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
@@ -106,6 +106,17 @@ public final class PikeVMMatcher extends ReggieMatcher {
   private int[] startClosureIds; // pos-0 closure (START/\A anchors crossed); set in ctor
   private int[] reinjectClosureIds; // pos>0 closure (START/\A anchors blocked); set in ctor
 
+  // Over-approximating "reject DFA": built for anchored patterns where the EXACT findDfa cannot be
+  // (its anchors need per-position context), but only when there are no assertions/backrefs. Every
+  // anchor is treated as always-passable (crossed as epsilon — no position threaded into the state,
+  // so no state-space fracture), so the DFA accepts a SUPERSET of the language. Used ONLY by the
+  // findMatchResultFrom fast-reject: if this DFA finds NO match at/after a position, there is
+  // definitely no real match (sound necessary condition). null when not built (e.g. assertions
+  // present, or the over-approximation can itself match empty so it would accept everywhere).
+  private final LazyDFACache rejectDfa;
+  private final NfaStep rejectStep;
+  private int[] rejectStartClosureIds; // start closure with ALL anchors crossed; set in ctor
+
   // T1.6 boolean matches() fast path: a STRICT (non-self-anchoring) lazy DFA over the same NFA.
   // matches() asks whether the WHOLE input matches from the start, which is priority-independent,
   // so the DFA's yes/no equals the thread simulation's. Built under the same anchor/assertion/
@@ -180,6 +191,37 @@ public final class PikeVMMatcher extends ReggieMatcher {
       findCanMatchEmpty = false;
       matchesDfa = null;
       matchesStep = null;
+    }
+
+    // Build the over-approximating reject DFA for anchored (but assertion/backref-free) patterns
+    // the
+    // exact findDfa rejected. It crosses every anchor as epsilon → accepts a superset → a sound
+    // fast-reject (see field doc). Skipped when the over-approximation can match empty (it would
+    // then
+    // accept at every position, making it useless as a reject filter).
+    if (findDfa == null && noAssertionsOrBackrefs(nfa)) {
+      int[] startAll = sortedEpsilonClosure(new int[] {nfa.getStartState().id}, false);
+      boolean approxEmpty = false;
+      for (int id : startAll) {
+        if (isAccept[id]) {
+          approxEmpty = true;
+          break;
+        }
+      }
+      if (approxEmpty) {
+        rejectDfa = null;
+        rejectStep = null;
+      } else {
+        rejectStartClosureIds = startAll;
+        int[] acceptArr = new int[nfa.getAcceptStates().size()];
+        int ai = 0;
+        for (NFA.NFAState s : nfa.getAcceptStates()) acceptArr[ai++] = s.id;
+        rejectDfa = new LazyDFACache(startAll, acceptArr);
+        rejectStep = (cur, c) -> rejectStepClosure(transitionTargets(cur, (char) c));
+      }
+    } else {
+      rejectDfa = null;
+      rejectStep = null;
     }
 
     markNativeRichApi();
@@ -295,6 +337,34 @@ public final class PikeVMMatcher extends ReggieMatcher {
     int oi = 0;
     for (int id = 0; id < stateCount; id++) if (inSet[id]) out[oi++] = id;
     return out; // ascending
+  }
+
+  /**
+   * The reject-DFA step: {@code sortedEpsilonClosure(targets, blockStart=false)} (cross ALL
+   * anchors, including START/\A) UNION {@link #rejectStartClosureIds}. Re-injecting the
+   * all-anchors-crossed start closure each char makes a match begin at any position
+   * (self-anchoring); crossing every anchor is the over-approximation that keeps this a sound
+   * necessary-condition filter.
+   */
+  private int[] rejectStepClosure(int[] targets) {
+    int[] tc = sortedEpsilonClosure(targets, false);
+    boolean[] inSet = new boolean[stateCount];
+    for (int id : tc) inSet[id] = true;
+    for (int id : rejectStartClosureIds) inSet[id] = true;
+    int count = 0;
+    for (boolean b : inSet) if (b) count++;
+    int[] out = new int[count];
+    int oi = 0;
+    for (int id = 0; id < stateCount; id++) if (inSet[id]) out[oi++] = id;
+    return out; // ascending
+  }
+
+  /** True when no NFA state carries a lookaround assertion or a backreference check. */
+  private static boolean noAssertionsOrBackrefs(NFA nfa) {
+    for (NFA.NFAState s : nfa.getStates()) {
+      if (s.assertionType != null || s.backrefCheck != null) return false;
+    }
+    return true;
   }
 
   /**
@@ -452,94 +522,117 @@ public final class PikeVMMatcher extends ReggieMatcher {
   // -------------------------------------------------------------------------
 
   private int findStartFrom(String input, int fromPos) {
-    int len = input.length();
-    for (int start = fromPos; start <= len; start++) {
-      // T1.2 prefilter: skip start positions whose char cannot begin any match.
-      if (prefilterUsable && start < len) {
-        char c = input.charAt(start);
-        if (c < 128 && !firstByteAscii[c]) continue;
-      }
-      if (tryFindAt(input, start, fromPos, len) >= 0) return start;
-    }
-    return -1;
+    MatchResult r = findMatchResultFrom(input, fromPos);
+    return r == null ? -1 : r.start();
   }
 
   /**
-   * Try matching starting at {@code tryPos}; returns match-end position or -1. {@code regionStart}
-   * is the fixed search-region origin used for start-anchor evaluation (^, \A); it does not move
-   * with {@code tryPos}.
+   * One continuing left-to-right pass returning the leftmost match at or after {@code fromPos}, or
+   * {@code null}. Replaces the former per-start retry loop (the O(n^2) PCRE "try every start"
+   * anti-pattern): the start thread is re-seeded at LOWEST priority at every position — the
+   * implicit {@code .*?} prefix with RE2's "Mark" priority separator — so a single pass tracks
+   * every candidate start in parallel and {@code inClist} dedup-by-PC collapses them to &le; {@code
+   * stateCount} live threads, giving O(n*m). Leftmost-first is preserved because an earlier seed
+   * has higher priority and survives the accept-time priority cut, overriding a later seed that
+   * happens to accept first.
+   *
+   * <p>The greedy/zero-length finalization is identical to the former {@code tryFindMatchAt}: on
+   * the highest-priority accept, record it as {@code best} and cut strictly-lower-priority threads;
+   * higher-priority non-accept threads keep running and may overwrite {@code best} with a longer
+   * end (greedy give-back). Finalize when the in-progress match's threads are all gone.
+   *
+   * <p>The anchor origin is PINNED to absolute 0 (not {@code fromPos}), so {@code ^}/{@code \A}
+   * match only at input start exactly like {@code java.util.regex.Matcher.find(start)} — this is
+   * why find-all no longer spuriously re-anchors {@code ^} at each restart.
    */
-  private int tryFindAt(String input, int tryPos, int regionStart, int regionEnd) {
-    initClist(input, tryPos, regionStart, regionEnd);
-
-    for (int pos = tryPos; pos <= regionEnd; pos++) {
-      if (clistFirstAccept >= 0) {
-        return pos; // match ends here
-      }
-      if (pos == regionEnd) break;
-
-      char ch = input.charAt(pos);
-      resetNlist();
-      stepChar(ch, pos + 1, input, regionStart, regionEnd);
-      swapLists();
-    }
-    return -1;
-  }
-
   private MatchResult findMatchResultFrom(String input, int fromPos) {
-    int len = input.length();
-    for (int start = fromPos; start <= len; start++) {
-      // T1.2 prefilter: skip start positions whose char cannot begin any match.
-      if (prefilterUsable && start < len) {
-        char c = input.charAt(start);
-        if (c < 128 && !firstByteAscii[c]) continue;
+    int regionEnd = input.length();
+    // Fast reject: the T1.4 boolean find DFA (when present) decides whether ANY match exists at or
+    // after fromPos in one cheap O(n) single-state DFA scan — far cheaper than the per-char thread
+    // simulation below. If it proves none, skip the thread sim entirely. This is the dominant win
+    // on
+    // no-match drains (e.g. malformed payloads with zero matches). Soundness: the self-anchoring
+    // DFA
+    // re-injects the start closure each char so it tracks every start position (no false
+    // negatives);
+    // a ^/\A over-acceptance at fromPos>0 is only a false positive (we harmlessly fall through to
+    // the
+    // thread sim). Skipped when the pattern can match empty (a match always exists at fromPos, so
+    // the
+    // DFA would never report -1 anyway).
+    if (findDfa != null && !findCanMatchEmpty) {
+      if (findDfa.findFrom(input, fromPos, findStep) < 0) {
+        return null;
       }
-      MatchResult r = tryFindMatchAt(input, start, fromPos, len);
-      if (r != null) return r;
+    } else if (rejectDfa != null && rejectDfa.findFrom(input, fromPos, rejectStep) < 0) {
+      // Over-approximating reject DFA proved no match exists at/after fromPos (sound: it accepts a
+      // superset, so -1 means truly no match). Only built when it cannot match empty, so no
+      // findCanMatchEmpty guard is needed here.
+      return null;
     }
-    return null;
-  }
-
-  private MatchResult tryFindMatchAt(String input, int tryPos, int regionStart, int regionEnd) {
-    initClist(input, tryPos, regionStart, regionEnd);
-
-    // Greedy PikeVM rule: when a thread at index t accepts, threads at indices > t (lower priority)
-    // cannot produce a better match. Truncate the clist to [0..t-1] so only higher-priority
-    // non-accept threads continue. This lets a higher-priority thread that hasn't accepted yet
-    // (but will at a later position) override the current accept — giving greedy longest-match from
-    // the highest-priority thread (e.g. (_)? prefers consuming _ over the empty match, while
-    // (fo|foo) prefers "fo" over "foo" since "fo" is the higher-priority first alternative).
-    //
-    // Exception — zero-length match at tryPos: JDK semantics prevent anchor-derived consuming
-    // threads from overriding a zero-length accept. When the first accept fires at tryPos,
-    // retain only non-anchor-derived higher-priority threads so that legitimate greedy consuming
-    // paths (e.g. `a` in `(a)*`) can still extend the match while anchor-driven empty-iteration
-    // consuming paths (e.g. `a` copy3 in `(^a?){3}`) cannot.
+    resetClist();
     MatchResult best = null;
 
-    for (int pos = tryPos; pos <= regionEnd; pos++) {
+    for (int pos = fromPos; pos <= regionEnd; pos++) {
+      // Re-seed the start thread (appended last = lowest priority) until a match accepts. Once
+      // `best` is set the accept-time cut removes lower-priority threads (incl. any new seed), so a
+      // later start cannot beat the already-found leftmost match; stop seeding. A still-running
+      // higher-priority thread can still override `best` (greedy give-back).
+      if (best == null) {
+        // T1.2 prefilter: don't seed a start whose char cannot begin any match (the single-pass
+        // equivalent of the former per-start `continue`). Live higher-priority threads still step.
+        boolean skipSeed = false;
+        if (prefilterUsable && pos < regionEnd) {
+          char c = input.charAt(pos);
+          skipSeed = c < 128 && !firstByteAscii[c];
+        }
+        if (!skipSeed) {
+          seedStart(input, pos, regionEnd);
+        }
+      }
+
       int t = clistFirstAccept;
       if (t >= 0) {
         int[] caps = Arrays.copyOf(clistCaptures[t], winCaptures.length);
         caps[1] = pos;
         best = buildResult(input, caps);
-        if (pos == tryPos) {
-          // Zero-length match at start: prune anchor-derived high-priority threads; discard
+        if (pos == fromPos) {
+          // Zero-length accept at the origin-most seed (caps[0] == fromPos == pos): the
+          // clistViaMultipleAnchors flags are still fresh (no swapLists yet), so the anchor-derived
+          // pruning is valid here exactly as in the former tryFindMatchAt first iteration. Discard
           // lower-priority threads (keepLowerPriority=false) per Perl priority rules.
           pruneAnchorDerivedAtStart(t, false);
         } else {
+          // Cut strictly-lower-priority threads. The accepting thread started at pos > fromPos, so
+          // (^/\A fire only at the pinned origin 0) it cannot be a multi-anchor-origin thread —
+          // hence no pruning is needed, and the now-stale post-swap flags must not be read.
           clistSize = t;
+          clistFirstAccept = -1;
         }
       }
       if (pos == regionEnd) break;
 
       char ch = input.charAt(pos);
       resetNlist();
-      stepChar(ch, pos + 1, input, regionStart, regionEnd);
+      stepChar(ch, pos + 1, input, 0, regionEnd);
       swapLists();
-      if (clistSize == 0) break;
+      // Finalize only once a match is in progress: when its threads are all gone `best` is final.
+      // With best == null we must keep scanning (and re-seeding) for a start further right.
+      if (best != null && clistSize == 0) break;
     }
     return best;
+  }
+
+  /**
+   * Append the start-state thread for position {@code pos} at the current (lowest) clist priority,
+   * without clearing the clist. Unlike {@link #initClist}, the anchor origin is pinned to absolute
+   * 0; the {@code inClist} dedup collapses this seed into any already-present equivalent thread.
+   */
+  private void seedStart(String input, int pos, int regionEnd) {
+    int[] init = scratchCaptures[0];
+    Arrays.fill(init, -1);
+    init[0] = pos; // tentative whole-match start
+    addThread(nfa.getStartState(), init, pos, 0, 0, false, input, 0, regionEnd);
   }
 
   // -------------------------------------------------------------------------

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
@@ -199,11 +199,9 @@ public final class PikeVMMatcher extends ReggieMatcher {
     }
 
     // Build the over-approximating reject DFA for anchored (but assertion/backref-free) patterns
-    // the
-    // exact findDfa rejected. It crosses every anchor as epsilon → accepts a superset → a sound
-    // fast-reject (see field doc). Skipped when the over-approximation can match empty (it would
-    // then
-    // accept at every position, making it useless as a reject filter).
+    // the exact findDfa rejected. It crosses every anchor as epsilon → accepts a superset → a
+    // sound fast-reject (see field doc). Skipped when the over-approximation can match empty (it
+    // would then accept at every position, making it useless as a reject filter).
     if (findDfa == null && noAssertionsOrBackrefs(nfa)) {
       int[] startAll = sortedEpsilonClosure(new int[] {nfa.getStartState().id}, false);
       boolean approxEmpty = false;
@@ -442,7 +440,9 @@ public final class PikeVMMatcher extends ReggieMatcher {
 
   @Override
   public int findFrom(String input, int start) {
-    return findStartFrom(input, start);
+    int clamped = Math.max(0, start);
+    if (clamped > input.length()) return -1;
+    return findStartFrom(input, clamped);
   }
 
   @Override
@@ -457,7 +457,9 @@ public final class PikeVMMatcher extends ReggieMatcher {
 
   @Override
   public MatchResult findMatchFrom(String input, int start) {
-    return findMatchResultFrom(input, start);
+    int clamped = Math.max(0, start);
+    if (clamped > input.length()) return null;
+    return findMatchResultFrom(input, clamped);
   }
 
   @Override

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
@@ -117,6 +117,10 @@ public final class PikeVMMatcher extends ReggieMatcher {
   private final NfaStep rejectStep;
   private int[] rejectStartClosureIds; // start closure with ALL anchors crossed; set in ctor
 
+  // Shared scratch buffer for sorted two-pointer union merges in findStepClosure /
+  // rejectStepClosure. Sized stateCount; never allocated inside the hot step.
+  private final int[] mergeScratch;
+
   // T1.6 boolean matches() fast path: a STRICT (non-self-anchoring) lazy DFA over the same NFA.
   // matches() asks whether the WHOLE input matches from the start, which is priority-independent,
   // so the DFA's yes/no equals the thread simulation's. Built under the same anchor/assertion/
@@ -146,6 +150,7 @@ public final class PikeVMMatcher extends ReggieMatcher {
     for (NFA.NFAState s : nfa.getStates()) {
       statesById[s.id] = s;
     }
+    mergeScratch = new int[stateCount];
 
     // Precompute groupBodyNullable: for each GroupExit state, determine whether there is
     // an epsilon-only path from its matching GroupEntry to that GroupExit.
@@ -318,7 +323,32 @@ public final class PikeVMMatcher extends ReggieMatcher {
     return out; // ascending
   }
 
-  /** Sorted closure of {@code targets} UNIONed with the start closure (the self-anchoring step). */
+  /**
+   * Sorted two-pointer union of two ascending int arrays. Writes the merged result into {@link
+   * #mergeScratch} and returns an {@code int[]} sized exactly to the merged count. Neither input
+   * array is modified. Both inputs must be sorted ascending and deduplicated.
+   */
+  private int[] sortedUnion(int[] a, int[] b) {
+    int ai = 0, bi = 0, n = 0;
+    while (ai < a.length && bi < b.length) {
+      int av = a[ai], bv = b[bi];
+      if (av < bv) {
+        mergeScratch[n++] = av;
+        ai++;
+      } else if (bv < av) {
+        mergeScratch[n++] = bv;
+        bi++;
+      } else {
+        mergeScratch[n++] = av;
+        ai++;
+        bi++; // deduplicate equal ids
+      }
+    }
+    while (ai < a.length) mergeScratch[n++] = a[ai++];
+    while (bi < b.length) mergeScratch[n++] = b[bi++];
+    return Arrays.copyOf(mergeScratch, n);
+  }
+
   /**
    * The self-anchoring find() step: {@code sortedEpsilonClosure(targets, blockStart=true)} UNION
    * {@code reinjectClosureIds}. Re-injecting the pos&gt;0 start closure each character lets a match
@@ -328,15 +358,7 @@ public final class PikeVMMatcher extends ReggieMatcher {
    */
   private int[] findStepClosure(int[] targets) {
     int[] tc = sortedEpsilonClosure(targets, true);
-    boolean[] inSet = new boolean[stateCount];
-    for (int id : tc) inSet[id] = true;
-    for (int id : reinjectClosureIds) inSet[id] = true;
-    int count = 0;
-    for (boolean b : inSet) if (b) count++;
-    int[] out = new int[count];
-    int oi = 0;
-    for (int id = 0; id < stateCount; id++) if (inSet[id]) out[oi++] = id;
-    return out; // ascending
+    return sortedUnion(tc, reinjectClosureIds);
   }
 
   /**
@@ -348,15 +370,7 @@ public final class PikeVMMatcher extends ReggieMatcher {
    */
   private int[] rejectStepClosure(int[] targets) {
     int[] tc = sortedEpsilonClosure(targets, false);
-    boolean[] inSet = new boolean[stateCount];
-    for (int id : tc) inSet[id] = true;
-    for (int id : rejectStartClosureIds) inSet[id] = true;
-    int count = 0;
-    for (boolean b : inSet) if (b) count++;
-    int[] out = new int[count];
-    int oi = 0;
-    for (int id = 0; id < stateCount; id++) if (inSet[id]) out[oi++] = id;
-    return out; // ascending
+    return sortedUnion(tc, rejectStartClosureIds);
   }
 
   /** True when no NFA state carries a lookaround assertion or a backreference check. */
@@ -596,16 +610,14 @@ public final class PikeVMMatcher extends ReggieMatcher {
         int[] caps = Arrays.copyOf(clistCaptures[t], winCaptures.length);
         caps[1] = pos;
         best = buildResult(input, caps);
-        if (pos == fromPos) {
-          // Zero-length accept at the origin-most seed (caps[0] == fromPos == pos): the
-          // clistViaMultipleAnchors flags are still fresh (no swapLists yet), so the anchor-derived
-          // pruning is valid here exactly as in the former tryFindMatchAt first iteration. Discard
-          // lower-priority threads (keepLowerPriority=false) per Perl priority rules.
+        if (pos == clistCaptures[t][0]) {
+          // Zero-length accept at this thread's own seed position: clistViaMultipleAnchors flags
+          // are still valid (swapLists has not yet cleared them). Prune multi-anchor-derived
+          // threads per Perl priority rules (keepLowerPriority=false for find semantics).
           pruneAnchorDerivedAtStart(t, false);
         } else {
-          // Cut strictly-lower-priority threads. The accepting thread started at pos > fromPos, so
-          // (^/\A fire only at the pinned origin 0) it cannot be a multi-anchor-origin thread —
-          // hence no pruning is needed, and the now-stale post-swap flags must not be read.
+          // Accepting thread started before pos (non-zero-length match). Cut lower-priority
+          // threads.
           clistSize = t;
           clistFirstAccept = -1;
         }
@@ -960,6 +972,10 @@ public final class PikeVMMatcher extends ReggieMatcher {
     for (int i = 0; i < nlistSize; i++) {
       clistIds[i] = nlistIds[i];
       System.arraycopy(nlistCaptures[i], 0, clistCaptures[i], 0, len);
+      // Threads from nlist have advanced past their seed position: anchor-derived pruning no longer
+      // applies, so reset the flag rather than letting a stale value from the previous clist
+      // survive.
+      clistViaMultipleAnchors[i] = false;
       inClist[nlistIds[i]] = true;
       inNlist[nlistIds[i]] = false;
       // nlist is built in priority order, so the first accepting entry is the highest priority.

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/FromPosClampingRegressionTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/FromPosClampingRegressionTest.java
@@ -128,4 +128,29 @@ class FromPosClampingRegressionTest {
     assertNotNull(r, "backref: negative start clamped to 0 should find match");
     assertEquals(0, r.start());
   }
+
+  // -------------------------------------------------------------------------
+  // T10 — JavaRegexFallbackMatcher negative start (lazy quantifier → fallback)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void fallbackMatcher_findFrom_negativeStart_clampsToZero() {
+    // a*?b has a lazy quantifier → RECURSIVE_DESCENT + needsFallback → JavaRegexFallbackMatcher
+    ReggieMatcher m = Reggie.compile("a*?b", WITH_FALLBACK);
+    assertEquals(0, m.findFrom("ab", -1), "fallback: negative start must clamp to 0");
+  }
+
+  @Test
+  void fallbackMatcher_findFrom_startPastEnd_returnsMinusOne() {
+    ReggieMatcher m = Reggie.compile("a*?b", WITH_FALLBACK);
+    assertEquals(-1, m.findFrom("ab", 10), "fallback: start past end must return -1");
+  }
+
+  @Test
+  void fallbackMatcher_findMatchFrom_negativeStart_returnsMatchAtZero() {
+    ReggieMatcher m = Reggie.compile("a*?b", WITH_FALLBACK);
+    MatchResult r = m.findMatchFrom("ab", -1);
+    assertNotNull(r, "fallback: negative start clamped to 0 should find match");
+    assertEquals(0, r.start());
+  }
 }

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/FromPosClampingRegressionTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/FromPosClampingRegressionTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.datadoghq.reggie.Reggie;
+import com.datadoghq.reggie.ReggieOptions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for fromPos clamping in {@code findFrom} / {@code findMatchFrom}.
+ *
+ * <p>Covers {@code PikeVMMatcher} (routed via {@code PIKEVM_CAPTURE}) and {@code
+ * BackrefBacktrackMatcher} (routed via {@code OPTIMIZED_NFA_WITH_BACKREFS}) to verify both clamp
+ * negative starts to 0 and return -1/null for starts past end, matching the JDK contract.
+ */
+class FromPosClampingRegressionTest {
+
+  private static final ReggieOptions WITH_FALLBACK =
+      ReggieOptions.builder().allowJdkFallback().build();
+
+  // -------------------------------------------------------------------------
+  // T1 — findFrom with negative start clamps to 0 (PikeVMMatcher path)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void findFrom_negativeStart_clampsToZero() {
+    ReggieMatcher m = Reggie.compile("a", WITH_FALLBACK);
+    assertEquals(0, m.findFrom("abc", -1), "negative start -1 must clamp to 0");
+    assertEquals(0, m.findFrom("abc", -5), "negative start -5 must clamp to 0");
+  }
+
+  // -------------------------------------------------------------------------
+  // T2 — findFrom with start past end returns -1 (PikeVMMatcher path)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void findFrom_startPastEnd_returnsMinusOne() {
+    ReggieMatcher m = Reggie.compile("a", WITH_FALLBACK);
+    assertEquals(-1, m.findFrom("abc", 10), "start past end must return -1");
+    assertEquals(-1, m.findFrom("", 1), "start past empty string must return -1");
+  }
+
+  // -------------------------------------------------------------------------
+  // T3 — findMatchFrom with negative start returns match at 0 (PikeVMMatcher path)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void findMatchFrom_negativeStart_returnsMatchAtZero() {
+    ReggieMatcher m = Reggie.compile("a", WITH_FALLBACK);
+    MatchResult r = m.findMatchFrom("abc", -3);
+    assertNotNull(r, "negative start clamped to 0 should find match");
+    assertEquals(0, r.start());
+    assertEquals(1, r.end());
+  }
+
+  // -------------------------------------------------------------------------
+  // T4 — findMatchFrom with start past end returns null (PikeVMMatcher path)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void findMatchFrom_startPastEnd_returnsNull() {
+    ReggieMatcher m = Reggie.compile("a", WITH_FALLBACK);
+    assertNull(m.findMatchFrom("abc", 100), "start past end must return null");
+  }
+
+  // -------------------------------------------------------------------------
+  // T5 — Boundary: start == input.length() with zero-length pattern
+  // -------------------------------------------------------------------------
+
+  @Test
+  void findFrom_startEqualsLength_zeroLengthPattern() {
+    ReggieMatcher m = Reggie.compile("a*", WITH_FALLBACK);
+    assertEquals(3, m.findFrom("abc", 3), "start == length must find zero-length match at end");
+  }
+
+  // -------------------------------------------------------------------------
+  // T6 — Boundary: start == 0 on empty input with zero-length pattern
+  // -------------------------------------------------------------------------
+
+  @Test
+  void findFrom_startZero_emptyInput_zeroLengthPattern() {
+    ReggieMatcher m = Reggie.compile("a*", WITH_FALLBACK);
+    assertEquals(0, m.findFrom("", 0), "start == 0 on empty input must return 0");
+  }
+
+  // -------------------------------------------------------------------------
+  // T8 — No regression on normal positive-start findFrom
+  // -------------------------------------------------------------------------
+
+  @Test
+  void findFrom_normalPositiveStart_noRegression() {
+    ReggieMatcher m = Reggie.compile("foo", WITH_FALLBACK);
+    assertEquals(6, m.findFrom("barbarfoobar", 0), "should find 'foo' at 6 from start 0");
+    assertEquals(6, m.findFrom("barbarfoobar", 6), "should find 'foo' at 6 from start 6");
+    assertEquals(-1, m.findFrom("barbarfoobar", 7), "should return -1 when no match after start 7");
+  }
+
+  // -------------------------------------------------------------------------
+  // T9 — BackrefBacktrackMatcher negative start (backref pattern)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void backrefMatcher_findFrom_negativeStart_clampsToZero() {
+    // (a)\1 forces OPTIMIZED_NFA_WITH_BACKREFS / BackrefBacktrackMatcher
+    ReggieMatcher m = Reggie.compile("(a)\\1", WITH_FALLBACK);
+    assertEquals(0, m.findFrom("aa", -2), "backref: negative start must clamp to 0");
+  }
+
+  @Test
+  void backrefMatcher_findMatchFrom_negativeStart_returnsMatchAtZero() {
+    ReggieMatcher m = Reggie.compile("(a)\\1", WITH_FALLBACK);
+    MatchResult r = m.findMatchFrom("aa", -1);
+    assertNotNull(r, "backref: negative start clamped to 0 should find match");
+    assertEquals(0, r.start());
+  }
+}

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/MultilineAnchorAndStepClosureRegressionTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/MultilineAnchorAndStepClosureRegressionTest.java
@@ -244,8 +244,8 @@ public class MultilineAnchorAndStepClosureRegressionTest {
     ReggieMatcher m = Reggie.compile(pattern);
     List<MatchResult> all = m.findAll(input);
 
-    // Expect at least the two line starts: pos=0 and pos=2 (after '\n')
-    assertTrue(all.size() >= 2, "must find at least 2 zero-length matches; got " + all.size());
+    // Expect exactly two line starts: pos=0 and pos=2 (after '\n'); over-matching is a regression.
+    assertEquals(2, all.size(), "(?m)^ on \"a\\nb\" must produce exactly 2 zero-length matches");
 
     assertEquals(0, all.get(0).start(), "first zero-length match at input start");
     assertEquals(0, all.get(0).end(), "first match is zero-length");

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/MultilineAnchorAndStepClosureRegressionTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/MultilineAnchorAndStepClosureRegressionTest.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datadoghq.reggie.Reggie;
+import com.datadoghq.reggie.codegen.analysis.PatternAnalyzer;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Acceptance tests for two defects fixed in this PR:
+ *
+ * <ul>
+ *   <li>Defect A: O(stateCount) allocation in {@code rejectStepClosure}/{@code findStepClosure}
+ *       (correctness verified via observable behavior; allocation removal is transparent).
+ *   <li>Defect B: multiline {@code ^} patterns must not be routed to {@code
+ *       SPECIALIZED_MULTI_GROUP_GREEDY}; they must match at every line start, not only at pos==0.
+ * </ul>
+ *
+ * <p>Group A covers Defect B routing + correctness. Group B covers Defect A step-closure
+ * correctness. Group C covers the sibling zero-length-accept pruning fix for multiline {@code ^}.
+ */
+public class MultilineAnchorAndStepClosureRegressionTest {
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private static void assertRoute(String pattern, PatternAnalyzer.MatchingStrategy expected)
+      throws Exception {
+    PatternAnalyzer.MatchingStrategy actual = StrategyCorrectnessMetaTest.routeOf(pattern);
+    assertEquals(
+        expected, actual, "routing changed for /" + pattern + "/ — fix would not be exercised");
+  }
+
+  private static void assertNotRoute(String pattern, PatternAnalyzer.MatchingStrategy forbidden)
+      throws Exception {
+    PatternAnalyzer.MatchingStrategy actual = StrategyCorrectnessMetaTest.routeOf(pattern);
+    assertNotEquals(forbidden, actual, "pattern /" + pattern + "/ must NOT route to " + forbidden);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Group A — Defect B: multiline ^ must not route to SPECIALIZED_MULTI_GROUP_GREEDY
+  // ---------------------------------------------------------------------------
+
+  /**
+   * A1: multiline ^ with two capture groups must produce all line-start matches, not only pos==0.
+   *
+   * <p>Pattern: {@code (?m)^(\d+)-(\w+)}, Input: {@code "123-abc\n456-def\n"}
+   */
+  @Test
+  void a1_multilineCaretMultiGroup_allLineMatches() throws Exception {
+    String pattern = "(?m)^(\\d+)-(\\w+)";
+    String input = "123-abc\n456-def\n";
+
+    assertNotRoute(pattern, PatternAnalyzer.MatchingStrategy.SPECIALIZED_MULTI_GROUP_GREEDY);
+
+    ReggieMatcher m = Reggie.compile(pattern);
+    List<MatchResult> all = m.findAll(input);
+
+    assertEquals(2, all.size(), "expected exactly 2 line matches");
+
+    MatchResult first = all.get(0);
+    assertEquals(0, first.start(), "first match start");
+    assertEquals("123", first.group(1), "first match group(1)");
+    assertEquals("abc", first.group(2), "first match group(2)");
+
+    MatchResult second = all.get(1);
+    assertEquals(8, second.start(), "second match start");
+    assertEquals("456", second.group(1), "second match group(1)");
+    assertEquals("def", second.group(2), "second match group(2)");
+  }
+
+  /**
+   * A2: multiline ^ with uppercase letter groups and literal separator. Both lines must be matched.
+   *
+   * <p>Pattern: {@code (?m)^([A-Z]+):([0-9]+)}, Input: {@code "FOO:1\nBAR:2"}
+   */
+  @Test
+  void a2_multilineCaretLiteralSeparator_bothLines() throws Exception {
+    String pattern = "(?m)^([A-Z]+):([0-9]+)";
+    String input = "FOO:1\nBAR:2";
+
+    assertNotRoute(pattern, PatternAnalyzer.MatchingStrategy.SPECIALIZED_MULTI_GROUP_GREEDY);
+
+    ReggieMatcher m = Reggie.compile(pattern);
+    List<MatchResult> all = m.findAll(input);
+
+    assertEquals(2, all.size(), "expected exactly 2 matches");
+
+    assertEquals("FOO", all.get(0).group(1), "first match group(1)");
+    assertEquals("1", all.get(0).group(2), "first match group(2)");
+
+    assertEquals("BAR", all.get(1).group(1), "second match group(1)");
+    assertEquals("2", all.get(1).group(2), "second match group(2)");
+  }
+
+  /**
+   * A3: non-multiline ^ must still anchor only to input start — regression guard.
+   *
+   * <p>Pattern: {@code ^(\d+)-(\w+)}, Input: {@code "123-abc\n456-def\n"}
+   */
+  @Test
+  void a3_nonMultilineCaretAnchorInputStartOnly() {
+    String pattern = "^(\\d+)-(\\w+)";
+    String input = "123-abc\n456-def\n";
+
+    ReggieMatcher m = Reggie.compile(pattern);
+    List<MatchResult> all = m.findAll(input);
+
+    assertEquals(1, all.size(), "non-multiline ^ must produce exactly one match");
+    assertEquals(0, all.get(0).start(), "match must be at input start");
+    assertEquals("123", all.get(0).group(1), "group(1)");
+    assertEquals("abc", all.get(0).group(2), "group(2)");
+  }
+
+  /**
+   * A4: \A must always anchor to input start regardless of newlines.
+   *
+   * <p>Pattern: {@code \A(\d+)-(\w+)}, Input: {@code "123-abc\n456-def\n"}
+   */
+  @Test
+  void a4_absoluteStartAnchorInputStartOnly() {
+    String pattern = "\\A(\\d+)-(\\w+)";
+    String input = "123-abc\n456-def\n";
+
+    ReggieMatcher m = Reggie.compile(pattern);
+    List<MatchResult> all = m.findAll(input);
+
+    assertEquals(1, all.size(), "\\A must produce exactly one match");
+    assertEquals(0, all.get(0).start(), "match must be at input start");
+    assertEquals("123", all.get(0).group(1), "group(1)");
+    assertEquals("abc", all.get(0).group(2), "group(2)");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Group B — Defect A: step-closure correctness (allocation fix is transparent)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * B1: anchored pattern with no match exercises {@code rejectStepClosure}; must return false/null.
+   *
+   * <p>Pattern: {@code ^foo(\d+)bar}, Input: {@code "xxxfooxxx"}
+   */
+  @Test
+  void b1_anchoredPatternNoMatch_rejectStepClosure() {
+    String pattern = "^foo(\\d+)bar";
+    String input = "xxxfooxxx";
+
+    ReggieMatcher m = Reggie.compile(pattern);
+    assertFalse(m.find(input), "find() must return false — no match");
+    assertNull(m.findMatch(input), "findMatch() must return null — no match");
+  }
+
+  /**
+   * B2: anchor-free pattern exercises {@code findStepClosure}; must find embedded match.
+   *
+   * <p>Pattern: {@code (\d{3})-(\d{4})}, Input: {@code "call 555-1234 now"}
+   */
+  @Test
+  void b2_anchorFreePattern_findStepClosure() {
+    String pattern = "(\\d{3})-(\\d{4})";
+    String input = "call 555-1234 now";
+
+    ReggieMatcher m = Reggie.compile(pattern);
+    assertTrue(m.find(input), "find() must return true");
+
+    MatchResult r = m.findMatch(input);
+    assertNotNull(r, "findMatch() must not be null");
+    assertEquals(5, r.start(), "match start");
+    assertEquals("555", r.group(1), "group(1)");
+    assertEquals("1234", r.group(2), "group(2)");
+  }
+
+  /**
+   * B3: pattern with start + end anchors exercises {@code rejectStepClosure} with non-trivial
+   * reinject closure.
+   *
+   * <p>Pattern: {@code ^(\w+)$}, Input: {@code "hello"}
+   */
+  @Test
+  void b3_startEndAnchorPattern_matches() {
+    String pattern = "^(\\w+)$";
+    String input = "hello";
+
+    ReggieMatcher m = Reggie.compile(pattern);
+    assertTrue(m.matches(input), "matches() must return true");
+
+    MatchResult r = m.match(input);
+    assertNotNull(r, "match() must not be null");
+    assertEquals("hello", r.group(1), "group(1)");
+  }
+
+  /**
+   * B4: alternation exercises {@code findStepClosure} with overlapping closure state ids; find must
+   * succeed.
+   *
+   * <p>Pattern: {@code (\d+)|\w+}, Input: {@code "abc123"}
+   */
+  @Test
+  void b4_alternationOverlappingClosures_findSucceeds() {
+    String pattern = "(\\d+)|\\w+";
+    String input = "abc123";
+
+    ReggieMatcher m = Reggie.compile(pattern);
+    assertTrue(m.find(input), "find() must return true");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Group C — zero-length-accept pruning for multiline ^
+  // ---------------------------------------------------------------------------
+
+  /**
+   * C1: multiline {@code ^} (zero-length match) must match at every line boundary, not just
+   * fromPos.
+   *
+   * <p>Pattern: {@code (?m)^}, Input: {@code "a\nb"}
+   */
+  @Test
+  void c1_multilineCaretZeroLength_allLineBoundaries() {
+    String pattern = "(?m)^";
+    String input = "a\nb";
+
+    ReggieMatcher m = Reggie.compile(pattern);
+    List<MatchResult> all = m.findAll(input);
+
+    // Expect at least the two line starts: pos=0 and pos=2 (after '\n')
+    assertTrue(all.size() >= 2, "must find at least 2 zero-length matches; got " + all.size());
+
+    assertEquals(0, all.get(0).start(), "first zero-length match at input start");
+    assertEquals(0, all.get(0).end(), "first match is zero-length");
+
+    assertEquals(2, all.get(1).start(), "second zero-length match after newline");
+    assertEquals(2, all.get(1).end(), "second match is zero-length");
+  }
+
+  /**
+   * C2: non-zero-length multiline {@code ^} match at both line boundaries; no spurious pruning.
+   *
+   * <p>Pattern: {@code (?m)^(abc)}, Input: {@code "abc\nabc"}
+   */
+  @Test
+  void c2_multilineCaretNonZeroLength_noPruning() {
+    String pattern = "(?m)^(abc)";
+    String input = "abc\nabc";
+
+    ReggieMatcher m = Reggie.compile(pattern);
+    List<MatchResult> all = m.findAll(input);
+
+    assertEquals(2, all.size(), "expected 2 matches — one per line");
+
+    assertEquals(0, all.get(0).start(), "first match start");
+    assertEquals("abc", all.get(0).group(1), "first match group(1)");
+
+    assertEquals(4, all.get(1).start(), "second match start");
+    assertEquals("abc", all.get(1).group(1), "second match group(1)");
+  }
+}

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/PikeVMRoutingTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/PikeVMRoutingTest.java
@@ -107,4 +107,29 @@ class PikeVMRoutingTest {
         m.findMatch("ab").group(0),
         "(a|ab) find on 'ab' must return 'a' (first alternative wins)");
   }
+
+  // -------------------------------------------------------------------------
+  // Class E: interacting alternations wrapped in non-capturing groups
+  // -------------------------------------------------------------------------
+
+  @Test
+  void ncgWrappedInteractingAlts_routesToPikeVmCapture() throws Exception {
+    // ((?:a|ab))((?:c|bcd)) — same Class E shape as (a|ab)(c|bcd) but alternations
+    // are wrapped in a transparent non-capturing group; capturingGroupAlternation must
+    // unwrap the NCG layer to detect the interacting variable-length alternations.
+    assertEquals(
+        PatternAnalyzer.MatchingStrategy.PIKEVM_CAPTURE,
+        StrategyCorrectnessMetaTest.routeOf("((?:a|ab))((?:c|bcd))"),
+        "((?:a|ab))((?:c|bcd)) must route to PIKEVM_CAPTURE (Class E via NCG unwrap)");
+  }
+
+  @Test
+  void ncgWrappedInteractingAlts_captureCorrect() {
+    // ((?:a|ab))((?:c|bcd)) on "abcd": JDK leftmost-longest → group(1)="a", group(2)="bcd"
+    ReggieMatcher m = Reggie.compile("((?:a|ab))((?:c|bcd))");
+    MatchResult r = m.findMatch("abcd");
+    assertNotNull(r, "must find a match in 'abcd'");
+    assertEquals("a", r.group(1), "group(1) must be 'a'");
+    assertEquals("bcd", r.group(2), "group(2) must be 'bcd'");
+  }
 }


### PR DESCRIPTION
### What does this PR do?

Makes the IAST `findAll` drain O(n): single continuing-cursor PikeVM find (replacing the per-start O(n²) retry), anchor origin pinned to absolute 0 (also fixes a latent `^`/`\A` findAll re-anchoring bug), plus a boolean-DFA fast-reject and an over-approximating "reject DFA" (anchors crossed as epsilon) so anchored patterns also skip the thread sim on no-match. Adds a `findAll` group-span fuzz oracle. Capture routing: `MGG` declines give-back (fixes `(\w+)0` returning no match), and nullable-group-in-alternation (`1|()b`) + interacting variable-length capturing alternations (`(a|ab)(c|bcd)`) route to PikeVM for correct spans.

### Motivation

Adversarial IAST drains were catastrophically O(n²) (up to ~153,000 µs at 2048 B). This is the core re2j-replacement goal.

### Related Issue(s)

Stacked on PR4. Final PR of the 2026-06 effort.

### Change Type

- [x] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [ ] Test improvement
- [ ] Build/CI change

### Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] All existing tests pass (`./gradlew build`)
- [x] I have added tests for my changes
- [x] I have updated documentation (if applicable)
- [ ] My commits are signed

### Performance Impact

Adversarial / zero-match IAST drains (URL/SQL/COMMAND) now ~8.5 µs/op at 2048 B vs re2j 84–306 — **10–31× faster than re2j** (was up to ~153,000 µs). Verified by the differential fuzz gate (budget 78→69).

### Additional Notes

Stacked on `pr/4-perf-boolean-dfa-bitmap`. No merge commits. Cuts at `f06e984` (HEAD). The deferred capture-correctness classes (Class B empty-iteration, Class C DFA give-back) remain as documented, native, O(n)/ReDoS-safe, span-only limitations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
