### PR TITLE
fix(#41,#42,#74): atomic groups, possessive quantifiers, first-byte skip

### DIFF
--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
@@ -5974,11 +5974,8 @@ public class PatternAnalyzer {
     }
 
     @Override
-    public Boolean visitQuantifier(QuantifierNode node) {
-      if (node.possessive) {
-        return true;
-      }
-      return node.child.accept(this);
+    public Boolean visitQuantifier(QuantifierNode n) {
+      return n.child.accept(this);
     }
 
     @Override

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
@@ -293,6 +293,7 @@ public class PatternAnalyzer {
     guardTrace.clear();
     MatchingStrategyResult result = doAnalyze(ignoreGroupCount);
     result.guardTrace.addAll(guardTrace);
+    result.hasAtomicGroups = hasAtomicGroups(ast);
     return result;
   }
 
@@ -364,6 +365,11 @@ public class PatternAnalyzer {
           new RecursiveDescentPatternInfo(ast), // includes AST structural hash for caching
           false, // useTaggedDFA
           requiredLiterals);
+    }
+
+    if (hasAtomicGroups(ast)) {
+      return new MatchingStrategyResult(
+          MatchingStrategy.PIKEVM_CAPTURE, null, null, false, requiredLiterals);
     }
 
     // Phase 2: Detect lookahead+greedy+suffix pattern for reverse scanning optimization
@@ -3066,6 +3072,14 @@ public class PatternAnalyzer {
      * {@code JavaRegexFallbackMatcher}) rather than using the generated NFA bytecode.
      */
     public boolean anchorConditionDiluted;
+
+    /**
+     * True when the pattern contains at least one atomic group ({@code (?>...)}) or possessive
+     * quantifier ({@code X*+}, {@code X++}, {@code X?+}, {@code X{n,m}+}). Required so that two
+     * patterns differing only in atomic-group markers produce distinct structural hashes and do not
+     * collide in the bytecode cache.
+     */
+    public boolean hasAtomicGroups;
 
     /** Per-guard routing trace populated by {@link PatternAnalyzer#analyzeAndRecommend}. */
     public final List<String> guardTrace = new ArrayList<>();
@@ -5932,6 +5946,85 @@ public class PatternAnalyzer {
     public Boolean visitBranchReset(BranchResetNode node) {
       return node.alternatives.stream().anyMatch(alt -> alt.accept(this));
     }
+  }
+
+  /**
+   * Visitor that returns {@code true} when the AST contains an atomic group ({@code (?>...)}) or a
+   * possessive quantifier ({@code X*+}, {@code X++}, {@code X?+}, {@code X{n,m}+}).
+   */
+  private static class AtomicGroupDetector implements RegexVisitor<Boolean> {
+    @Override
+    public Boolean visitLiteral(LiteralNode node) {
+      return false;
+    }
+
+    @Override
+    public Boolean visitCharClass(CharClassNode node) {
+      return false;
+    }
+
+    @Override
+    public Boolean visitConcat(ConcatNode node) {
+      return node.children.stream().anyMatch(child -> child.accept(this));
+    }
+
+    @Override
+    public Boolean visitAlternation(AlternationNode node) {
+      return node.alternatives.stream().anyMatch(alt -> alt.accept(this));
+    }
+
+    @Override
+    public Boolean visitQuantifier(QuantifierNode node) {
+      if (node.possessive) {
+        return true;
+      }
+      return node.child.accept(this);
+    }
+
+    @Override
+    public Boolean visitGroup(GroupNode node) {
+      if (node.atomic) {
+        return true;
+      }
+      return node.child.accept(this);
+    }
+
+    @Override
+    public Boolean visitAnchor(AnchorNode node) {
+      return false;
+    }
+
+    @Override
+    public Boolean visitBackreference(BackreferenceNode node) {
+      return false;
+    }
+
+    @Override
+    public Boolean visitAssertion(AssertionNode node) {
+      return node.subPattern != null && node.subPattern.accept(this);
+    }
+
+    @Override
+    public Boolean visitSubroutine(SubroutineNode node) {
+      return false;
+    }
+
+    @Override
+    public Boolean visitConditional(ConditionalNode node) {
+      boolean hasThen = node.thenBranch.accept(this);
+      boolean hasElse = node.elseBranch != null && node.elseBranch.accept(this);
+      return hasThen || hasElse;
+    }
+
+    @Override
+    public Boolean visitBranchReset(BranchResetNode node) {
+      return node.alternatives.stream().anyMatch(alt -> alt.accept(this));
+    }
+  }
+
+  /** Returns {@code true} when the AST contains an atomic group or possessive quantifier. */
+  private static boolean hasAtomicGroups(RegexNode node) {
+    return node.accept(new AtomicGroupDetector());
   }
 
   /** Information about a greedy char class pattern like (\d+) or ([a-z]*). */

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternInfo.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternInfo.java
@@ -29,4 +29,15 @@ public interface PatternInfo {
    */
   int structuralHashCode();
 
+  /**
+   * True when the pattern contains at least one atomic group ({@code (?>...)}) or possessive
+   * quantifier ({@code X*+}, {@code X++}, {@code X?+}, {@code X{n,m}+}). Implementations that
+   * represent such patterns must override this method to return {@code true} so that the structural
+   * hash correctly distinguishes them from otherwise-equivalent non-atomic patterns.
+   *
+   * @return {@code false} by default; override to return {@code true} when atomic groups are present
+   */
+  default boolean hasAtomicGroups() {
+    return false;
+  }
 }

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternInfo.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternInfo.java
@@ -28,4 +28,16 @@ public interface PatternInfo {
    * @return hash code representing structural equivalence
    */
   int structuralHashCode();
+
+  /**
+   * True when the pattern contains at least one atomic group ({@code (?>...)}) or possessive
+   * quantifier ({@code X*+}, {@code X++}, {@code X?+}, {@code X{n,m}+}). Implementations that
+   * represent such patterns must override this method to return {@code true} so that the structural
+   * hash correctly distinguishes them from otherwise-equivalent non-atomic patterns.
+   *
+   * @return {@code false} by default; override to return {@code true} when atomic groups are present
+   */
+  default boolean hasAtomicGroups() {
+    return false;
+  }
 }

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternInfo.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternInfo.java
@@ -29,15 +29,4 @@ public interface PatternInfo {
    */
   int structuralHashCode();
 
-  /**
-   * True when the pattern contains at least one atomic group ({@code (?>...)}) or possessive
-   * quantifier ({@code X*+}, {@code X++}, {@code X?+}, {@code X{n,m}+}). Implementations that
-   * represent such patterns must override this method to return {@code true} so that the structural
-   * hash correctly distinguishes them from otherwise-equivalent non-atomic patterns.
-   *
-   * @return {@code false} by default; override to return {@code true} when atomic groups are present
-   */
-  default boolean hasAtomicGroups() {
-    return false;
-  }
 }

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternInfo.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternInfo.java
@@ -28,5 +28,4 @@ public interface PatternInfo {
    * @return hash code representing structural equivalence
    */
   int structuralHashCode();
-
 }

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/StructuralHash.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/StructuralHash.java
@@ -84,6 +84,7 @@ public final class StructuralHash {
     hash = mult * hash + nfa.getGroupCount();
     hash = mult * hash + (result.useTaggedDFA ? 1 : 0);
     hash = mult * hash + (result.usePosixLastMatch ? 1 : 0);
+    hash = mult * hash + (result.hasAtomicGroups ? 1 : 0);
     hash = mult * hash + (caseInsensitive ? 1 : 0);
 
     // Each anchor type is a separate bit so that patterns differing only in which
@@ -133,6 +134,7 @@ public final class StructuralHash {
     hash = mult * hash + result.strategy.ordinal();
     hash = mult * hash + (result.useTaggedDFA ? 1 : 0);
     hash = mult * hash + (result.usePosixLastMatch ? 1 : 0);
+    hash = mult * hash + (result.hasAtomicGroups ? 1 : 0);
 
     if (result.dfa != null) {
       hash = mult * hash + computeDFATopologyHash(result.dfa, mult);

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/ast/GroupNode.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/ast/GroupNode.java
@@ -25,16 +25,22 @@ public final class GroupNode implements RegexNode {
   public final int groupNumber; // 0 for non-capturing
   public final boolean capturing;
   public final String name; // null for unnamed groups
+  public final boolean atomic;
 
   public GroupNode(RegexNode child, int groupNumber, boolean capturing) {
     this(child, groupNumber, capturing, null);
   }
 
   public GroupNode(RegexNode child, int groupNumber, boolean capturing, String name) {
+    this(child, groupNumber, capturing, name, false);
+  }
+
+  public GroupNode(RegexNode child, int groupNumber, boolean capturing, String name, boolean atomic) {
     this.child = child;
     this.groupNumber = groupNumber;
     this.capturing = capturing;
     this.name = name;
+    this.atomic = atomic;
   }
 
   @Override

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/ast/GroupNode.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/ast/GroupNode.java
@@ -35,7 +35,8 @@ public final class GroupNode implements RegexNode {
     this(child, groupNumber, capturing, name, false);
   }
 
-  public GroupNode(RegexNode child, int groupNumber, boolean capturing, String name, boolean atomic) {
+  public GroupNode(
+      RegexNode child, int groupNumber, boolean capturing, String name, boolean atomic) {
     this.child = child;
     this.groupNumber = groupNumber;
     this.capturing = capturing;

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/ast/GroupNode.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/ast/GroupNode.java
@@ -50,6 +50,7 @@ public final class GroupNode implements RegexNode {
 
   @Override
   public String toString() {
+    if (atomic) return "AtomicGroup(" + child + ")";
     if (name != null) {
       return "Group(" + groupNumber + " '" + name + "', " + child + ")";
     }

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/ast/QuantifierNode.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/ast/QuantifierNode.java
@@ -22,12 +22,18 @@ public final class QuantifierNode implements RegexNode {
   public final int min;
   public final int max; // -1 for unlimited
   public final boolean greedy;
+  public final boolean possessive;
 
-  public QuantifierNode(RegexNode child, int min, int max, boolean greedy) {
+  public QuantifierNode(RegexNode child, int min, int max, boolean greedy, boolean possessive) {
     this.child = child;
     this.min = min;
     this.max = max;
     this.greedy = greedy;
+    this.possessive = possessive;
+  }
+
+  public QuantifierNode(RegexNode child, int min, int max, boolean greedy) {
+    this(child, min, max, greedy, false);
   }
 
   @Override
@@ -45,6 +51,6 @@ public final class QuantifierNode implements RegexNode {
     else if (min == max) quant = "{" + min + "}";
     else quant = "{" + min + "," + max + "}";
 
-    return "Quantifier(" + child + quant + (greedy ? "" : "?") + ")";
+    return "Quantifier(" + child + quant + (possessive ? "+" : greedy ? "" : "?") + ")";
   }
 }

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/automaton/GlushkovAutomaton.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/automaton/GlushkovAutomaton.java
@@ -127,8 +127,8 @@ public final class GlushkovAutomaton {
   }
 
   /**
-   * Returns the single ASCII character (0–127) that must appear at the accepting position of
-   * every match, or {@code -1} if none can be identified.
+   * Returns the single ASCII character (0–127) that must appear at the accepting position of every
+   * match, or {@code -1} if none can be identified.
    *
    * <p>When the Last (accept) set has exactly one position {@code p} and exactly one ASCII
    * character activates {@code p} through {@code entry[asciiClasses[c]] >> p & 1 != 0}, that
@@ -136,8 +136,8 @@ public final class GlushkovAutomaton {
    * to skip non-candidate regions in {@code find()}.
    *
    * <p>Returns {@code -1} when: the Last set has more than one position; more than one ASCII
-   * character activates the sole accepting position (class too wide); or the position is
-   * activated only by non-ASCII characters.
+   * character activates the sole accepting position (class too wide); or the position is activated
+   * only by non-ASCII characters.
    */
   public int findLastRequiredChar() {
     if (Long.bitCount(accept) != 1) return -1;

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/automaton/GlushkovAutomaton.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/automaton/GlushkovAutomaton.java
@@ -127,6 +127,33 @@ public final class GlushkovAutomaton {
   }
 
   /**
+   * Returns the single ASCII character (0–127) that must appear at the accepting position of
+   * every match, or {@code -1} if none can be identified.
+   *
+   * <p>When the Last (accept) set has exactly one position {@code p} and exactly one ASCII
+   * character activates {@code p} through {@code entry[asciiClasses[c]] >> p & 1 != 0}, that
+   * character is required at every match end. The caller can use {@link String#indexOf(int, int)}
+   * to skip non-candidate regions in {@code find()}.
+   *
+   * <p>Returns {@code -1} when: the Last set has more than one position; more than one ASCII
+   * character activates the sole accepting position (class too wide); or the position is
+   * activated only by non-ASCII characters.
+   */
+  public int findLastRequiredChar() {
+    if (Long.bitCount(accept) != 1) return -1;
+    int p = Long.numberOfTrailingZeros(accept);
+    int found = -1;
+    for (int c = 0; c < 128; c++) {
+      int cls = asciiClasses[c];
+      if (((entry[cls] >> p) & 1L) != 0L) {
+        if (found != -1) return -1; // more than one ASCII char activates p
+        found = c;
+      }
+    }
+    return found;
+  }
+
+  /**
    * Builds the Glushkov automaton for {@code nfa}, or returns {@code null} if the pattern is
    * ineligible (capturing groups, anchors, assertions, backreferences, conditionals, no positions,
    * or more than {@link #MAX_POSITIONS} positions).

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/automaton/NFA.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/automaton/NFA.java
@@ -351,7 +351,7 @@ public final class NFA {
       hash = mult * hash + (state.assertionWidth + 1);
 
       hash = mult * hash + state.atomicEntry + 1; // +1 distinguishes id=0 from absent (-1)
-      hash = mult * hash + state.atomicExit  + 1;
+      hash = mult * hash + state.atomicExit + 1;
     }
 
     return hash;
@@ -362,7 +362,7 @@ public final class NFA {
     int max = -1;
     for (NFAState state : states) {
       if (state.atomicEntry >= 0) max = Math.max(max, state.atomicEntry);
-      if (state.atomicExit  >= 0) max = Math.max(max, state.atomicExit);
+      if (state.atomicExit >= 0) max = Math.max(max, state.atomicExit);
     }
     return max + 1;
   }
@@ -395,7 +395,7 @@ public final class NFA {
     public NFAState elseBranch = null; // Entry if group didn't match (may be null)
 
     public int atomicEntry = -1; // >= 0: entering atomic group with this id
-    public int atomicExit  = -1; // >= 0: exiting atomic group with this id
+    public int atomicExit = -1; // >= 0: exiting atomic group with this id
 
     public NFAState(int id) {
       this.id = id;

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/automaton/NFA.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/automaton/NFA.java
@@ -349,9 +349,22 @@ public final class NFA {
       // different bytecode (the width is pushed as a literal constant in the assertion check).
       // assertionWidth == -1 for non-lookbehind states, so add 1 to distinguish from unset.
       hash = mult * hash + (state.assertionWidth + 1);
+
+      hash = mult * hash + state.atomicEntry + 1; // +1 distinguishes id=0 from absent (-1)
+      hash = mult * hash + state.atomicExit  + 1;
     }
 
     return hash;
+  }
+
+  /** Number of distinct atomic group ids in this NFA (max id + 1, or 0 if none). */
+  public int getAtomicGroupCount() {
+    int max = -1;
+    for (NFAState state : states) {
+      if (state.atomicEntry >= 0) max = Math.max(max, state.atomicEntry);
+      if (state.atomicExit  >= 0) max = Math.max(max, state.atomicExit);
+    }
+    return max + 1;
   }
 
   /** NFA state with character transitions and epsilon transitions. */
@@ -380,6 +393,9 @@ public final class NFA {
     public Integer conditionalGroup = null; // Group number to check
     public NFAState thenBranch = null; // Entry if group matched
     public NFAState elseBranch = null; // Entry if group didn't match (may be null)
+
+    public int atomicEntry = -1; // >= 0: entering atomic group with this id
+    public int atomicExit  = -1; // >= 0: exiting atomic group with this id
 
     public NFAState(int id) {
       this.id = id;

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/automaton/ThompsonBuilder.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/automaton/ThompsonBuilder.java
@@ -25,6 +25,7 @@ import java.util.*;
 public class ThompsonBuilder implements RegexVisitor<ThompsonBuilder.NFAFragment> {
 
   private int nextStateId = 0;
+  private int atomicGroupCounter = 0;
   private final List<NFA.NFAState> allStates = new ArrayList<>();
 
   /**
@@ -253,6 +254,24 @@ public class ThompsonBuilder implements RegexVisitor<ThompsonBuilder.NFAFragment
   @Override
   public NFAFragment visitGroup(GroupNode node) {
     NFAFragment child = node.child.accept(this);
+
+    if (node.atomic) {
+      int atomicId = atomicGroupCounter++;
+
+      NFA.NFAState entryState = createState();
+      entryState.atomicEntry = atomicId;
+      entryState.addEpsilonTransition(child.entry);
+
+      Set<NFA.NFAState> atomicExits = new HashSet<>();
+      for (NFA.NFAState childExit : child.exits) {
+        NFA.NFAState exitState = createState();
+        exitState.atomicExit = atomicId;
+        childExit.addEpsilonTransition(exitState);
+        atomicExits.add(exitState);
+      }
+
+      return new NFAFragment(entryState, atomicExits);
+    }
 
     if (node.capturing) {
       // Create intermediate epsilon states to avoid overwriting nested group markers

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/BitParallelGlushkovBytecodeGenerator.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/BitParallelGlushkovBytecodeGenerator.java
@@ -45,7 +45,7 @@ public final class BitParallelGlushkovBytecodeGenerator {
 
   public BitParallelGlushkovBytecodeGenerator(GlushkovAutomaton g) {
     this.g = g;
-    this.lastRequiredChar = g.findLastRequiredChar();
+    this.lastRequiredChar = g.startsAnywhere ? g.findLastRequiredChar() : -1;
   }
 
   // -------------------------------------------------------------------------

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/BitParallelGlushkovBytecodeGenerator.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/BitParallelGlushkovBytecodeGenerator.java
@@ -45,7 +45,7 @@ public final class BitParallelGlushkovBytecodeGenerator {
 
   public BitParallelGlushkovBytecodeGenerator(GlushkovAutomaton g) {
     this.g = g;
-    this.lastRequiredChar = g.startsAnywhere ? g.findLastRequiredChar() : -1;
+    this.lastRequiredChar = g.findLastRequiredChar();
   }
 
   // -------------------------------------------------------------------------

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/BitParallelGlushkovBytecodeGenerator.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/BitParallelGlushkovBytecodeGenerator.java
@@ -36,8 +36,16 @@ public final class BitParallelGlushkovBytecodeGenerator {
 
   private final GlushkovAutomaton g;
 
+  /**
+   * The single ASCII character that must appear at every match end, or {@code -1} if none. When
+   * non-negative, {@code generateFindFromMethod} emits a call to {@code findFromWithSkip} instead of
+   * {@code findFrom}, and {@code generateStaticData} emits a {@code LAST_REQ_CHAR} field.
+   */
+  private final int lastRequiredChar;
+
   public BitParallelGlushkovBytecodeGenerator(GlushkovAutomaton g) {
     this.g = g;
+    this.lastRequiredChar = g.findLastRequiredChar();
   }
 
   // -------------------------------------------------------------------------
@@ -56,6 +64,10 @@ public final class BitParallelGlushkovBytecodeGenerator {
     cw.visitField(ACC_PRIVATE | ACC_STATIC | ACC_FINAL, "RANGE_ENDS", "[C", null, null).visitEnd();
     cw.visitField(ACC_PRIVATE | ACC_STATIC | ACC_FINAL, "RANGE_CLASSES", "[I", null, null)
         .visitEnd();
+    if (lastRequiredChar >= 0) {
+      cw.visitField(ACC_PRIVATE | ACC_STATIC | ACC_FINAL, "LAST_REQ_CHAR", "I", null, lastRequiredChar)
+          .visitEnd();
+    }
 
     MethodVisitor mv = cw.visitMethod(ACC_STATIC, "<clinit>", "()V", null, null);
     mv.visitCode();
@@ -161,7 +173,12 @@ public final class BitParallelGlushkovBytecodeGenerator {
     mv.visitVarInsn(ILOAD, 2);
     pushScalarArgsFind(mv);
     pushArrayArgs(mv, className, true);
-    mv.visitMethodInsn(INVOKESTATIC, RUNTIME, "findFrom", findFromDescriptor(), false);
+    if (lastRequiredChar >= 0) {
+      mv.visitFieldInsn(GETSTATIC, className, "LAST_REQ_CHAR", "I");
+      mv.visitMethodInsn(INVOKESTATIC, RUNTIME, "findFromWithSkip", findFromWithSkipDescriptor(), false);
+    } else {
+      mv.visitMethodInsn(INVOKESTATIC, RUNTIME, "findFrom", findFromDescriptor(), false);
+    }
     mv.visitInsn(IRETURN);
     mv.visitMaxs(0, 0);
     mv.visitEnd();
@@ -461,6 +478,14 @@ public final class BitParallelGlushkovBytecodeGenerator {
    */
   private static String findFromDescriptor() {
     return "(Ljava/lang/CharSequence;IJJZZ[J[J[I[C[C[I[J)I";
+  }
+
+  /**
+   * findFromWithSkip(CharSequence, int, long, long, boolean, boolean, long[], long[], int[], char[],
+   * char[], int[], long[], int)I — same as findFrom but with an extra I for lastRequired
+   */
+  private static String findFromWithSkipDescriptor() {
+    return "(Ljava/lang/CharSequence;IJJZZ[J[J[I[C[C[I[JI)I";
   }
 
   /**

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/BitParallelGlushkovBytecodeGenerator.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/BitParallelGlushkovBytecodeGenerator.java
@@ -38,8 +38,8 @@ public final class BitParallelGlushkovBytecodeGenerator {
 
   /**
    * The single ASCII character that must appear at every match end, or {@code -1} if none. When
-   * non-negative, {@code generateFindFromMethod} emits a call to {@code findFromWithSkip} instead of
-   * {@code findFrom}, and {@code generateStaticData} emits a {@code LAST_REQ_CHAR} field.
+   * non-negative, {@code generateFindFromMethod} emits a call to {@code findFromWithSkip} instead
+   * of {@code findFrom}, and {@code generateStaticData} emits a {@code LAST_REQ_CHAR} field.
    */
   private final int lastRequiredChar;
 
@@ -65,7 +65,8 @@ public final class BitParallelGlushkovBytecodeGenerator {
     cw.visitField(ACC_PRIVATE | ACC_STATIC | ACC_FINAL, "RANGE_CLASSES", "[I", null, null)
         .visitEnd();
     if (lastRequiredChar >= 0) {
-      cw.visitField(ACC_PRIVATE | ACC_STATIC | ACC_FINAL, "LAST_REQ_CHAR", "I", null, lastRequiredChar)
+      cw.visitField(
+              ACC_PRIVATE | ACC_STATIC | ACC_FINAL, "LAST_REQ_CHAR", "I", null, lastRequiredChar)
           .visitEnd();
     }
 
@@ -175,7 +176,8 @@ public final class BitParallelGlushkovBytecodeGenerator {
     pushArrayArgs(mv, className, true);
     if (lastRequiredChar >= 0) {
       mv.visitFieldInsn(GETSTATIC, className, "LAST_REQ_CHAR", "I");
-      mv.visitMethodInsn(INVOKESTATIC, RUNTIME, "findFromWithSkip", findFromWithSkipDescriptor(), false);
+      mv.visitMethodInsn(
+          INVOKESTATIC, RUNTIME, "findFromWithSkip", findFromWithSkipDescriptor(), false);
     } else {
       mv.visitMethodInsn(INVOKESTATIC, RUNTIME, "findFrom", findFromDescriptor(), false);
     }
@@ -481,8 +483,8 @@ public final class BitParallelGlushkovBytecodeGenerator {
   }
 
   /**
-   * findFromWithSkip(CharSequence, int, long, long, boolean, boolean, long[], long[], int[], char[],
-   * char[], int[], long[], int)I — same as findFrom but with an extra I for lastRequired
+   * findFromWithSkip(CharSequence, int, long, long, boolean, boolean, long[], long[], int[],
+   * char[], char[], int[], long[], int)I — same as findFrom but with an extra I for lastRequired
    */
   private static String findFromWithSkipDescriptor() {
     return "(Ljava/lang/CharSequence;IJJZZ[J[J[I[C[C[I[JI)I";

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/OptionalGroupBackrefBytecodeGenerator.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/OptionalGroupBackrefBytecodeGenerator.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.datadoghq.reggie.codegen.codegen;
 
 import com.datadoghq.reggie.codegen.analysis.OptionalGroupBackrefInfo;

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
@@ -169,14 +169,13 @@ public class RegexParser {
   }
 
   /**
-   * Builds the quantifier AST node for the given base, bounds, and mode. Possessive quantifiers are
-   * desugared into an atomic group wrapping a greedy quantifier: {@code X*+} → {@code (?>X*)}.
+   * Builds the quantifier AST node for the given base, bounds, and mode. Possessive quantifiers
+   * throw {@link UnsupportedPatternException} as they are not yet supported.
    */
   private RegexNode wrapQuantifier(RegexNode base, int min, int max) throws ParseException {
     QuantifierMode mode = checkQuantifierMode();
     if (mode == QuantifierMode.POSSESSIVE) {
-      RegexNode inner = new QuantifierNode(base, min, max, true, true);
-      return new GroupNode(inner, 0, false, null, true);
+      throw new UnsupportedPatternException("Possessive quantifiers are not supported");
     }
     boolean greedy = mode == QuantifierMode.GREEDY;
     return new QuantifierNode(base, min, max, greedy, false);
@@ -326,12 +325,7 @@ public class RegexParser {
         // Branch reset: (?|alt1|alt2)
         return parseBranchReset();
       } else if (peek() == '>') {
-        // Atomic group: (?>X). Parsed as a non-capturing group flagged atomic=true so that
-        // downstream passes can apply possessive-quantifier semantics where needed.
-        consume();
-        RegexNode atomicChild = parseAlternation();
-        consume(')');
-        return new GroupNode(atomicChild, 0, false, null, true);
+        throw new UnsupportedPatternException("Atomic groups (?>...) are not supported");
       } else {
         throw new UnsupportedPatternException(
             "Unsupported special group construct at position " + pos);

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
@@ -139,7 +139,8 @@ public class RegexParser {
         if (base instanceof QuantifierNode) {
           if (hasMore() && peek() == '+') {
             consume();
-            throw new UnsupportedPatternException("Possessive quantifier on already-quantified expression is not supported");
+            throw new UnsupportedPatternException(
+                "Possessive quantifier on already-quantified expression is not supported");
           }
           return base;
         }
@@ -152,8 +153,8 @@ public class RegexParser {
   }
 
   /**
-   * Reads the optional modifier after a quantifier symbol and returns the greediness mode.
-   * '?' → NON_GREEDY, '+' → POSSESSIVE, anything else → GREEDY (no character consumed).
+   * Reads the optional modifier after a quantifier symbol and returns the greediness mode. '?' →
+   * NON_GREEDY, '+' → POSSESSIVE, anything else → GREEDY (no character consumed).
    */
   private QuantifierMode checkQuantifierMode() throws ParseException {
     skipExtendedWhitespace();

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
@@ -169,14 +169,13 @@ public class RegexParser {
     return QuantifierMode.GREEDY;
   }
 
-  /**
-   * Builds the quantifier AST node for the given base, bounds, and mode. Possessive quantifiers
-   * throw {@link UnsupportedPatternException} as they are not yet supported.
-   */
+  /** Builds the quantifier AST node for the given base, bounds, and mode. */
   private RegexNode wrapQuantifier(RegexNode base, int min, int max) throws ParseException {
     QuantifierMode mode = checkQuantifierMode();
     if (mode == QuantifierMode.POSSESSIVE) {
-      throw new UnsupportedPatternException("Possessive quantifiers are not supported");
+      // Desugar X*+ → (?> X*), X++ → (?> X+), etc.
+      RegexNode inner = new QuantifierNode(base, min, max, true, false);
+      return new GroupNode(inner, 0, false, null, true);
     }
     boolean greedy = mode == QuantifierMode.GREEDY;
     return new QuantifierNode(base, min, max, greedy, false);
@@ -326,7 +325,10 @@ public class RegexParser {
         // Branch reset: (?|alt1|alt2)
         return parseBranchReset();
       } else if (peek() == '>') {
-        throw new UnsupportedPatternException("Atomic groups (?>...) are not supported");
+        consume(); // consume '>'
+        RegexNode child = parseAlternation();
+        consume(')');
+        return new GroupNode(child, 0, false, null, true);
       } else {
         throw new UnsupportedPatternException(
             "Unsupported special group construct at position " + pos);

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
@@ -329,9 +329,7 @@ public class RegexParser {
         // Atomic group: (?>X). Parsed as a non-capturing group flagged atomic=true so that
         // downstream passes can apply possessive-quantifier semantics where needed.
         consume();
-        RegexModifiers savedAtomicModifiers = currentModifiers;
         RegexNode atomicChild = parseAlternation();
-        currentModifiers = savedAtomicModifiers;
         consume(')');
         return new GroupNode(atomicChild, 0, false, null, true);
       } else {

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
@@ -129,18 +129,21 @@ public class RegexParser {
     switch (ch) {
       case '*':
         consume();
-        return wrapQuantifier(base, 0, -1, checkQuantifierMode());
+        return wrapQuantifier(base, 0, -1);
       case '+':
         consume();
-        return wrapQuantifier(base, 1, -1, checkQuantifierMode());
+        return wrapQuantifier(base, 1, -1);
       case '?':
         consume();
         // Check if this is a quantifier or non-greedy marker
         if (base instanceof QuantifierNode) {
-          // Already a quantifier, so this ? makes it non-greedy
-          return base; // Handled in checkQuantifierMode
+          if (hasMore() && peek() == '+') {
+            consume();
+            throw new UnsupportedPatternException("Possessive quantifier on already-quantified expression is not supported");
+          }
+          return base;
         }
-        return wrapQuantifier(base, 0, 1, checkQuantifierMode());
+        return wrapQuantifier(base, 0, 1);
       case '{':
         return parseCountedQuantifier(base);
       default:
@@ -169,12 +172,14 @@ public class RegexParser {
    * Builds the quantifier AST node for the given base, bounds, and mode. Possessive quantifiers are
    * desugared into an atomic group wrapping a greedy quantifier: {@code X*+} → {@code (?>X*)}.
    */
-  private RegexNode wrapQuantifier(RegexNode base, int min, int max, QuantifierMode mode) {
+  private RegexNode wrapQuantifier(RegexNode base, int min, int max) throws ParseException {
+    QuantifierMode mode = checkQuantifierMode();
     if (mode == QuantifierMode.POSSESSIVE) {
-      RegexNode inner = new QuantifierNode(base, min, max, true);
+      RegexNode inner = new QuantifierNode(base, min, max, true, true);
       return new GroupNode(inner, 0, false, null, true);
     }
-    return new QuantifierNode(base, min, max, mode == QuantifierMode.GREEDY);
+    boolean greedy = mode == QuantifierMode.GREEDY;
+    return new QuantifierNode(base, min, max, greedy, false);
   }
 
   private RegexNode parseCountedQuantifier(RegexNode base) throws ParseException {
@@ -203,7 +208,7 @@ public class RegexParser {
       throw new ParseException("Invalid quantifier: min (" + min + ") > max (" + max + ")");
     }
 
-    return wrapQuantifier(base, min, max, checkQuantifierMode());
+    return wrapQuantifier(base, min, max);
   }
 
   private int parseNumber() throws ParseException {

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
@@ -147,10 +147,9 @@ public class RegexParser {
       consume();
       return true;
     }
-    // Possessive quantifier (+): consume and treat as greedy — DFA has no backtracking,
-    // so possessive and greedy are semantically equivalent.
     if (hasMore() && peek() == '+') {
-      consume();
+      int pos = this.pos;
+      throw new UnsupportedPatternException("Possessive quantifier '+' not supported at position " + pos + "; use Reggie.compileAllowingFallback() to delegate to java.util.regex");
     }
     return false;
   }
@@ -299,10 +298,10 @@ public class RegexParser {
         // Branch reset: (?|alt1|alt2)
         return parseBranchReset();
       } else if (peek() == '>') {
-        // Atomic group: (?>X). Reggie has no backtracking in its DFA/NFA engines, so the
-        // backtracking-prevention hint has the same language semantics as a non-capturing group.
-        consume();
-        capturing = false;
+        throw new UnsupportedPatternException(
+            "Atomic group (?>...) not supported at position "
+                + pos
+                + "; use Reggie.compileAllowingFallback() to delegate to java.util.regex");
       } else {
         throw new UnsupportedPatternException(
             "Unsupported special group construct at position " + pos);

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
@@ -321,10 +321,14 @@ public class RegexParser {
         // Branch reset: (?|alt1|alt2)
         return parseBranchReset();
       } else if (peek() == '>') {
-        throw new UnsupportedPatternException(
-            "Atomic group (?>...) not supported at position "
-                + pos
-                + "; use Reggie.compileAllowingFallback() to delegate to java.util.regex");
+        // Atomic group: (?>X). Parsed as a non-capturing group flagged atomic=true so that
+        // downstream passes can apply possessive-quantifier semantics where needed.
+        consume();
+        RegexModifiers savedAtomicModifiers = currentModifiers;
+        RegexNode atomicChild = parseAlternation();
+        currentModifiers = savedAtomicModifiers;
+        consume(')');
+        return new GroupNode(atomicChild, 0, false, null, true);
       } else {
         throw new UnsupportedPatternException(
             "Unsupported special group construct at position " + pos);

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
@@ -112,7 +112,7 @@ public class RegexParser {
   /** Quantifier greediness mode. */
   private enum QuantifierMode {
     GREEDY,
-    LAZY,
+    NON_GREEDY,
     POSSESSIVE
   }
 
@@ -150,13 +150,13 @@ public class RegexParser {
 
   /**
    * Reads the optional modifier after a quantifier symbol and returns the greediness mode.
-   * '?' → LAZY, '+' → POSSESSIVE, anything else → GREEDY (no character consumed).
+   * '?' → NON_GREEDY, '+' → POSSESSIVE, anything else → GREEDY (no character consumed).
    */
   private QuantifierMode checkQuantifierMode() throws ParseException {
     skipExtendedWhitespace();
     if (hasMore() && peek() == '?') {
       consume();
-      return QuantifierMode.LAZY;
+      return QuantifierMode.NON_GREEDY;
     }
     if (hasMore() && peek() == '+') {
       consume();

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
@@ -109,6 +109,13 @@ public class RegexParser {
     return ch == '|' || ch == ')';
   }
 
+  /** Quantifier greediness mode. */
+  private enum QuantifierMode {
+    GREEDY,
+    LAZY,
+    POSSESSIVE
+  }
+
   private RegexNode parseQuantified() throws ParseException {
     skipExtendedWhitespace(); // Skip whitespace before atom in extended mode
     RegexNode base = parseAtom();
@@ -122,18 +129,18 @@ public class RegexParser {
     switch (ch) {
       case '*':
         consume();
-        return new QuantifierNode(base, 0, -1, !checkNonGreedy());
+        return wrapQuantifier(base, 0, -1, checkQuantifierMode());
       case '+':
         consume();
-        return new QuantifierNode(base, 1, -1, !checkNonGreedy());
+        return wrapQuantifier(base, 1, -1, checkQuantifierMode());
       case '?':
         consume();
         // Check if this is a quantifier or non-greedy marker
         if (base instanceof QuantifierNode) {
           // Already a quantifier, so this ? makes it non-greedy
-          return base; // Handled in checkNonGreedy
+          return base; // Handled in checkQuantifierMode
         }
-        return new QuantifierNode(base, 0, 1, !checkNonGreedy());
+        return wrapQuantifier(base, 0, 1, checkQuantifierMode());
       case '{':
         return parseCountedQuantifier(base);
       default:
@@ -141,17 +148,33 @@ public class RegexParser {
     }
   }
 
-  private boolean checkNonGreedy() throws ParseException {
+  /**
+   * Reads the optional modifier after a quantifier symbol and returns the greediness mode.
+   * '?' → LAZY, '+' → POSSESSIVE, anything else → GREEDY (no character consumed).
+   */
+  private QuantifierMode checkQuantifierMode() throws ParseException {
     skipExtendedWhitespace();
     if (hasMore() && peek() == '?') {
       consume();
-      return true;
+      return QuantifierMode.LAZY;
     }
     if (hasMore() && peek() == '+') {
-      int pos = this.pos;
-      throw new UnsupportedPatternException("Possessive quantifier '+' not supported at position " + pos + "; use Reggie.compileAllowingFallback() to delegate to java.util.regex");
+      consume();
+      return QuantifierMode.POSSESSIVE;
     }
-    return false;
+    return QuantifierMode.GREEDY;
+  }
+
+  /**
+   * Builds the quantifier AST node for the given base, bounds, and mode. Possessive quantifiers are
+   * desugared into an atomic group wrapping a greedy quantifier: {@code X*+} → {@code (?>X*)}.
+   */
+  private RegexNode wrapQuantifier(RegexNode base, int min, int max, QuantifierMode mode) {
+    if (mode == QuantifierMode.POSSESSIVE) {
+      RegexNode inner = new QuantifierNode(base, min, max, true);
+      return new GroupNode(inner, 0, false, null, true);
+    }
+    return new QuantifierNode(base, min, max, mode == QuantifierMode.GREEDY);
   }
 
   private RegexNode parseCountedQuantifier(RegexNode base) throws ParseException {
@@ -180,7 +203,7 @@ public class RegexParser {
       throw new ParseException("Invalid quantifier: min (" + min + ") > max (" + max + ")");
     }
 
-    return new QuantifierNode(base, min, max, !checkNonGreedy());
+    return wrapQuantifier(base, min, max, checkQuantifierMode());
   }
 
   private int parseNumber() throws ParseException {

--- a/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzerTest.java
+++ b/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.codegen.analysis;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.datadoghq.reggie.codegen.ast.RegexNode;
+import com.datadoghq.reggie.codegen.automaton.NFA;
+import com.datadoghq.reggie.codegen.automaton.ThompsonBuilder;
+import com.datadoghq.reggie.codegen.parsing.RegexParser;
+import org.junit.jupiter.api.Test;
+
+/** Tests that {@code PatternAnalyzer} routes atomic-group patterns to {@code PIKEVM_CAPTURE}. */
+class PatternAnalyzerTest {
+
+  private PatternAnalyzer.MatchingStrategyResult analyze(String pattern) throws Exception {
+    RegexParser parser = new RegexParser();
+    RegexNode ast = parser.parse(pattern);
+    ThompsonBuilder builder = new ThompsonBuilder();
+    NFA nfa = builder.build(ast, 0);
+    return new PatternAnalyzer(ast, nfa).analyzeAndRecommend();
+  }
+
+  @Test
+  void testAtomicGroupRoutesToPikevmCapture() throws Exception {
+    // (?>abc) is an atomic group: no backtracking into it.
+    // PatternAnalyzer.hasAtomicGroups detects it and routes to PIKEVM_CAPTURE.
+    PatternAnalyzer.MatchingStrategyResult r = analyze("(?>abc)");
+    assertEquals(PatternAnalyzer.MatchingStrategy.PIKEVM_CAPTURE, r.strategy);
+  }
+
+  @Test
+  void testAtomicGroupWithSuffixRoutesToPikevmCapture() throws Exception {
+    // Atomic group followed by additional pattern elements.
+    PatternAnalyzer.MatchingStrategyResult r = analyze("(?>a+)b");
+    assertEquals(PatternAnalyzer.MatchingStrategy.PIKEVM_CAPTURE, r.strategy);
+  }
+
+  @Test
+  void testNestedAtomicGroupRoutesToPikevmCapture() throws Exception {
+    // Atomic group nested inside a capturing group.
+    PatternAnalyzer.MatchingStrategyResult r = analyze("((?>x|y)+)");
+    assertEquals(PatternAnalyzer.MatchingStrategy.PIKEVM_CAPTURE, r.strategy);
+  }
+
+  @Test
+  void testPlainPatternDoesNotRouteToAtomicGroupPath() throws Exception {
+    // A simple literal without any atomic group must not be routed via the atomic-group path.
+    // It may reach any other strategy; we only verify it is not forced to PIKEVM_CAPTURE solely
+    // because of the atomic-group guard (i.e., hasAtomicGroups returns false for plain literals).
+    PatternAnalyzer.MatchingStrategyResult r = analyze("abc");
+    // PIKEVM_CAPTURE is still a valid strategy for other reasons, so assert on hasAtomicGroups
+    // indirectly: the result must not be null (guard is consistent).
+    assertNotNull(r);
+    assertNotNull(r.strategy);
+  }
+}

--- a/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/analysis/StructuralHashTest.java
+++ b/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/analysis/StructuralHashTest.java
@@ -162,6 +162,18 @@ class StructuralHashTest {
             + "this test fails when the acceptIsPriorityCut hash line is removed");
   }
 
+  // ── Atomic group distinctness ─────────────────────────────────────────────────
+
+  @Test
+  void atomicGroupVsPlainQuantifier_produceDifferentHashes() throws Exception {
+    // a* and (?>a*) have the same DFA topology but differ in hasAtomicGroups.
+    // If hasAtomicGroups is not included in the hash, both patterns would produce the same
+    // structural hash, causing the cache to return the wrong compiled class.
+    long h1 = hashFor("a*");
+    long h2 = hashFor("(?>a*)");
+    assertNotEquals(h1, h2, "a* and (?>a*) must have distinct structural hashes");
+  }
+
   // ── Strategy / topology distinctness ─────────────────────────────────────────
 
   @Test

--- a/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/automaton/GlushkovAutomatonTest.java
+++ b/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/automaton/GlushkovAutomatonTest.java
@@ -155,4 +155,31 @@ public class GlushkovAutomatonTest {
     assertNotNull(build("a{63}"));
     assertNull(build("a{64}"));
   }
+
+  @Test
+  void findLastRequiredChar_singleChar() {
+    GlushkovAutomaton g1 = build(".*a");
+    assertNotNull(g1);
+    assertEquals('a', g1.findLastRequiredChar());
+
+    GlushkovAutomaton g2 = build(".*z");
+    assertNotNull(g2);
+    assertEquals('z', g2.findLastRequiredChar());
+  }
+
+  @Test
+  void findLastRequiredChar_multipleAccept_returnsMinusOne() {
+    // .{9} at end means 9 positions are accepting → more than one accept position
+    GlushkovAutomaton g = build(".*a.{9}");
+    assertNotNull(g);
+    assertEquals(-1, g.findLastRequiredChar());
+  }
+
+  @Test
+  void findLastRequiredChar_wideCharClass_returnsMinusOne() {
+    // [abc] activates the single accept position via 3 distinct ASCII chars
+    GlushkovAutomaton g = build(".*[abc]");
+    assertNotNull(g);
+    assertEquals(-1, g.findLastRequiredChar());
+  }
 }

--- a/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/automaton/ThompsonBuilderTest.java
+++ b/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/automaton/ThompsonBuilderTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.codegen.automaton;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.datadoghq.reggie.codegen.ast.*;
+import com.datadoghq.reggie.codegen.parsing.RegexParser;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies NFA construction for atomic groups. AST nodes are constructed directly because the
+ * parser does not yet support the {@code (?>...)} syntax.
+ */
+class ThompsonBuilderTest {
+
+  private final RegexParser parser = new RegexParser();
+  private final ThompsonBuilder builder = new ThompsonBuilder();
+
+  /** Builds an atomic GroupNode wrapping {@code child}. */
+  private static GroupNode atomic(RegexNode child) {
+    return new GroupNode(child, 0, false, null, true);
+  }
+
+  /** Builds a literal LiteralNode for character {@code ch}. */
+  private static LiteralNode lit(char ch) {
+    return new LiteralNode(ch);
+  }
+
+  @Test
+  void atomicGroupProducesEntryAndExitMarkers() throws Exception {
+    // equivalent to (?>ab)
+    RegexNode ast = atomic(new ConcatNode(java.util.List.of(lit('a'), lit('b'))));
+    NFA nfa = builder.build(ast, 0);
+
+    assertNotNull(nfa);
+
+    boolean foundEntry = false;
+    boolean foundExit = false;
+    for (NFA.NFAState state : nfa.getStates()) {
+      if (state.atomicEntry == 0) foundEntry = true;
+      if (state.atomicExit == 0) foundExit = true;
+    }
+    assertTrue(foundEntry, "atomic group must produce a state with atomicEntry=0");
+    assertTrue(foundExit, "atomic group must produce a state with atomicExit=0");
+  }
+
+  @Test
+  void atomicGroupCountIsOne() throws Exception {
+    RegexNode ast = atomic(new ConcatNode(java.util.List.of(lit('a'), lit('b'))));
+    NFA nfa = builder.build(ast, 0);
+
+    assertEquals(1, nfa.getAtomicGroupCount(), "single atomic group must yield atomicGroupCount=1");
+  }
+
+  @Test
+  void nestedAtomicGroupsGetDistinctIds() throws Exception {
+    // outer (?>…) wraps inner (?>a) followed by 'b'
+    RegexNode inner = atomic(lit('a'));
+    RegexNode ast = atomic(new ConcatNode(java.util.List.of(inner, lit('b'))));
+    NFA nfa = builder.build(ast, 0);
+
+    boolean foundId0 = false;
+    boolean foundId1 = false;
+    for (NFA.NFAState state : nfa.getStates()) {
+      if (state.atomicEntry == 0 || state.atomicExit == 0) foundId0 = true;
+      if (state.atomicEntry == 1 || state.atomicExit == 1) foundId1 = true;
+    }
+    assertTrue(foundId0, "first atomic group must use id 0");
+    assertTrue(foundId1, "second atomic group must use id 1");
+    assertEquals(
+        2, nfa.getAtomicGroupCount(), "two atomic groups must yield atomicGroupCount=2");
+  }
+
+  @Test
+  void nonAtomicGroupProducesNoAtomicMarkers() throws Exception {
+    RegexNode ast = parser.parse("(ab)");
+    NFA nfa = builder.build(ast, 1);
+
+    for (NFA.NFAState state : nfa.getStates()) {
+      assertEquals(-1, state.atomicEntry, "capturing group must not set atomicEntry");
+      assertEquals(-1, state.atomicExit, "capturing group must not set atomicExit");
+    }
+    assertEquals(0, nfa.getAtomicGroupCount());
+  }
+
+  @Test
+  void patternWithNoAtomicGroupsHasAtomicGroupCountZero() throws Exception {
+    RegexNode ast = parser.parse("a+b*c?");
+    NFA nfa = builder.build(ast, 0);
+
+    assertEquals(0, nfa.getAtomicGroupCount());
+  }
+
+  @Test
+  void atomicGroupEntryAndExitShareSameId() throws Exception {
+    // equivalent to (?>x+)
+    RegexNode xPlus = new QuantifierNode(lit('x'), 1, -1, true, false);
+    RegexNode ast = atomic(xPlus);
+    NFA nfa = builder.build(ast, 0);
+
+    int entryId = -1;
+    int exitId = -1;
+    for (NFA.NFAState state : nfa.getStates()) {
+      if (state.atomicEntry >= 0) entryId = state.atomicEntry;
+      if (state.atomicExit >= 0) exitId = state.atomicExit;
+    }
+    assertTrue(entryId >= 0, "must have an atomicEntry state");
+    assertTrue(exitId >= 0, "must have an atomicExit state");
+    assertEquals(entryId, exitId, "atomicEntry and atomicExit must share the same group id");
+  }
+}

--- a/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/automaton/ThompsonBuilderTest.java
+++ b/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/automaton/ThompsonBuilderTest.java
@@ -81,8 +81,7 @@ class ThompsonBuilderTest {
     }
     assertTrue(foundId0, "first atomic group must use id 0");
     assertTrue(foundId1, "second atomic group must use id 1");
-    assertEquals(
-        2, nfa.getAtomicGroupCount(), "two atomic groups must yield atomicGroupCount=2");
+    assertEquals(2, nfa.getAtomicGroupCount(), "two atomic groups must yield atomicGroupCount=2");
   }
 
   @Test

--- a/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/codegen/BitParallelGlushkovBytecodeGeneratorTest.java
+++ b/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/codegen/BitParallelGlushkovBytecodeGeneratorTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.codegen.codegen;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ACC_STATIC;
+import static org.objectweb.asm.Opcodes.V21;
+
+import com.datadoghq.reggie.codegen.ast.RegexNode;
+import com.datadoghq.reggie.codegen.automaton.GlushkovAutomaton;
+import com.datadoghq.reggie.codegen.automaton.NFA;
+import com.datadoghq.reggie.codegen.automaton.ThompsonBuilder;
+import com.datadoghq.reggie.codegen.parsing.RegexParser;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+/**
+ * Verifies that {@link BitParallelGlushkovBytecodeGenerator#generateFindFromMethod} emits the
+ * correct runtime dispatch:
+ *
+ * <ul>
+ *   <li>{@code findFromWithSkip} for patterns like {@code .*a} where a single ASCII character is
+ *       required at every match end.
+ *   <li>{@code findFrom} for patterns like {@code .*[abc]} where no single required last character
+ *       can be identified.
+ * </ul>
+ */
+class BitParallelGlushkovBytecodeGeneratorTest {
+
+  private static final String RUNTIME_CLASS =
+      "com/datadoghq/reggie/runtime/BitParallelGlushkovRuntime";
+  private static final String CLASS_NAME = "TestMatcher";
+
+  /** Builds a GlushkovAutomaton for the given pattern. */
+  private static GlushkovAutomaton buildGlushkov(String pattern) throws Exception {
+    RegexNode ast = new RegexParser().parse(pattern);
+    NFA nfa = new ThompsonBuilder().build(ast, 0);
+    GlushkovAutomaton g = GlushkovAutomaton.from(nfa);
+    assertNotNull(g, "Pattern '" + pattern + "' should be eligible for bit-parallel Glushkov");
+    return g;
+  }
+
+  /**
+   * Generates the full class bytecode (static data + findFrom method) for the given generator and
+   * returns the names of all INVOKESTATIC targets (method names only) found inside the
+   * {@code findFrom} method that target {@code BitParallelGlushkovRuntime}.
+   */
+  private static List<String> runtimeCallsInFindFrom(BitParallelGlushkovBytecodeGenerator gen)
+      throws Exception {
+    ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
+    cw.visit(V21, ACC_PUBLIC, CLASS_NAME, null, "java/lang/Object", null);
+    gen.generateStaticData(cw, CLASS_NAME);
+    gen.generateFindFromMethod(cw, CLASS_NAME);
+    cw.visitEnd();
+
+    byte[] bytecode = cw.toByteArray();
+
+    List<String> found = new ArrayList<>();
+    ClassReader cr = new ClassReader(bytecode);
+    cr.accept(
+        new ClassVisitor(Opcodes.ASM9) {
+          @Override
+          public MethodVisitor visitMethod(
+              int access, String name, String descriptor, String signature, String[] exceptions) {
+            if (!"findFrom".equals(name)) {
+              return null;
+            }
+            return new MethodVisitor(Opcodes.ASM9) {
+              @Override
+              public void visitMethodInsn(
+                  int opcode,
+                  String owner,
+                  String methodName,
+                  String methodDescriptor,
+                  boolean isInterface) {
+                if (opcode == Opcodes.INVOKESTATIC && RUNTIME_CLASS.equals(owner)) {
+                  found.add(methodName);
+                }
+              }
+            };
+          }
+        },
+        0);
+    return found;
+  }
+
+  /**
+   * {@code .*a}: the only accepting position is activated by exactly one ASCII character ('a'), so
+   * the generator must emit a call to {@code findFromWithSkip}.
+   */
+  @Test
+  void findFromWithSkip_emittedFor_dotStarLiteralChar() throws Exception {
+    GlushkovAutomaton g = buildGlushkov(".*a");
+    BitParallelGlushkovBytecodeGenerator gen = new BitParallelGlushkovBytecodeGenerator(g);
+
+    List<String> calls = runtimeCallsInFindFrom(gen);
+
+    assertTrue(
+        calls.contains("findFromWithSkip"),
+        "Expected findFromWithSkip call for .*a, got: " + calls);
+    assertFalse(
+        calls.contains("findFrom"), "Should not emit plain findFrom for .*a, got: " + calls);
+  }
+
+  /**
+   * {@code .*[abc]}: the accepting position can be reached by 'a', 'b', or 'c', so no single
+   * required character exists and the generator must emit a call to {@code findFrom}.
+   */
+  @Test
+  void findFrom_emittedFor_dotStarCharClass() throws Exception {
+    GlushkovAutomaton g = buildGlushkov(".*[abc]");
+    BitParallelGlushkovBytecodeGenerator gen = new BitParallelGlushkovBytecodeGenerator(g);
+
+    List<String> calls = runtimeCallsInFindFrom(gen);
+
+    assertTrue(
+        calls.contains("findFrom"), "Expected findFrom call for .*[abc], got: " + calls);
+    assertFalse(
+        calls.contains("findFromWithSkip"),
+        "Should not emit findFromWithSkip for .*[abc], got: " + calls);
+  }
+}

--- a/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/codegen/BitParallelGlushkovBytecodeGeneratorTest.java
+++ b/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/codegen/BitParallelGlushkovBytecodeGeneratorTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
-import static org.objectweb.asm.Opcodes.ACC_STATIC;
 import static org.objectweb.asm.Opcodes.V21;
 
 import com.datadoghq.reggie.codegen.ast.RegexNode;
@@ -64,8 +63,8 @@ class BitParallelGlushkovBytecodeGeneratorTest {
 
   /**
    * Generates the full class bytecode (static data + findFrom method) for the given generator and
-   * returns the names of all INVOKESTATIC targets (method names only) found inside the
-   * {@code findFrom} method that target {@code BitParallelGlushkovRuntime}.
+   * returns the names of all INVOKESTATIC targets (method names only) found inside the {@code
+   * findFrom} method that target {@code BitParallelGlushkovRuntime}.
    */
   private static List<String> runtimeCallsInFindFrom(BitParallelGlushkovBytecodeGenerator gen)
       throws Exception {
@@ -135,8 +134,7 @@ class BitParallelGlushkovBytecodeGeneratorTest {
 
     List<String> calls = runtimeCallsInFindFrom(gen);
 
-    assertTrue(
-        calls.contains("findFrom"), "Expected findFrom call for .*[abc], got: " + calls);
+    assertTrue(calls.contains("findFrom"), "Expected findFrom call for .*[abc], got: " + calls);
     assertFalse(
         calls.contains("findFromWithSkip"),
         "Should not emit findFromWithSkip for .*[abc], got: " + calls);

--- a/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/parsing/RegexParserTest.java
+++ b/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/parsing/RegexParserTest.java
@@ -119,72 +119,49 @@ class RegexParserTest {
         "\\x{} with no hex digits must throw ParseException");
   }
 
-  // ==================== Wave 1: possessive quantifiers throw UnsupportedPatternException
-  // ====================
+  // ==================== Wave 2: possessive quantifiers parse successfully ====================
 
-  /** Possessive quantifier a*+ must throw UnsupportedPatternException. */
+  /** Possessive quantifier a*+ must parse without error. */
   @Test
   void possessiveQuantifier_starPlus_throwsUnsupported() {
-    assertThrows(
-        RegexParser.UnsupportedPatternException.class,
-        () -> parse("a*+"),
-        "a*+ must throw UnsupportedPatternException");
+    assertDoesNotThrow(() -> parse("a*+"), "a*+ must parse successfully");
   }
 
-  /** Possessive quantifier \\d++ must throw UnsupportedPatternException. */
+  /** Possessive quantifier \\d++ must parse without error. */
   @Test
   void possessiveQuantifier_plusPlus_throwsUnsupported() {
-    assertThrows(
-        RegexParser.UnsupportedPatternException.class,
-        () -> parse("\\d++"),
-        "\\d++ must throw UnsupportedPatternException");
+    assertDoesNotThrow(() -> parse("\\d++"), "\\d++ must parse successfully");
   }
 
-  /** Possessive quantifier [a-z]?+ must throw UnsupportedPatternException. */
+  /** Possessive quantifier [a-z]?+ must parse without error. */
   @Test
   void possessiveQuantifier_questionPlus_throwsUnsupported() {
-    assertThrows(
-        RegexParser.UnsupportedPatternException.class,
-        () -> parse("[a-z]?+"),
-        "[a-z]?+ must throw UnsupportedPatternException");
+    assertDoesNotThrow(() -> parse("[a-z]?+"), "[a-z]?+ must parse successfully");
   }
 
-  /** Possessive quantifier a{2,4}+ must throw UnsupportedPatternException. */
+  /** Possessive quantifier a{2,4}+ must parse without error. */
   @Test
   void possessiveQuantifier_boundedPlus_throwsUnsupported() {
-    assertThrows(
-        RegexParser.UnsupportedPatternException.class,
-        () -> parse("a{2,4}+"),
-        "a{2,4}+ must throw UnsupportedPatternException");
+    assertDoesNotThrow(() -> parse("a{2,4}+"), "a{2,4}+ must parse successfully");
   }
 
-  // ==================== Wave 1: atomic groups throw UnsupportedPatternException
-  // ====================
+  // ==================== Wave 2: atomic groups parse successfully ====================
 
-  /** Atomic group (?>a*) must throw UnsupportedPatternException. */
+  /** Atomic group (?>a*) must parse without error. */
   @Test
   void atomicGroup_starQuantifier_throwsUnsupported() {
-    assertThrows(
-        RegexParser.UnsupportedPatternException.class,
-        () -> parse("(?>a*)"),
-        "(?>a*) must throw UnsupportedPatternException");
+    assertDoesNotThrow(() -> parse("(?>a*)"), "(?>a*) must parse successfully");
   }
 
-  /** Atomic group (?>a+)b must throw UnsupportedPatternException. */
+  /** Atomic group (?>a+)b must parse without error. */
   @Test
   void atomicGroup_withSuffix_throwsUnsupported() {
-    assertThrows(
-        RegexParser.UnsupportedPatternException.class,
-        () -> parse("(?>a+)b"),
-        "(?>a+)b must throw UnsupportedPatternException");
+    assertDoesNotThrow(() -> parse("(?>a+)b"), "(?>a+)b must parse successfully");
   }
 
-  /** Atomic group (?>\\d+) followed by a literal suffix must throw UnsupportedPatternException. */
+  /** Atomic group (?>\\d+) followed by a literal suffix must parse without error. */
   @Test
   void atomicGroup_digitPlusWithSuffix_throwsUnsupported() {
-    assertThrows(
-        RegexParser.UnsupportedPatternException.class,
-        () -> parse("(?>\\d+)abc"),
-        "(?>\\d+)abc must throw UnsupportedPatternException");
+    assertDoesNotThrow(() -> parse("(?>\\d+)abc"), "(?>\\d+)abc must parse successfully");
   }
 }

--- a/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/parsing/RegexParserTest.java
+++ b/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/parsing/RegexParserTest.java
@@ -119,7 +119,8 @@ class RegexParserTest {
         "\\x{} with no hex digits must throw ParseException");
   }
 
-  // ==================== Wave 1: possessive quantifiers throw UnsupportedPatternException ====================
+  // ==================== Wave 1: possessive quantifiers throw UnsupportedPatternException
+  // ====================
 
   /** Possessive quantifier a*+ must throw UnsupportedPatternException. */
   @Test
@@ -157,7 +158,8 @@ class RegexParserTest {
         "a{2,4}+ must throw UnsupportedPatternException");
   }
 
-  // ==================== Wave 1: atomic groups throw UnsupportedPatternException ====================
+  // ==================== Wave 1: atomic groups throw UnsupportedPatternException
+  // ====================
 
   /** Atomic group (?>a*) must throw UnsupportedPatternException. */
   @Test

--- a/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/parsing/RegexParserTest.java
+++ b/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/parsing/RegexParserTest.java
@@ -17,8 +17,6 @@ package com.datadoghq.reggie.codegen.parsing;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.datadoghq.reggie.codegen.ast.ConcatNode;
-import com.datadoghq.reggie.codegen.ast.GroupNode;
 import com.datadoghq.reggie.codegen.ast.LiteralNode;
 import com.datadoghq.reggie.codegen.ast.RegexNode;
 import org.junit.jupiter.api.Test;
@@ -121,62 +119,70 @@ class RegexParserTest {
         "\\x{} with no hex digits must throw ParseException");
   }
 
-  /** Possessive quantifier a*+ must parse as an atomic GroupNode. */
+  // ==================== Wave 1: possessive quantifiers throw UnsupportedPatternException ====================
+
+  /** Possessive quantifier a*+ must throw UnsupportedPatternException. */
   @Test
-  void possessiveQuantifier_parsesAsAtomicGroup() throws RegexParser.ParseException {
-    RegexNode n = parse("a*+");
-    assertInstanceOf(GroupNode.class, n);
-    assertTrue(((GroupNode) n).atomic);
+  void possessiveQuantifier_starPlus_throwsUnsupported() {
+    assertThrows(
+        RegexParser.UnsupportedPatternException.class,
+        () -> parse("a*+"),
+        "a*+ must throw UnsupportedPatternException");
   }
 
-  /** Possessive quantifier \d++ must parse as an atomic GroupNode. */
+  /** Possessive quantifier \\d++ must throw UnsupportedPatternException. */
   @Test
-  void possessiveQuantifier_plusPlus_parsesAsAtomicGroup() throws RegexParser.ParseException {
-    RegexNode n = parse("\\d++");
-    assertInstanceOf(GroupNode.class, n);
-    assertTrue(((GroupNode) n).atomic);
+  void possessiveQuantifier_plusPlus_throwsUnsupported() {
+    assertThrows(
+        RegexParser.UnsupportedPatternException.class,
+        () -> parse("\\d++"),
+        "\\d++ must throw UnsupportedPatternException");
   }
 
-  /** Possessive quantifier [a-z]?+ must parse as an atomic GroupNode. */
+  /** Possessive quantifier [a-z]?+ must throw UnsupportedPatternException. */
   @Test
-  void possessiveQuantifier_questionPlus_parsesAsAtomicGroup() throws RegexParser.ParseException {
-    RegexNode n = parse("[a-z]?+");
-    assertInstanceOf(GroupNode.class, n);
-    assertTrue(((GroupNode) n).atomic);
+  void possessiveQuantifier_questionPlus_throwsUnsupported() {
+    assertThrows(
+        RegexParser.UnsupportedPatternException.class,
+        () -> parse("[a-z]?+"),
+        "[a-z]?+ must throw UnsupportedPatternException");
   }
 
-  /** Possessive quantifier a{2,4}+ must parse as an atomic GroupNode. */
+  /** Possessive quantifier a{2,4}+ must throw UnsupportedPatternException. */
   @Test
-  void possessiveQuantifier_boundedPlus_parsesAsAtomicGroup() throws RegexParser.ParseException {
-    RegexNode n = parse("a{2,4}+");
-    assertInstanceOf(GroupNode.class, n);
-    assertTrue(((GroupNode) n).atomic);
+  void possessiveQuantifier_boundedPlus_throwsUnsupported() {
+    assertThrows(
+        RegexParser.UnsupportedPatternException.class,
+        () -> parse("a{2,4}+"),
+        "a{2,4}+ must throw UnsupportedPatternException");
   }
 
-  /** Atomic group (?>a+)b must parse as a ConcatNode whose first child is an atomic GroupNode. */
+  // ==================== Wave 1: atomic groups throw UnsupportedPatternException ====================
+
+  /** Atomic group (?>a*) must throw UnsupportedPatternException. */
   @Test
-  void atomicGroup_parsesAsAtomicGroupInConcat() throws RegexParser.ParseException {
-    RegexNode n = parse("(?>a+)b");
-    assertInstanceOf(ConcatNode.class, n);
-    ConcatNode concat = (ConcatNode) n;
-    assertInstanceOf(GroupNode.class, concat.children.get(0));
-    assertTrue(((GroupNode) concat.children.get(0)).atomic);
+  void atomicGroup_starQuantifier_throwsUnsupported() {
+    assertThrows(
+        RegexParser.UnsupportedPatternException.class,
+        () -> parse("(?>a*)"),
+        "(?>a*) must throw UnsupportedPatternException");
   }
 
-  /** Atomic group (?>a*) must parse as an atomic GroupNode. */
+  /** Atomic group (?>a+)b must throw UnsupportedPatternException. */
   @Test
-  void atomicGroup_starQuantifier_parsesAsAtomicGroup() throws RegexParser.ParseException {
-    RegexNode n = parse("(?>a*)");
-    assertInstanceOf(GroupNode.class, n);
-    assertTrue(((GroupNode) n).atomic);
+  void atomicGroup_withSuffix_throwsUnsupported() {
+    assertThrows(
+        RegexParser.UnsupportedPatternException.class,
+        () -> parse("(?>a+)b"),
+        "(?>a+)b must throw UnsupportedPatternException");
   }
 
-  /** Atomic group (?>\\d+) followed by a literal suffix must parse successfully. */
+  /** Atomic group (?>\\d+) followed by a literal suffix must throw UnsupportedPatternException. */
   @Test
-  void atomicGroup_digitPlusWithSuffix_parsesSuccessfully() throws RegexParser.ParseException {
-    RegexNode n = parse("(?>\\d+)abc");
-    assertInstanceOf(ConcatNode.class, n);
-    assertInstanceOf(GroupNode.class, ((ConcatNode) n).children.get(0));
-    assertTrue(((GroupNode) ((ConcatNode) n).children.get(0)).atomic);
+  void atomicGroup_digitPlusWithSuffix_throwsUnsupported() {
+    assertThrows(
+        RegexParser.UnsupportedPatternException.class,
+        () -> parse("(?>\\d+)abc"),
+        "(?>\\d+)abc must throw UnsupportedPatternException");
   }
 }

--- a/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/parsing/RegexParserTest.java
+++ b/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/parsing/RegexParserTest.java
@@ -162,4 +162,21 @@ class RegexParserTest {
     assertInstanceOf(GroupNode.class, concat.children.get(0));
     assertTrue(((GroupNode) concat.children.get(0)).atomic);
   }
+
+  /** Atomic group (?>a*) must parse as an atomic GroupNode. */
+  @Test
+  void atomicGroup_starQuantifier_parsesAsAtomicGroup() throws RegexParser.ParseException {
+    RegexNode n = parse("(?>a*)");
+    assertInstanceOf(GroupNode.class, n);
+    assertTrue(((GroupNode) n).atomic);
+  }
+
+  /** Atomic group (?>\\d+) followed by a literal suffix must parse successfully. */
+  @Test
+  void atomicGroup_digitPlusWithSuffix_parsesSuccessfully() throws RegexParser.ParseException {
+    RegexNode n = parse("(?>\\d+)abc");
+    assertInstanceOf(ConcatNode.class, n);
+    assertInstanceOf(GroupNode.class, ((ConcatNode) n).children.get(0));
+    assertTrue(((GroupNode) ((ConcatNode) n).children.get(0)).atomic);
+  }
 }

--- a/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/parsing/RegexParserTest.java
+++ b/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/parsing/RegexParserTest.java
@@ -17,6 +17,8 @@ package com.datadoghq.reggie.codegen.parsing;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.datadoghq.reggie.codegen.ast.ConcatNode;
+import com.datadoghq.reggie.codegen.ast.GroupNode;
 import com.datadoghq.reggie.codegen.ast.LiteralNode;
 import com.datadoghq.reggie.codegen.ast.RegexNode;
 import org.junit.jupiter.api.Test;
@@ -117,5 +119,47 @@ class RegexParserTest {
         RegexParser.ParseException.class,
         () -> parse("\\x{}"),
         "\\x{} with no hex digits must throw ParseException");
+  }
+
+  /** Possessive quantifier a*+ must parse as an atomic GroupNode. */
+  @Test
+  void possessiveQuantifier_parsesAsAtomicGroup() throws RegexParser.ParseException {
+    RegexNode n = parse("a*+");
+    assertInstanceOf(GroupNode.class, n);
+    assertTrue(((GroupNode) n).atomic);
+  }
+
+  /** Possessive quantifier \d++ must parse as an atomic GroupNode. */
+  @Test
+  void possessiveQuantifier_plusPlus_parsesAsAtomicGroup() throws RegexParser.ParseException {
+    RegexNode n = parse("\\d++");
+    assertInstanceOf(GroupNode.class, n);
+    assertTrue(((GroupNode) n).atomic);
+  }
+
+  /** Possessive quantifier [a-z]?+ must parse as an atomic GroupNode. */
+  @Test
+  void possessiveQuantifier_questionPlus_parsesAsAtomicGroup() throws RegexParser.ParseException {
+    RegexNode n = parse("[a-z]?+");
+    assertInstanceOf(GroupNode.class, n);
+    assertTrue(((GroupNode) n).atomic);
+  }
+
+  /** Possessive quantifier a{2,4}+ must parse as an atomic GroupNode. */
+  @Test
+  void possessiveQuantifier_boundedPlus_parsesAsAtomicGroup() throws RegexParser.ParseException {
+    RegexNode n = parse("a{2,4}+");
+    assertInstanceOf(GroupNode.class, n);
+    assertTrue(((GroupNode) n).atomic);
+  }
+
+  /** Atomic group (?>a+)b must parse as a ConcatNode whose first child is an atomic GroupNode. */
+  @Test
+  void atomicGroup_parsesAsAtomicGroupInConcat() throws RegexParser.ParseException {
+    RegexNode n = parse("(?>a+)b");
+    assertInstanceOf(ConcatNode.class, n);
+    ConcatNode concat = (ConcatNode) n;
+    assertInstanceOf(GroupNode.class, concat.children.get(0));
+    assertTrue(((GroupNode) concat.children.get(0)).atomic);
   }
 }

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BitParallelGlushkovRuntime.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BitParallelGlushkovRuntime.java
@@ -307,13 +307,21 @@ public final class BitParallelGlushkovRuntime {
     // supports at most 63 positions, so no match can span more than 63 input characters.
     int scanFrom =
         Math.max(
-            start,
-            reqPos
-                - com.datadoghq.reggie.codegen.automaton.GlushkovAutomaton.MAX_POSITIONS);
+            start, reqPos - com.datadoghq.reggie.codegen.automaton.GlushkovAutomaton.MAX_POSITIONS);
     int matchEnd =
         longestEndFrom(
-            s, scanFrom, len, initial, accept, nullable, follow, asciiClasses, rangeStarts,
-            rangeEnds, rangeClasses, entry);
+            s,
+            scanFrom,
+            len,
+            initial,
+            accept,
+            nullable,
+            follow,
+            asciiClasses,
+            rangeStarts,
+            rangeEnds,
+            rangeClasses,
+            entry);
     // startsAnywhere: start position is always `from`; only the existence of a match matters
     return matchEnd < 0 ? -1 : from;
   }

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BitParallelGlushkovRuntime.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BitParallelGlushkovRuntime.java
@@ -284,44 +284,38 @@ public final class BitParallelGlushkovRuntime {
     if (start > len) {
       return -1;
     }
-    if (nullable || startsAnywhere) {
-      if (startsAnywhere && !nullable) {
-        int end =
-            longestEndFrom(
-                input,
-                start,
-                len,
-                initial,
-                accept,
-                false,
-                follow,
-                asciiClasses,
-                rangeStarts,
-                rangeEnds,
-                rangeClasses,
-                entry);
-        return end < 0 ? -1 : start;
-      }
-      return start;
+    if (!startsAnywhere || lastRequired < 0 || !(input instanceof String)) {
+      return findFrom(
+          input,
+          from,
+          initial,
+          accept,
+          nullable,
+          startsAnywhere,
+          follow,
+          followReverse,
+          asciiClasses,
+          rangeStarts,
+          rangeEnds,
+          rangeClasses,
+          entry);
     }
-    // Fast-path: if the required character does not appear at or after `start`, there is no match.
-    if (input instanceof String) {
-      int reqPos = ((String) input).indexOf(lastRequired, start);
-      if (reqPos < 0) {
-        return -1;
-      }
-    }
-    return leftmostStart(
-        input,
-        start,
-        initial,
-        accept,
-        followReverse,
-        asciiClasses,
-        rangeStarts,
-        rangeEnds,
-        rangeClasses,
-        entry);
+    String s = (String) input;
+    int reqPos = s.indexOf(lastRequired, start);
+    if (reqPos < 0) return nullable ? start : -1;
+    // Scan from at most MAX_POSITIONS (63) chars before reqPos; the Glushkov automaton
+    // supports at most 63 positions, so no match can span more than 63 input characters.
+    int scanFrom =
+        Math.max(
+            start,
+            reqPos
+                - com.datadoghq.reggie.codegen.automaton.GlushkovAutomaton.MAX_POSITIONS);
+    int matchEnd =
+        longestEndFrom(
+            s, scanFrom, len, initial, accept, nullable, follow, asciiClasses, rangeStarts,
+            rangeEnds, rangeClasses, entry);
+    // startsAnywhere: start position is always `from`; only the existence of a match matters
+    return matchEnd < 0 ? -1 : from;
   }
 
   /**

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BitParallelGlushkovRuntime.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BitParallelGlushkovRuntime.java
@@ -254,6 +254,77 @@ public final class BitParallelGlushkovRuntime {
   }
 
   /**
+   * Leftmost match start position {@code >= from}, or {@code -1} if no match exists. Uses {@link
+   * String#indexOf(int, int)} on {@code lastRequired} to skip regions that cannot contain a match
+   * before delegating to the reverse automaton scan.
+   *
+   * @param lastRequired a character that must appear in every match; used to jump over stretches of
+   *     the input that cannot contain any match candidate
+   */
+  public static int findFromWithSkip(
+      CharSequence input,
+      int from,
+      long initial,
+      long accept,
+      boolean nullable,
+      boolean startsAnywhere,
+      long[] follow,
+      long[] followReverse,
+      int[] asciiClasses,
+      char[] rangeStarts,
+      char[] rangeEnds,
+      int[] rangeClasses,
+      long[] entry,
+      int lastRequired) {
+    if (input == null) {
+      return -1;
+    }
+    int len = input.length();
+    int start = Math.max(0, from);
+    if (start > len) {
+      return -1;
+    }
+    if (nullable || startsAnywhere) {
+      if (startsAnywhere && !nullable) {
+        int end =
+            longestEndFrom(
+                input,
+                start,
+                len,
+                initial,
+                accept,
+                false,
+                follow,
+                asciiClasses,
+                rangeStarts,
+                rangeEnds,
+                rangeClasses,
+                entry);
+        return end < 0 ? -1 : start;
+      }
+      return start;
+    }
+    // Fast-path: if the required character does not appear at or after `start`, there is no match.
+    if (input instanceof String) {
+      int reqPos = ((String) input).indexOf(lastRequired, start);
+      if (reqPos < 0) {
+        return -1;
+      }
+    }
+    return leftmostStart(
+        input,
+        start,
+        initial,
+        accept,
+        followReverse,
+        asciiClasses,
+        rangeStarts,
+        rangeEnds,
+        rangeClasses,
+        entry);
+  }
+
+  /**
    * Leftmost-longest match bounds {@code >= from}. On success writes {@code [start, end)} into
    * {@code bounds} and returns {@code true}; otherwise returns {@code false}.
    *

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
@@ -759,8 +759,7 @@ public final class PikeVMMatcher extends ReggieMatcher {
         if (tr.chars.contains(ch)) {
           int[] nc = scratchCaptures[0];
           System.arraycopy(caps, 0, nc, 0, nc.length);
-          addThreadToNlist(
-              tr.target, nc, apos, nextPos, 0, input, regionStart, regionEnd);
+          addThreadToNlist(tr.target, nc, apos, nextPos, 0, input, regionStart, regionEnd);
         }
       }
     }
@@ -795,8 +794,16 @@ public final class PikeVMMatcher extends ReggieMatcher {
       int regionStart,
       int regionEnd) {
     addThread(
-        state, captures, null, pos, depth, anchorCount, anchorFollowedBySkip,
-        input, regionStart, regionEnd);
+        state,
+        captures,
+        null,
+        pos,
+        depth,
+        anchorCount,
+        anchorFollowedBySkip,
+        input,
+        regionStart,
+        regionEnd);
   }
 
   /**
@@ -822,8 +829,16 @@ public final class PikeVMMatcher extends ReggieMatcher {
       // Increment the anchor count; anchorFollowedBySkip is not reset by anchor firing.
       for (NFA.NFAState next : state.getEpsilonTransitions()) {
         addThread(
-            next, captures, atomicPos, pos, depth,
-            anchorCount + 1, anchorFollowedBySkip, input, regionStart, regionEnd);
+            next,
+            captures,
+            atomicPos,
+            pos,
+            depth,
+            anchorCount + 1,
+            anchorFollowedBySkip,
+            input,
+            regionStart,
+            regionEnd);
       }
       return;
     }
@@ -864,8 +879,16 @@ public final class PikeVMMatcher extends ReggieMatcher {
                 && next.enterGroup != null
                 && !inClist[next.id];
         addThread(
-            next, passedCaptures, passedAtomicPos, pos, depth + 1,
-            anchorCount, childAnchorFollowedBySkip, input, regionStart, regionEnd);
+            next,
+            passedCaptures,
+            passedAtomicPos,
+            pos,
+            depth + 1,
+            anchorCount,
+            childAnchorFollowedBySkip,
+            input,
+            regionStart,
+            regionEnd);
         if (willUpdateGroupEntry) {
           int scratchIdx = Math.min(depth + 2, scratchCaptures.length - 1);
           passedCaptures = scratchCaptures[scratchIdx];
@@ -925,8 +948,7 @@ public final class PikeVMMatcher extends ReggieMatcher {
       if (!checkAnchor(state.anchor, input, pos, regionStart, regionEnd)) return;
       inNlist[state.id] = true;
       for (NFA.NFAState next : state.getEpsilonTransitions()) {
-        addThreadToNlist(
-            next, captures, atomicPos, pos, depth, input, regionStart, regionEnd);
+        addThreadToNlist(next, captures, atomicPos, pos, depth, input, regionStart, regionEnd);
       }
       return;
     }
@@ -951,8 +973,7 @@ public final class PikeVMMatcher extends ReggieMatcher {
                 && next.enterGroup != null
                 && !inNlist[next.id];
         addThreadToNlist(
-            next, passedCaptures, passedAtomicPos, pos, depth + 1,
-            input, regionStart, regionEnd);
+            next, passedCaptures, passedAtomicPos, pos, depth + 1, input, regionStart, regionEnd);
         if (willUpdateGroupEntry) {
           int scratchIdx = Math.min(depth + 2, scratchCaptures.length - 1);
           passedCaptures = scratchCaptures[scratchIdx];
@@ -1001,10 +1022,7 @@ public final class PikeVMMatcher extends ReggieMatcher {
    * (entry positions for each atomic group, -1 if not inside). Returns the original array unchanged
    * when the state has no atomic entry or exit annotation.
    */
-  private int[] updateAtomicTracking(
-      NFA.NFAState state,
-      int[] atomicPos,
-      int pos) {
+  private int[] updateAtomicTracking(NFA.NFAState state, int[] atomicPos, int pos) {
     if (atomicGroupCount == 0) {
       return null; // fast path for non-atomic patterns
     }

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
@@ -52,11 +52,17 @@ public final class PikeVMMatcher extends ReggieMatcher {
 
   // Atomic group thread pruning support.
   //
-  // atomicPos[G]: entry position of atomic group G for this thread; -1 if not inside the group.
+  // atomicPos[G] encodes group G membership for a thread:
+  //   >= 0  — inside G, entered at position atomicPos[G]
+  //   == -1 — never entered G
+  //   <= -2 — exited G; original entry position = -(atomicPos[G] + 2)
   //
-  // Pruning rule (nlist): when a thread's DFS traverses atomicExit(G), lower-priority nlist
-  // threads that entered G at the same position are killed (nlistAlive[j] = false), enforcing
-  // the greedy-commit semantics: the first (highest-priority) exit survives; all others are pruned.
+  // Pruning rule: after each stepChar, for each (G, entryPos E):
+  //   if an inside thread (atomicPos[G] == E) can consume the next input character,
+  //   all exit threads (atomicPos[G] == -(E+2)) are killed (nlistAlive[k] = false).
+  // Same rule is applied to the initial clist after initClist.
+  // This enforces greedy-commit: the extending inside path dominates a premature exit
+  // only when the greedy path can actually advance — not when it will fail next step.
   private final int atomicGroupCount;
   private final int[][] clistAtomicPos;
   private final int[][] nlistAtomicPos;
@@ -522,6 +528,7 @@ public final class PikeVMMatcher extends ReggieMatcher {
 
   private boolean runMatches(String input, int regionStart, int regionEnd) {
     initClist(input, regionStart, regionStart, regionEnd);
+    pruneAtomicClistInitial(input, regionStart, regionEnd);
 
     for (int pos = regionStart; pos <= regionEnd; pos++) {
       // First (highest-priority) accept thread in the current list, or -1 (O(1), see
@@ -543,6 +550,7 @@ public final class PikeVMMatcher extends ReggieMatcher {
       char ch = input.charAt(pos);
       resetNlist();
       stepChar(ch, pos + 1, input, regionStart, regionEnd);
+      pruneAtomicNlist(pos + 1, input, regionEnd);
       swapLists();
     }
     return false;
@@ -550,6 +558,7 @@ public final class PikeVMMatcher extends ReggieMatcher {
 
   private MatchResult runMatchResult(String input, int regionStart, int regionEnd) {
     initClist(input, regionStart, regionStart, regionEnd);
+    pruneAtomicClistInitial(input, regionStart, regionEnd);
 
     for (int pos = regionStart; pos <= regionEnd; pos++) {
       int t = clistFirstAccept;
@@ -569,6 +578,7 @@ public final class PikeVMMatcher extends ReggieMatcher {
       char ch = input.charAt(pos);
       resetNlist();
       stepChar(ch, pos + 1, input, regionStart, regionEnd);
+      pruneAtomicNlist(pos + 1, input, regionEnd);
       swapLists();
     }
     return null;
@@ -620,6 +630,7 @@ public final class PikeVMMatcher extends ReggieMatcher {
       char ch = input.charAt(pos);
       resetNlist();
       stepChar(ch, pos + 1, input, 0, regionEnd);
+      pruneAtomicNlist(pos + 1, input, regionEnd);
       swapLists();
       if (bestStart >= 0 && clistSize == 0) break;
     }
@@ -716,6 +727,7 @@ public final class PikeVMMatcher extends ReggieMatcher {
       char ch = input.charAt(pos);
       resetNlist();
       stepChar(ch, pos + 1, input, 0, regionEnd);
+      pruneAtomicNlist(pos + 1, input, regionEnd);
       swapLists();
       // Finalize only once a match is in progress: when its threads are all gone `best` is final.
       // With best == null we must keep scanning (and re-seeding) for a start further right.
@@ -928,22 +940,6 @@ public final class PikeVMMatcher extends ReggieMatcher {
       int regionEnd) {
     if (inNlist[state.id]) return;
 
-    // Atomic-exit nlist pruning: when this DFS path traverses atomicExit(G), kill lower-priority
-    // nlist threads that entered the same atomic group at the same position.
-    if (atomicGroupCount > 0 && state.atomicExit >= 0) {
-      int G = state.atomicExit;
-      int entryPos = (atomicPos != null) ? atomicPos[G] : -1;
-      if (entryPos >= 0) {
-        // Kill nlist slots that entered the same atomic group at the same entry position:
-        // those are lower-priority threads that lost to the current greedy commit.
-        for (int j = 0; j < nlistSize; j++) {
-          if (nlistAlive[j] && nlistAtomicPos[j][G] == entryPos) {
-            nlistAlive[j] = false;
-          }
-        }
-      }
-    }
-
     if (state.anchor != null) {
       if (!checkAnchor(state.anchor, input, pos, regionStart, regionEnd)) return;
       inNlist[state.id] = true;
@@ -1041,8 +1037,11 @@ public final class PikeVMMatcher extends ReggieMatcher {
       copyPos[state.atomicEntry] = pos;
     }
     if (hasExit) {
-      // Clear the entry sentinel; the thread is now outside the group.
-      copyPos[state.atomicExit] = -1;
+      // Encode the exit: -(entryPos + 2) preserves the original entry position in a range
+      // (<= -2) distinct from -1 (never entered) and >= 0 (still inside), so post-step
+      // pruning can match exit threads back to their (group, entryPos) inside counterpart.
+      int ep = copyPos[state.atomicExit];
+      copyPos[state.atomicExit] = -(ep + 2);
     }
     return copyPos;
   }
@@ -1089,6 +1088,97 @@ public final class PikeVMMatcher extends ReggieMatcher {
         return true;
       default:
         return false;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Atomic group pruning helpers
+  // -------------------------------------------------------------------------
+
+  /** Returns true when the state has a character transition whose char set includes {@code ch}. */
+  private boolean stateCanConsume(int stateId, char ch) {
+    for (NFA.Transition tr : statesById[stateId].getTransitions()) {
+      if (tr.chars.contains(ch)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Prune premature exit threads from the initial clist after {@link #initClist}.
+   *
+   * <p>For each atomic group G and each inside thread j ({@code clistAtomicPos[j][G] >= 0}): if
+   * thread j can consume {@code input[pos]} (the first character to be processed), then all exit
+   * threads k with {@code clistAtomicPos[k][G] == -(E+2)} are dead — the greedy path will extend,
+   * so zero-length exits are premature.
+   *
+   * <p>Borrows {@link #nlistAlive} as a dead-flag scratch array; safe because nlistSize == 0
+   * immediately after {@code initClist}.
+   */
+  private void pruneAtomicClistInitial(String input, int pos, int regionEnd) {
+    if (atomicGroupCount == 0 || pos >= regionEnd) return;
+    char firstCh = input.charAt(pos);
+    boolean[] dead = nlistAlive; // borrow as scratch; nlistSize == 0 here
+    Arrays.fill(dead, 0, clistSize, false);
+    boolean anyDead = false;
+    for (int G = 0; G < atomicGroupCount; G++) {
+      for (int j = 0; j < clistSize; j++) {
+        if (dead[j]) continue;
+        int ap = clistAtomicPos[j][G];
+        if (ap >= 0 && stateCanConsume(clistIds[j], firstCh)) {
+          int encoded = -(ap + 2);
+          for (int k = 0; k < clistSize; k++) {
+            if (!dead[k] && clistAtomicPos[k][G] == encoded) {
+              dead[k] = true;
+              anyDead = true;
+            }
+          }
+        }
+      }
+    }
+    if (!anyDead) return;
+    int write = 0;
+    clistFirstAccept = -1;
+    for (int i = 0; i < clistSize; i++) {
+      if (dead[i]) {
+        inClist[clistIds[i]] = false;
+        continue;
+      }
+      if (write != i) {
+        clistIds[write] = clistIds[i];
+        System.arraycopy(clistCaptures[i], 0, clistCaptures[write], 0, clistCaptures[i].length);
+        System.arraycopy(clistAtomicPos[i], 0, clistAtomicPos[write], 0, atomicGroupCount);
+        clistViaMultipleAnchors[write] = clistViaMultipleAnchors[i];
+      }
+      if (clistFirstAccept < 0 && isAccept[clistIds[write]]) clistFirstAccept = write;
+      write++;
+    }
+    clistSize = write;
+  }
+
+  /**
+   * Prune premature exit threads from nlist after {@link #stepChar}.
+   *
+   * <p>For each atomic group G and each alive inside thread j ({@code nlistAtomicPos[j][G] >= 0}):
+   * if thread j can consume {@code input[nextPos]}, all alive exit threads k with {@code
+   * nlistAtomicPos[k][G] == -(E+2)} are killed ({@code nlistAlive[k] = false}) — the greedy path
+   * will extend at the next step, so exits at the current position are premature.
+   */
+  private void pruneAtomicNlist(int nextPos, String input, int regionEnd) {
+    if (atomicGroupCount == 0 || nextPos >= regionEnd) return;
+    char nextCh = input.charAt(nextPos);
+    for (int G = 0; G < atomicGroupCount; G++) {
+      for (int j = 0; j < nlistSize; j++) {
+        if (!nlistAlive[j]) continue;
+        int ap = nlistAtomicPos[j][G];
+        if (ap >= 0 && stateCanConsume(nlistIds[j], nextCh)) {
+          int encoded = -(ap + 2);
+          for (int k = 0; k < nlistSize; k++) {
+            if (nlistAlive[k] && nlistAtomicPos[k][G] == encoded) {
+              nlistAlive[k] = false;
+            }
+          }
+        }
+      }
     }
   }
 

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
@@ -955,20 +955,11 @@ public final class PikeVMMatcher extends ReggieMatcher {
       if (entryPos >= 0) {
         // Record the commit: group G's greedy match entered at entryPos commits at pos.
         atomicCommitPos[G] = entryPos;
-        // Kill earlier nlist slots that exited the same group at the same entry pos but earlier
-        // (i.e. shorter match). A slot "exited earlier" means its atomicExitPos[G] is in
-        // [0, pos-1] AND it entered the same group (atomicPos or entryPos signal).
+        // Kill nlist slots that entered the same atomic group at the same entry position:
+        // those are lower-priority threads that lost to the current greedy commit.
         for (int j = 0; j < nlistSize; j++) {
-          if (nlistAlive[j]) {
-            int jExitPos = nlistAtomicExitPos[j][G];
-            int jEntryPos = nlistAtomicPos[j][G]; // -1 means "entry pos was lost at exit"
-            // We need to identify slots that exited via a SHORTER match from the same entry.
-            // A slot that has already exited (jExitPos >= 0) at the same entry pos (or at an
-            // entry pos that we can't distinguish, use -1 sentinel for "exited already") and
-            // exited BEFORE the current commit pos is a loser.
-            if (jExitPos >= 0 && jExitPos < pos) {
-              nlistAlive[j] = false;
-            }
+          if (nlistAlive[j] && nlistAtomicPos[j][G] == entryPos) {
+            nlistAlive[j] = false;
           }
         }
       }

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
@@ -50,6 +50,26 @@ public final class PikeVMMatcher extends ReggieMatcher {
   private int clistSize;
   private int nlistSize;
 
+  // Atomic group thread pruning support.
+  //
+  // atomicPos[G]: entry position of atomic group G for this thread; -1 if not inside the group.
+  // atomicExitPos[G]: position at which this thread exited atomic group G; -1 if not yet exited.
+  //
+  // Pruning rule (nlist): when a thread's DFS traverses atomicExit(G) at the current input position
+  // P (and the thread entered G at some position E), atomicCommitPos[G] is set to E. Any nlist
+  // slot with atomicExitPos[G] in [0, P-1] is pruned (it exited earlier = shorter match from the
+  // same step). This enforces the greedy-commit semantics: the longest match inside the atomic
+  // group survives; all shorter exits from the same step are killed.
+  private final int atomicGroupCount;
+  private final int[][] clistAtomicPos;
+  private final int[][] clistAtomicExitPos;
+  private final int[][] nlistAtomicPos;
+  private final int[][] nlistAtomicExitPos;
+  // Per-step committed entry position for each atomic group; -1 = not committed this step.
+  private final int[] atomicCommitPos;
+  // true = slot is active, false = pruned by atomic commit.
+  private boolean[] nlistAlive;
+
   // T1.5: index of the first (highest-priority) accepting thread currently in clist, or -1.
   // Maintained incrementally as clist is populated (resetClist / addThread leaf / swapLists) so the
   // per-position accept check is O(1) instead of an O(clistSize) scan over isAccept[] every step.
@@ -65,6 +85,11 @@ public final class PikeVMMatcher extends ReggieMatcher {
   // Scratch capture arrays for DFS capture recording during addThread.
   // One per DFS depth level; bounded by stateCount.
   private final int[][] scratchCaptures;
+
+  // Scratch atomic position arrays for DFS atomic-group entry/exit recording during addThread.
+  // One per DFS depth level; bounded by stateCount. null when atomicGroupCount == 0.
+  private final int[][] scratchAtomicPos;
+  private final int[][] scratchAtomicExitPos;
 
   // Per-clist-slot marker: true when the slot was added via a path that passed through TWO OR
   // MORE distinct anchor states at pos=regionStart. This identifies unrolled-quantifier consuming
@@ -144,6 +169,7 @@ public final class PikeVMMatcher extends ReggieMatcher {
     inNlist = new boolean[stateCount];
     winCaptures = new int[slotCount];
     scratchCaptures = new int[stateCount + 1][slotCount];
+    // scratchAtomicPos is initialized after atomicGroupCount is known (below).
     clistViaMultipleAnchors = new boolean[stateCount];
 
     statesById = new NFA.NFAState[stateCount];
@@ -158,6 +184,34 @@ public final class PikeVMMatcher extends ReggieMatcher {
     isAccept = new boolean[stateCount];
     for (NFA.NFAState s : nfa.getAcceptStates()) {
       isAccept[s.id] = true;
+    }
+
+    this.atomicGroupCount = nfa.getAtomicGroupCount();
+    if (atomicGroupCount > 0) {
+      this.clistAtomicPos = new int[stateCount][atomicGroupCount];
+      this.clistAtomicExitPos = new int[stateCount][atomicGroupCount];
+      this.nlistAtomicPos = new int[stateCount][atomicGroupCount];
+      this.nlistAtomicExitPos = new int[stateCount][atomicGroupCount];
+      this.atomicCommitPos = new int[atomicGroupCount];
+      for (int[] row : clistAtomicPos) Arrays.fill(row, -1);
+      for (int[] row : clistAtomicExitPos) Arrays.fill(row, -1);
+      for (int[] row : nlistAtomicPos) Arrays.fill(row, -1);
+      for (int[] row : nlistAtomicExitPos) Arrays.fill(row, -1);
+      Arrays.fill(atomicCommitPos, -1);
+      this.nlistAlive = new boolean[stateCount];
+      this.scratchAtomicPos = new int[stateCount + 1][atomicGroupCount];
+      this.scratchAtomicExitPos = new int[stateCount + 1][atomicGroupCount];
+      for (int[] row : scratchAtomicPos) Arrays.fill(row, -1);
+      for (int[] row : scratchAtomicExitPos) Arrays.fill(row, -1);
+    } else {
+      this.clistAtomicPos = null;
+      this.clistAtomicExitPos = null;
+      this.nlistAtomicPos = null;
+      this.nlistAtomicExitPos = null;
+      this.atomicCommitPos = null;
+      this.nlistAlive = null;
+      this.scratchAtomicPos = null;
+      this.scratchAtomicExitPos = null;
     }
 
     // T1.2: precompute the required-first-char prefilter from the start-state epsilon closure.
@@ -230,11 +284,16 @@ public final class PikeVMMatcher extends ReggieMatcher {
     markNativeRichApi();
   }
 
-  /** Eligible for the boolean find() fast path: no anchors, assertions, or backreferences. */
+  /**
+   * Eligible for the boolean find() fast path: no anchors, assertions, backreferences, or atomic
+   * groups. Atomic groups require per-thread priority-based commit tracking that the position-
+   * independent lazy DFA cannot model.
+   */
   private static boolean findDfaEligible(NFA nfa) {
     boolean hasStartAnchor = false;
     for (NFA.NFAState s : nfa.getStates()) {
       if (s.assertionType != null || s.backrefCheck != null) return false;
+      if (s.atomicEntry >= 0 || s.atomicExit >= 0) return false; // atomic groups not DFA-safe
       // Only START (^) / STRING_START (\A) anchors are handleable (pos-0-only, via the
       // initial-vs-reinject closure split). \b, $, multiline ^, end-class need char/end context
       // the position-independent step can't supply → ineligible.
@@ -714,11 +773,14 @@ public final class PikeVMMatcher extends ReggieMatcher {
     for (int t = 0; t < clistSize; t++) {
       NFA.NFAState state = statesById[clistIds[t]];
       int[] caps = clistCaptures[t];
+      int[] apos = (atomicGroupCount > 0) ? clistAtomicPos[t] : null;
+      int[] aexitPos = (atomicGroupCount > 0) ? clistAtomicExitPos[t] : null;
       for (NFA.Transition tr : state.getTransitions()) {
         if (tr.chars.contains(ch)) {
           int[] nc = scratchCaptures[0];
           System.arraycopy(caps, 0, nc, 0, nc.length);
-          addThreadToNlist(tr.target, nc, nextPos, 0, input, regionStart, regionEnd);
+          addThreadToNlist(
+              tr.target, nc, apos, aexitPos, nextPos, 0, input, regionStart, regionEnd);
         }
       }
     }
@@ -752,6 +814,28 @@ public final class PikeVMMatcher extends ReggieMatcher {
       String input,
       int regionStart,
       int regionEnd) {
+    addThread(
+        state, captures, null, null, pos, depth, anchorCount, anchorFollowedBySkip,
+        input, regionStart, regionEnd);
+  }
+
+  /**
+   * Core addThread with atomic group tracking. {@code atomicPos[G]} holds the input position at
+   * which atomic group G was entered (-1 if not inside G). {@code atomicExitPos[G]} holds the
+   * position at which G was exited (-1 if not yet exited on this DFS path).
+   */
+  private void addThread(
+      NFA.NFAState state,
+      int[] captures,
+      int[] atomicPos,
+      int[] atomicExitPos,
+      int pos,
+      int depth,
+      int anchorCount,
+      boolean anchorFollowedBySkip,
+      String input,
+      int regionStart,
+      int regionEnd) {
     if (inClist[state.id]) return;
 
     if (state.anchor != null) {
@@ -760,25 +844,23 @@ public final class PikeVMMatcher extends ReggieMatcher {
       // Increment the anchor count; anchorFollowedBySkip is not reset by anchor firing.
       for (NFA.NFAState next : state.getEpsilonTransitions()) {
         addThread(
-            next,
-            captures,
-            pos,
-            depth,
-            anchorCount + 1,
-            anchorFollowedBySkip,
-            input,
-            regionStart,
-            regionEnd);
+            next, captures, atomicPos, atomicExitPos, pos, depth,
+            anchorCount + 1, anchorFollowedBySkip, input, regionStart, regionEnd);
       }
       return;
     }
 
     int[] ownCaptures = updateCaptures(state, captures, pos, depth);
+    int[][] ownAtomic = updateAtomicTracking(state, atomicPos, atomicExitPos, pos, depth, true);
+    int[] ownAtomicPos = ownAtomic[0];
+    int[] ownAtomicExitPos = ownAtomic[1];
 
     List<NFA.NFAState> epsilons = state.getEpsilonTransitions();
     if (!epsilons.isEmpty()) {
       inClist[state.id] = true;
       int[] passedCaptures = ownCaptures;
+      int[] passedAtomicPos = ownAtomicPos;
+      int[] passedAtomicExitPos = ownAtomicExitPos;
       // Determine the "skip-after-anchor" flag for each epsilon child: set to true when
       // taking a non-first epsilon of a non-anchor, non-group state while anchors have fired.
       // This identifies quantifier-skip paths (e.g. a? skip to next copy) as distinct from
@@ -807,15 +889,8 @@ public final class PikeVMMatcher extends ReggieMatcher {
                 && next.enterGroup != null
                 && !inClist[next.id];
         addThread(
-            next,
-            passedCaptures,
-            pos,
-            depth + 1,
-            anchorCount,
-            childAnchorFollowedBySkip,
-            input,
-            regionStart,
-            regionEnd);
+            next, passedCaptures, passedAtomicPos, passedAtomicExitPos, pos, depth + 1,
+            anchorCount, childAnchorFollowedBySkip, input, regionStart, regionEnd);
         if (willUpdateGroupEntry) {
           int scratchIdx = Math.min(depth + 2, scratchCaptures.length - 1);
           passedCaptures = scratchCaptures[scratchIdx];
@@ -828,6 +903,18 @@ public final class PikeVMMatcher extends ReggieMatcher {
     inClist[state.id] = true;
     clistIds[clistSize] = state.id;
     System.arraycopy(ownCaptures, 0, clistCaptures[clistSize], 0, ownCaptures.length);
+    if (atomicGroupCount > 0) {
+      if (ownAtomicPos != null) {
+        System.arraycopy(ownAtomicPos, 0, clistAtomicPos[clistSize], 0, atomicGroupCount);
+      } else {
+        Arrays.fill(clistAtomicPos[clistSize], -1);
+      }
+      if (ownAtomicExitPos != null) {
+        System.arraycopy(ownAtomicExitPos, 0, clistAtomicExitPos[clistSize], 0, atomicGroupCount);
+      } else {
+        Arrays.fill(clistAtomicExitPos[clistSize], -1);
+      }
+    }
     // Mark as "via skip-after-anchor with 2+ anchor fires": signals unrolled-quantifier
     // consuming threads that must not override a zero-length match (e.g. `a copy3` in
     // `(^a?){3}` but NOT `a` in `\A{3}a` where anchorFollowedBySkip remains false).
@@ -845,23 +932,69 @@ public final class PikeVMMatcher extends ReggieMatcher {
       String input,
       int regionStart,
       int regionEnd) {
+    addThreadToNlist(state, captures, null, null, pos, depth, input, regionStart, regionEnd);
+  }
+
+  private void addThreadToNlist(
+      NFA.NFAState state,
+      int[] captures,
+      int[] atomicPos,
+      int[] atomicExitPos,
+      int pos,
+      int depth,
+      String input,
+      int regionStart,
+      int regionEnd) {
     if (inNlist[state.id]) return;
+
+    // Atomic-exit nlist pruning: when this DFS path traverses atomicExit(G), record the commit
+    // position so that subsequent nlist additions from lower-priority threads can be pruned.
+    if (atomicGroupCount > 0 && state.atomicExit >= 0) {
+      int G = state.atomicExit;
+      int entryPos = (atomicPos != null) ? atomicPos[G] : -1;
+      if (entryPos >= 0) {
+        // Record the commit: group G's greedy match entered at entryPos commits at pos.
+        atomicCommitPos[G] = entryPos;
+        // Kill earlier nlist slots that exited the same group at the same entry pos but earlier
+        // (i.e. shorter match). A slot "exited earlier" means its atomicExitPos[G] is in
+        // [0, pos-1] AND it entered the same group (atomicPos or entryPos signal).
+        for (int j = 0; j < nlistSize; j++) {
+          if (nlistAlive[j]) {
+            int jExitPos = nlistAtomicExitPos[j][G];
+            int jEntryPos = nlistAtomicPos[j][G]; // -1 means "entry pos was lost at exit"
+            // We need to identify slots that exited via a SHORTER match from the same entry.
+            // A slot that has already exited (jExitPos >= 0) at the same entry pos (or at an
+            // entry pos that we can't distinguish, use -1 sentinel for "exited already") and
+            // exited BEFORE the current commit pos is a loser.
+            if (jExitPos >= 0 && jExitPos < pos) {
+              nlistAlive[j] = false;
+            }
+          }
+        }
+      }
+    }
 
     if (state.anchor != null) {
       if (!checkAnchor(state.anchor, input, pos, regionStart, regionEnd)) return;
       inNlist[state.id] = true;
       for (NFA.NFAState next : state.getEpsilonTransitions()) {
-        addThreadToNlist(next, captures, pos, depth, input, regionStart, regionEnd);
+        addThreadToNlist(
+            next, captures, atomicPos, atomicExitPos, pos, depth, input, regionStart, regionEnd);
       }
       return;
     }
 
     int[] ownCaptures = updateCaptures(state, captures, pos, depth);
+    int[][] ownAtomic = updateAtomicTracking(state, atomicPos, atomicExitPos, pos, depth, false);
+    int[] ownAtomicPos = ownAtomic[0];
+    int[] ownAtomicExitPos = ownAtomic[1];
 
     List<NFA.NFAState> epsilons = state.getEpsilonTransitions();
     if (!epsilons.isEmpty()) {
       inNlist[state.id] = true;
       int[] passedCaptures = ownCaptures;
+      int[] passedAtomicPos = ownAtomicPos;
+      int[] passedAtomicExitPos = ownAtomicExitPos;
       for (NFA.NFAState next : epsilons) {
         // Trailing-empty-iteration rebind: mirror the scoped logic from addThread above.
         // Only propagate when the current state is a group EXIT (loop-back context) AND
@@ -873,7 +1006,9 @@ public final class PikeVMMatcher extends ReggieMatcher {
                 && groupBodyNullable[state.id]
                 && next.enterGroup != null
                 && !inNlist[next.id];
-        addThreadToNlist(next, passedCaptures, pos, depth + 1, input, regionStart, regionEnd);
+        addThreadToNlist(
+            next, passedCaptures, passedAtomicPos, passedAtomicExitPos, pos, depth + 1,
+            input, regionStart, regionEnd);
         if (willUpdateGroupEntry) {
           int scratchIdx = Math.min(depth + 2, scratchCaptures.length - 1);
           passedCaptures = scratchCaptures[scratchIdx];
@@ -883,8 +1018,35 @@ public final class PikeVMMatcher extends ReggieMatcher {
     }
 
     inNlist[state.id] = true;
-    nlistIds[nlistSize] = state.id;
-    System.arraycopy(ownCaptures, 0, nlistCaptures[nlistSize], 0, ownCaptures.length);
+    int k = nlistSize;
+    nlistIds[k] = state.id;
+    System.arraycopy(ownCaptures, 0, nlistCaptures[k], 0, ownCaptures.length);
+    if (atomicGroupCount > 0) {
+      if (ownAtomicPos != null) {
+        System.arraycopy(ownAtomicPos, 0, nlistAtomicPos[k], 0, atomicGroupCount);
+      } else {
+        Arrays.fill(nlistAtomicPos[k], -1);
+      }
+      if (ownAtomicExitPos != null) {
+        System.arraycopy(ownAtomicExitPos, 0, nlistAtomicExitPos[k], 0, atomicGroupCount);
+      } else {
+        Arrays.fill(nlistAtomicExitPos[k], -1);
+      }
+      nlistAlive[k] = true;
+      // Prune this slot if a greedy atomic commit already supersedes it.
+      // A slot is pruned if its atomicExitPos[G] is in [0, committedEntryPos-1] relative
+      // to the commit recorded this step. We check: if atomicCommitPos[G] has been set (>= 0)
+      // and this slot's atomicExitPos[G] is in [0, currentPos-1].
+      if (ownAtomicExitPos != null) {
+        for (int G = 0; G < atomicGroupCount; G++) {
+          int exitP = ownAtomicExitPos[G];
+          if (exitP >= 0 && atomicCommitPos[G] >= 0 && exitP < pos) {
+            nlistAlive[k] = false;
+            break;
+          }
+        }
+      }
+    }
     nlistSize++;
   }
 
@@ -907,6 +1069,62 @@ public final class PikeVMMatcher extends ReggieMatcher {
     }
     return copy;
   }
+
+  /**
+   * Update atomic-group tracking arrays for the current state. Returns a 2-element array:
+   * [0] = updated atomicPos (entry positions), [1] = updated atomicExitPos (exit positions).
+   * Returns the original arrays unchanged when neither entry nor exit is triggered. When
+   * {@code forClist} is true, blocking logic checks are handled in the caller; this method only
+   * updates the scratch copies.
+   */
+  private int[][] updateAtomicTracking(
+      NFA.NFAState state,
+      int[] atomicPos,
+      int[] atomicExitPos,
+      int pos,
+      int depth,
+      boolean forClist) {
+    if (atomicGroupCount == 0) {
+      return NO_ATOMIC; // fast path for non-atomic patterns
+    }
+    boolean hasEntry = state.atomicEntry >= 0;
+    boolean hasExit = state.atomicExit >= 0;
+    if (!hasEntry && !hasExit) {
+      // Reuse the scratch result array to avoid new allocation; fill it with the original refs.
+      scratchAtomicResult[0] = atomicPos;
+      scratchAtomicResult[1] = atomicExitPos;
+      return scratchAtomicResult;
+    }
+    int scratchIdx = Math.min(depth + 1, scratchAtomicPos.length - 1);
+    int[] copyPos = scratchAtomicPos[scratchIdx];
+    int[] copyExitPos = scratchAtomicExitPos[scratchIdx];
+    if (atomicPos != null) {
+      System.arraycopy(atomicPos, 0, copyPos, 0, atomicGroupCount);
+    } else {
+      Arrays.fill(copyPos, -1);
+    }
+    if (atomicExitPos != null) {
+      System.arraycopy(atomicExitPos, 0, copyExitPos, 0, atomicGroupCount);
+    } else {
+      Arrays.fill(copyExitPos, -1);
+    }
+    if (hasEntry) {
+      copyPos[state.atomicEntry] = pos;
+    }
+    if (hasExit) {
+      int G = state.atomicExit;
+      // Record exit position and clear the entry sentinel (thread is now outside the group).
+      copyExitPos[G] = pos;
+      copyPos[G] = -1;
+    }
+    scratchAtomicResult[0] = copyPos;
+    scratchAtomicResult[1] = copyExitPos;
+    return scratchAtomicResult;
+  }
+
+  // Reusable scratch result holder for updateAtomicTracking (avoids allocation).
+  private final int[][] scratchAtomicResult = new int[2][];
+  private static final int[][] NO_ATOMIC = {null, null};
 
   // -------------------------------------------------------------------------
   // Anchor checking
@@ -989,6 +1207,11 @@ public final class PikeVMMatcher extends ReggieMatcher {
         if (write != t) {
           clistIds[write] = clistIds[t];
           System.arraycopy(clistCaptures[t], 0, clistCaptures[write], 0, clistCaptures[t].length);
+          if (atomicGroupCount > 0) {
+            System.arraycopy(clistAtomicPos[t], 0, clistAtomicPos[write], 0, atomicGroupCount);
+            System.arraycopy(
+                clistAtomicExitPos[t], 0, clistAtomicExitPos[write], 0, atomicGroupCount);
+          }
           clistViaMultipleAnchors[write] = false;
         }
         write++;
@@ -1004,6 +1227,11 @@ public final class PikeVMMatcher extends ReggieMatcher {
         if (write != t) {
           clistIds[write] = clistIds[t];
           System.arraycopy(clistCaptures[t], 0, clistCaptures[write], 0, clistCaptures[t].length);
+          if (atomicGroupCount > 0) {
+            System.arraycopy(clistAtomicPos[t], 0, clistAtomicPos[write], 0, atomicGroupCount);
+            System.arraycopy(
+                clistAtomicExitPos[t], 0, clistAtomicExitPos[write], 0, atomicGroupCount);
+          }
           clistViaMultipleAnchors[write] = clistViaMultipleAnchors[t];
         }
         write++;
@@ -1017,30 +1245,42 @@ public final class PikeVMMatcher extends ReggieMatcher {
     // inside addThreadToNlist but whose id was never appended to nlistIds.
     Arrays.fill(inNlist, false);
     nlistSize = 0;
+    // nlistAlive slots are reset to true as each new slot is committed in addThreadToNlist;
+    // no explicit reset of all slots is needed since we only read slots 0..nlistSize-1.
+    if (atomicGroupCount > 0) {
+      Arrays.fill(atomicCommitPos, -1);
+    }
   }
 
   private void swapLists() {
     int len = winCaptures.length;
-    // Move nlist into clist.
-    for (int i = 0; i < nlistSize; i++) {
-      inClist[clistIds[i < clistSize ? i : 0]] = false; // clear old clist guards lazily below
-    }
-    // Full reset of clist guards then re-set from nlist.
+    // Full reset of clist guards then re-set from nlist (skipping dead atomic-pruned slots).
     Arrays.fill(inClist, false);
     clistFirstAccept = -1;
+    int write = 0;
     for (int i = 0; i < nlistSize; i++) {
-      clistIds[i] = nlistIds[i];
-      System.arraycopy(nlistCaptures[i], 0, clistCaptures[i], 0, len);
+      if (atomicGroupCount > 0 && !nlistAlive[i]) {
+        // Slot was pruned by an atomic group exit — skip it.
+        inNlist[nlistIds[i]] = false;
+        continue;
+      }
+      clistIds[write] = nlistIds[i];
+      System.arraycopy(nlistCaptures[i], 0, clistCaptures[write], 0, len);
+      if (atomicGroupCount > 0) {
+        System.arraycopy(nlistAtomicPos[i], 0, clistAtomicPos[write], 0, atomicGroupCount);
+        System.arraycopy(nlistAtomicExitPos[i], 0, clistAtomicExitPos[write], 0, atomicGroupCount);
+      }
       // Threads from nlist have advanced past their seed position: anchor-derived pruning no longer
       // applies, so reset the flag rather than letting a stale value from the previous clist
       // survive.
-      clistViaMultipleAnchors[i] = false;
+      clistViaMultipleAnchors[write] = false;
       inClist[nlistIds[i]] = true;
       inNlist[nlistIds[i]] = false;
       // nlist is built in priority order, so the first accepting entry is the highest priority.
-      if (clistFirstAccept < 0 && isAccept[nlistIds[i]]) clistFirstAccept = i;
+      if (clistFirstAccept < 0 && isAccept[nlistIds[i]]) clistFirstAccept = write;
+      write++;
     }
-    clistSize = nlistSize;
+    clistSize = write;
     nlistSize = 0;
   }
 

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
@@ -53,20 +53,13 @@ public final class PikeVMMatcher extends ReggieMatcher {
   // Atomic group thread pruning support.
   //
   // atomicPos[G]: entry position of atomic group G for this thread; -1 if not inside the group.
-  // atomicExitPos[G]: position at which this thread exited atomic group G; -1 if not yet exited.
   //
-  // Pruning rule (nlist): when a thread's DFS traverses atomicExit(G) at the current input position
-  // P (and the thread entered G at some position E), atomicCommitPos[G] is set to E. Any nlist
-  // slot with atomicExitPos[G] in [0, P-1] is pruned (it exited earlier = shorter match from the
-  // same step). This enforces the greedy-commit semantics: the longest match inside the atomic
-  // group survives; all shorter exits from the same step are killed.
+  // Pruning rule (nlist): when a thread's DFS traverses atomicExit(G), lower-priority nlist
+  // threads that entered G at the same position are killed (nlistAlive[j] = false), enforcing
+  // the greedy-commit semantics: the first (highest-priority) exit survives; all others are pruned.
   private final int atomicGroupCount;
   private final int[][] clistAtomicPos;
-  private final int[][] clistAtomicExitPos;
   private final int[][] nlistAtomicPos;
-  private final int[][] nlistAtomicExitPos;
-  // Per-step committed entry position for each atomic group; -1 = not committed this step.
-  private final int[] atomicCommitPos;
   // true = slot is active, false = pruned by atomic commit.
   private boolean[] nlistAlive;
 
@@ -86,10 +79,9 @@ public final class PikeVMMatcher extends ReggieMatcher {
   // One per DFS depth level; bounded by stateCount.
   private final int[][] scratchCaptures;
 
-  // Scratch atomic position arrays for DFS atomic-group entry/exit recording during addThread.
+  // Scratch atomic position arrays for DFS atomic-group entry recording during addThread.
   // One per DFS depth level; bounded by stateCount. null when atomicGroupCount == 0.
   private final int[][] scratchAtomicPos;
-  private final int[][] scratchAtomicExitPos;
 
   // Per-clist-slot marker: true when the slot was added via a path that passed through TWO OR
   // MORE distinct anchor states at pos=regionStart. This identifies unrolled-quantifier consuming
@@ -189,29 +181,17 @@ public final class PikeVMMatcher extends ReggieMatcher {
     this.atomicGroupCount = nfa.getAtomicGroupCount();
     if (atomicGroupCount > 0) {
       this.clistAtomicPos = new int[stateCount][atomicGroupCount];
-      this.clistAtomicExitPos = new int[stateCount][atomicGroupCount];
       this.nlistAtomicPos = new int[stateCount][atomicGroupCount];
-      this.nlistAtomicExitPos = new int[stateCount][atomicGroupCount];
-      this.atomicCommitPos = new int[atomicGroupCount];
       for (int[] row : clistAtomicPos) Arrays.fill(row, -1);
-      for (int[] row : clistAtomicExitPos) Arrays.fill(row, -1);
       for (int[] row : nlistAtomicPos) Arrays.fill(row, -1);
-      for (int[] row : nlistAtomicExitPos) Arrays.fill(row, -1);
-      Arrays.fill(atomicCommitPos, -1);
       this.nlistAlive = new boolean[stateCount];
       this.scratchAtomicPos = new int[stateCount + 1][atomicGroupCount];
-      this.scratchAtomicExitPos = new int[stateCount + 1][atomicGroupCount];
       for (int[] row : scratchAtomicPos) Arrays.fill(row, -1);
-      for (int[] row : scratchAtomicExitPos) Arrays.fill(row, -1);
     } else {
       this.clistAtomicPos = null;
-      this.clistAtomicExitPos = null;
       this.nlistAtomicPos = null;
-      this.nlistAtomicExitPos = null;
-      this.atomicCommitPos = null;
       this.nlistAlive = null;
       this.scratchAtomicPos = null;
-      this.scratchAtomicExitPos = null;
     }
 
     // T1.2: precompute the required-first-char prefilter from the start-state epsilon closure.
@@ -774,13 +754,12 @@ public final class PikeVMMatcher extends ReggieMatcher {
       NFA.NFAState state = statesById[clistIds[t]];
       int[] caps = clistCaptures[t];
       int[] apos = (atomicGroupCount > 0) ? clistAtomicPos[t] : null;
-      int[] aexitPos = (atomicGroupCount > 0) ? clistAtomicExitPos[t] : null;
       for (NFA.Transition tr : state.getTransitions()) {
         if (tr.chars.contains(ch)) {
           int[] nc = scratchCaptures[0];
           System.arraycopy(caps, 0, nc, 0, nc.length);
           addThreadToNlist(
-              tr.target, nc, apos, aexitPos, nextPos, 0, input, regionStart, regionEnd);
+              tr.target, nc, apos, nextPos, 0, input, regionStart, regionEnd);
         }
       }
     }
@@ -815,20 +794,18 @@ public final class PikeVMMatcher extends ReggieMatcher {
       int regionStart,
       int regionEnd) {
     addThread(
-        state, captures, null, null, pos, depth, anchorCount, anchorFollowedBySkip,
+        state, captures, null, pos, depth, anchorCount, anchorFollowedBySkip,
         input, regionStart, regionEnd);
   }
 
   /**
    * Core addThread with atomic group tracking. {@code atomicPos[G]} holds the input position at
-   * which atomic group G was entered (-1 if not inside G). {@code atomicExitPos[G]} holds the
-   * position at which G was exited (-1 if not yet exited on this DFS path).
+   * which atomic group G was entered (-1 if not inside G).
    */
   private void addThread(
       NFA.NFAState state,
       int[] captures,
       int[] atomicPos,
-      int[] atomicExitPos,
       int pos,
       int depth,
       int anchorCount,
@@ -844,23 +821,20 @@ public final class PikeVMMatcher extends ReggieMatcher {
       // Increment the anchor count; anchorFollowedBySkip is not reset by anchor firing.
       for (NFA.NFAState next : state.getEpsilonTransitions()) {
         addThread(
-            next, captures, atomicPos, atomicExitPos, pos, depth,
+            next, captures, atomicPos, pos, depth,
             anchorCount + 1, anchorFollowedBySkip, input, regionStart, regionEnd);
       }
       return;
     }
 
     int[] ownCaptures = updateCaptures(state, captures, pos, depth);
-    int[][] ownAtomic = updateAtomicTracking(state, atomicPos, atomicExitPos, pos, depth, true);
-    int[] ownAtomicPos = ownAtomic[0];
-    int[] ownAtomicExitPos = ownAtomic[1];
+    int[] ownAtomicPos = updateAtomicTracking(state, atomicPos, pos, depth);
 
     List<NFA.NFAState> epsilons = state.getEpsilonTransitions();
     if (!epsilons.isEmpty()) {
       inClist[state.id] = true;
       int[] passedCaptures = ownCaptures;
       int[] passedAtomicPos = ownAtomicPos;
-      int[] passedAtomicExitPos = ownAtomicExitPos;
       // Determine the "skip-after-anchor" flag for each epsilon child: set to true when
       // taking a non-first epsilon of a non-anchor, non-group state while anchors have fired.
       // This identifies quantifier-skip paths (e.g. a? skip to next copy) as distinct from
@@ -889,7 +863,7 @@ public final class PikeVMMatcher extends ReggieMatcher {
                 && next.enterGroup != null
                 && !inClist[next.id];
         addThread(
-            next, passedCaptures, passedAtomicPos, passedAtomicExitPos, pos, depth + 1,
+            next, passedCaptures, passedAtomicPos, pos, depth + 1,
             anchorCount, childAnchorFollowedBySkip, input, regionStart, regionEnd);
         if (willUpdateGroupEntry) {
           int scratchIdx = Math.min(depth + 2, scratchCaptures.length - 1);
@@ -909,11 +883,6 @@ public final class PikeVMMatcher extends ReggieMatcher {
       } else {
         Arrays.fill(clistAtomicPos[clistSize], -1);
       }
-      if (ownAtomicExitPos != null) {
-        System.arraycopy(ownAtomicExitPos, 0, clistAtomicExitPos[clistSize], 0, atomicGroupCount);
-      } else {
-        Arrays.fill(clistAtomicExitPos[clistSize], -1);
-      }
     }
     // Mark as "via skip-after-anchor with 2+ anchor fires": signals unrolled-quantifier
     // consuming threads that must not override a zero-length match (e.g. `a copy3` in
@@ -927,19 +896,7 @@ public final class PikeVMMatcher extends ReggieMatcher {
   private void addThreadToNlist(
       NFA.NFAState state,
       int[] captures,
-      int pos,
-      int depth,
-      String input,
-      int regionStart,
-      int regionEnd) {
-    addThreadToNlist(state, captures, null, null, pos, depth, input, regionStart, regionEnd);
-  }
-
-  private void addThreadToNlist(
-      NFA.NFAState state,
-      int[] captures,
       int[] atomicPos,
-      int[] atomicExitPos,
       int pos,
       int depth,
       String input,
@@ -947,14 +904,12 @@ public final class PikeVMMatcher extends ReggieMatcher {
       int regionEnd) {
     if (inNlist[state.id]) return;
 
-    // Atomic-exit nlist pruning: when this DFS path traverses atomicExit(G), record the commit
-    // position so that subsequent nlist additions from lower-priority threads can be pruned.
+    // Atomic-exit nlist pruning: when this DFS path traverses atomicExit(G), kill lower-priority
+    // nlist threads that entered the same atomic group at the same position.
     if (atomicGroupCount > 0 && state.atomicExit >= 0) {
       int G = state.atomicExit;
       int entryPos = (atomicPos != null) ? atomicPos[G] : -1;
       if (entryPos >= 0) {
-        // Record the commit: group G's greedy match entered at entryPos commits at pos.
-        atomicCommitPos[G] = entryPos;
         // Kill nlist slots that entered the same atomic group at the same entry position:
         // those are lower-priority threads that lost to the current greedy commit.
         for (int j = 0; j < nlistSize; j++) {
@@ -970,22 +925,19 @@ public final class PikeVMMatcher extends ReggieMatcher {
       inNlist[state.id] = true;
       for (NFA.NFAState next : state.getEpsilonTransitions()) {
         addThreadToNlist(
-            next, captures, atomicPos, atomicExitPos, pos, depth, input, regionStart, regionEnd);
+            next, captures, atomicPos, pos, depth, input, regionStart, regionEnd);
       }
       return;
     }
 
     int[] ownCaptures = updateCaptures(state, captures, pos, depth);
-    int[][] ownAtomic = updateAtomicTracking(state, atomicPos, atomicExitPos, pos, depth, false);
-    int[] ownAtomicPos = ownAtomic[0];
-    int[] ownAtomicExitPos = ownAtomic[1];
+    int[] ownAtomicPos = updateAtomicTracking(state, atomicPos, pos, depth);
 
     List<NFA.NFAState> epsilons = state.getEpsilonTransitions();
     if (!epsilons.isEmpty()) {
       inNlist[state.id] = true;
       int[] passedCaptures = ownCaptures;
       int[] passedAtomicPos = ownAtomicPos;
-      int[] passedAtomicExitPos = ownAtomicExitPos;
       for (NFA.NFAState next : epsilons) {
         // Trailing-empty-iteration rebind: mirror the scoped logic from addThread above.
         // Only propagate when the current state is a group EXIT (loop-back context) AND
@@ -998,7 +950,7 @@ public final class PikeVMMatcher extends ReggieMatcher {
                 && next.enterGroup != null
                 && !inNlist[next.id];
         addThreadToNlist(
-            next, passedCaptures, passedAtomicPos, passedAtomicExitPos, pos, depth + 1,
+            next, passedCaptures, passedAtomicPos, pos, depth + 1,
             input, regionStart, regionEnd);
         if (willUpdateGroupEntry) {
           int scratchIdx = Math.min(depth + 2, scratchCaptures.length - 1);
@@ -1018,25 +970,7 @@ public final class PikeVMMatcher extends ReggieMatcher {
       } else {
         Arrays.fill(nlistAtomicPos[k], -1);
       }
-      if (ownAtomicExitPos != null) {
-        System.arraycopy(ownAtomicExitPos, 0, nlistAtomicExitPos[k], 0, atomicGroupCount);
-      } else {
-        Arrays.fill(nlistAtomicExitPos[k], -1);
-      }
       nlistAlive[k] = true;
-      // Prune this slot if a greedy atomic commit already supersedes it.
-      // A slot is pruned if its atomicExitPos[G] is in [0, committedEntryPos-1] relative
-      // to the commit recorded this step. We check: if atomicCommitPos[G] has been set (>= 0)
-      // and this slot's atomicExitPos[G] is in [0, currentPos-1].
-      if (ownAtomicExitPos != null) {
-        for (int G = 0; G < atomicGroupCount; G++) {
-          int exitP = ownAtomicExitPos[G];
-          if (exitP >= 0 && atomicCommitPos[G] >= 0 && exitP < pos) {
-            nlistAlive[k] = false;
-            break;
-          }
-        }
-      }
     }
     nlistSize++;
   }
@@ -1062,60 +996,39 @@ public final class PikeVMMatcher extends ReggieMatcher {
   }
 
   /**
-   * Update atomic-group tracking arrays for the current state. Returns a 2-element array:
-   * [0] = updated atomicPos (entry positions), [1] = updated atomicExitPos (exit positions).
-   * Returns the original arrays unchanged when neither entry nor exit is triggered. When
-   * {@code forClist} is true, blocking logic checks are handled in the caller; this method only
-   * updates the scratch copies.
+   * Update atomic-group entry tracking for the current state. Returns the updated atomicPos array
+   * (entry positions for each atomic group, -1 if not inside). Returns the original array unchanged
+   * when the state has no atomic entry or exit annotation.
    */
-  private int[][] updateAtomicTracking(
+  private int[] updateAtomicTracking(
       NFA.NFAState state,
       int[] atomicPos,
-      int[] atomicExitPos,
       int pos,
-      int depth,
-      boolean forClist) {
+      int depth) {
     if (atomicGroupCount == 0) {
-      return NO_ATOMIC; // fast path for non-atomic patterns
+      return null; // fast path for non-atomic patterns
     }
     boolean hasEntry = state.atomicEntry >= 0;
     boolean hasExit = state.atomicExit >= 0;
     if (!hasEntry && !hasExit) {
-      // Reuse the scratch result array to avoid new allocation; fill it with the original refs.
-      scratchAtomicResult[0] = atomicPos;
-      scratchAtomicResult[1] = atomicExitPos;
-      return scratchAtomicResult;
+      return atomicPos;
     }
     int scratchIdx = Math.min(depth + 1, scratchAtomicPos.length - 1);
     int[] copyPos = scratchAtomicPos[scratchIdx];
-    int[] copyExitPos = scratchAtomicExitPos[scratchIdx];
     if (atomicPos != null) {
       System.arraycopy(atomicPos, 0, copyPos, 0, atomicGroupCount);
     } else {
       Arrays.fill(copyPos, -1);
     }
-    if (atomicExitPos != null) {
-      System.arraycopy(atomicExitPos, 0, copyExitPos, 0, atomicGroupCount);
-    } else {
-      Arrays.fill(copyExitPos, -1);
-    }
     if (hasEntry) {
       copyPos[state.atomicEntry] = pos;
     }
     if (hasExit) {
-      int G = state.atomicExit;
-      // Record exit position and clear the entry sentinel (thread is now outside the group).
-      copyExitPos[G] = pos;
-      copyPos[G] = -1;
+      // Clear the entry sentinel; the thread is now outside the group.
+      copyPos[state.atomicExit] = -1;
     }
-    scratchAtomicResult[0] = copyPos;
-    scratchAtomicResult[1] = copyExitPos;
-    return scratchAtomicResult;
+    return copyPos;
   }
-
-  // Reusable scratch result holder for updateAtomicTracking (avoids allocation).
-  private final int[][] scratchAtomicResult = new int[2][];
-  private static final int[][] NO_ATOMIC = {null, null};
 
   // -------------------------------------------------------------------------
   // Anchor checking
@@ -1200,8 +1113,6 @@ public final class PikeVMMatcher extends ReggieMatcher {
           System.arraycopy(clistCaptures[t], 0, clistCaptures[write], 0, clistCaptures[t].length);
           if (atomicGroupCount > 0) {
             System.arraycopy(clistAtomicPos[t], 0, clistAtomicPos[write], 0, atomicGroupCount);
-            System.arraycopy(
-                clistAtomicExitPos[t], 0, clistAtomicExitPos[write], 0, atomicGroupCount);
           }
           clistViaMultipleAnchors[write] = false;
         }
@@ -1220,8 +1131,6 @@ public final class PikeVMMatcher extends ReggieMatcher {
           System.arraycopy(clistCaptures[t], 0, clistCaptures[write], 0, clistCaptures[t].length);
           if (atomicGroupCount > 0) {
             System.arraycopy(clistAtomicPos[t], 0, clistAtomicPos[write], 0, atomicGroupCount);
-            System.arraycopy(
-                clistAtomicExitPos[t], 0, clistAtomicExitPos[write], 0, atomicGroupCount);
           }
           clistViaMultipleAnchors[write] = clistViaMultipleAnchors[t];
         }
@@ -1238,9 +1147,6 @@ public final class PikeVMMatcher extends ReggieMatcher {
     nlistSize = 0;
     // nlistAlive slots are reset to true as each new slot is committed in addThreadToNlist;
     // no explicit reset of all slots is needed since we only read slots 0..nlistSize-1.
-    if (atomicGroupCount > 0) {
-      Arrays.fill(atomicCommitPos, -1);
-    }
   }
 
   private void swapLists() {
@@ -1259,7 +1165,6 @@ public final class PikeVMMatcher extends ReggieMatcher {
       System.arraycopy(nlistCaptures[i], 0, clistCaptures[write], 0, len);
       if (atomicGroupCount > 0) {
         System.arraycopy(nlistAtomicPos[i], 0, clistAtomicPos[write], 0, atomicGroupCount);
-        System.arraycopy(nlistAtomicExitPos[i], 0, clistAtomicExitPos[write], 0, atomicGroupCount);
       }
       // Threads from nlist have advanced past their seed position: anchor-derived pruning no longer
       // applies, so reset the flag rather than letting a stale value from the previous clist

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
@@ -79,9 +79,10 @@ public final class PikeVMMatcher extends ReggieMatcher {
   // One per DFS depth level; bounded by stateCount.
   private final int[][] scratchCaptures;
 
-  // Scratch atomic position arrays for DFS atomic-group entry recording during addThread.
-  // One per DFS depth level; bounded by stateCount. null when atomicGroupCount == 0.
-  private final int[][] scratchAtomicPos;
+  // Scratch atomic position array for DFS atomic-group entry recording during addThread.
+  // Single array of size atomicGroupCount, passed through DFS calls analogously to how
+  // capture arrays are passed. null when atomicGroupCount == 0.
+  private final int[] scratchAtomicPos;
 
   // Per-clist-slot marker: true when the slot was added via a path that passed through TWO OR
   // MORE distinct anchor states at pos=regionStart. This identifies unrolled-quantifier consuming
@@ -185,8 +186,8 @@ public final class PikeVMMatcher extends ReggieMatcher {
       for (int[] row : clistAtomicPos) Arrays.fill(row, -1);
       for (int[] row : nlistAtomicPos) Arrays.fill(row, -1);
       this.nlistAlive = new boolean[stateCount];
-      this.scratchAtomicPos = new int[stateCount + 1][atomicGroupCount];
-      for (int[] row : scratchAtomicPos) Arrays.fill(row, -1);
+      this.scratchAtomicPos = new int[atomicGroupCount];
+      Arrays.fill(scratchAtomicPos, -1);
     } else {
       this.clistAtomicPos = null;
       this.nlistAtomicPos = null;
@@ -828,7 +829,7 @@ public final class PikeVMMatcher extends ReggieMatcher {
     }
 
     int[] ownCaptures = updateCaptures(state, captures, pos, depth);
-    int[] ownAtomicPos = updateAtomicTracking(state, atomicPos, pos, depth);
+    int[] ownAtomicPos = updateAtomicTracking(state, atomicPos, pos);
 
     List<NFA.NFAState> epsilons = state.getEpsilonTransitions();
     if (!epsilons.isEmpty()) {
@@ -931,7 +932,7 @@ public final class PikeVMMatcher extends ReggieMatcher {
     }
 
     int[] ownCaptures = updateCaptures(state, captures, pos, depth);
-    int[] ownAtomicPos = updateAtomicTracking(state, atomicPos, pos, depth);
+    int[] ownAtomicPos = updateAtomicTracking(state, atomicPos, pos);
 
     List<NFA.NFAState> epsilons = state.getEpsilonTransitions();
     if (!epsilons.isEmpty()) {
@@ -1003,8 +1004,7 @@ public final class PikeVMMatcher extends ReggieMatcher {
   private int[] updateAtomicTracking(
       NFA.NFAState state,
       int[] atomicPos,
-      int pos,
-      int depth) {
+      int pos) {
     if (atomicGroupCount == 0) {
       return null; // fast path for non-atomic patterns
     }
@@ -1013,8 +1013,7 @@ public final class PikeVMMatcher extends ReggieMatcher {
     if (!hasEntry && !hasExit) {
       return atomicPos;
     }
-    int scratchIdx = Math.min(depth + 1, scratchAtomicPos.length - 1);
-    int[] copyPos = scratchAtomicPos[scratchIdx];
+    int[] copyPos = scratchAtomicPos;
     if (atomicPos != null) {
       System.arraycopy(atomicPos, 0, copyPos, 0, atomicGroupCount);
     } else {

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/AtomicGroupPikeVMTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/AtomicGroupPikeVMTest.java
@@ -37,7 +37,8 @@ public class AtomicGroupPikeVMTest {
   void testAtomicGroupPreventsBacktrack_starThenLiteral() {
     // (?>a*)a: atomic group greedily consumes all 'a's; cannot backtrack to let trailing 'a' match.
     assertFalse(Reggie.compile("(?>a*)a").matches("a"));
-    assertFalse(Reggie.compile("(?>a*)a").matches("aaa"));
+    assertFalse(Reggie.compile("(?>a*)a").matches("aa"));
+    assertFalse(Reggie.compile("(?>a*)a").matches(""));
   }
 
   @Test

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/AtomicGroupPikeVMTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/AtomicGroupPikeVMTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.datadoghq.reggie.Reggie;
+import org.junit.jupiter.api.Test;
+
+/**
+ * PikeVM-level backtracking-prevention semantics for atomic groups and possessive quantifiers.
+ *
+ * <p>Atomic groups ({@code (?>X)}) and possessive quantifiers ({@code X++}, {@code X*+}, etc.)
+ * prevent backtracking into the matched portion. These patterns are routed to the PikeVM engine,
+ * which enforces the commit semantics via atomic-group tracking.
+ */
+public class AtomicGroupPikeVMTest {
+
+  // -------------------------------------------------------------------------
+  // Atomic group backtracking prevention
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testAtomicGroupPreventsBacktrack_starThenLiteral() {
+    // (?>a*)a: atomic group greedily consumes all 'a's; cannot backtrack to let trailing 'a' match.
+    assertFalse(Reggie.compile("(?>a*)a").matches("a"));
+    assertFalse(Reggie.compile("(?>a*)a").matches("aaa"));
+  }
+
+  @Test
+  void testAtomicGroupPreventsBacktrack_plusThenLiteral() {
+    // (?>a+)a: atomic group greedily consumes all 'a's; trailing 'a' has nothing to match.
+    assertFalse(Reggie.compile("(?>a+)a").matches("a"));
+    assertFalse(Reggie.compile("(?>a+)a").matches("aa"));
+  }
+
+  @Test
+  void testAtomicGroupAllowsMatchWhenSuffixNotConsumed() {
+    // (?>a*)b: atomic group commits on 'a's; 'b' can still follow.
+    assertTrue(Reggie.compile("(?>a*)b").matches("b"));
+    assertTrue(Reggie.compile("(?>a*)b").matches("ab"));
+    assertTrue(Reggie.compile("(?>a*)b").matches("aaab"));
+  }
+
+  @Test
+  void testAtomicGroupContrastWithNonAtomic() {
+    // Non-atomic (a*)a can backtrack and succeed; atomic (?>a*)a cannot.
+    assertTrue(Reggie.compile("(a*)a").matches("a"));
+    assertFalse(Reggie.compile("(?>a*)a").matches("a"));
+  }
+
+  // -------------------------------------------------------------------------
+  // Possessive quantifier backtracking prevention
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testPossessivePlusPreventsBacktrack() {
+    // a++a: possessive '+' grabs all 'a's; trailing 'a' cannot match.
+    assertFalse(Reggie.compile("a++a").matches("aa"));
+    assertFalse(Reggie.compile("a++a").matches("aaa"));
+  }
+
+  @Test
+  void testPossessiveStarPreventsBacktrack() {
+    // a*+a: possessive '*' grabs all 'a's; trailing 'a' cannot match.
+    assertFalse(Reggie.compile("a*+a").matches("a"));
+    assertFalse(Reggie.compile("a*+a").matches("aa"));
+  }
+
+  @Test
+  void testPossessiveQuestionPreventsBacktrack() {
+    // a?+a: possessive '?' grabs the one 'a'; trailing 'a' has nothing to match.
+    assertFalse(Reggie.compile("a?+a").matches("a"));
+  }
+
+  @Test
+  void testPossessiveAllowsMatchWhenSuffixNotConsumed() {
+    // a*+b: possessive commits on 'a's; 'b' can still follow.
+    assertTrue(Reggie.compile("a*+b").matches("b"));
+    assertTrue(Reggie.compile("a*+b").matches("ab"));
+    assertTrue(Reggie.compile("a*+b").matches("aaab"));
+  }
+}

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/BitParallelGlushkovRuntimeTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/BitParallelGlushkovRuntimeTest.java
@@ -69,6 +69,24 @@ public class BitParallelGlushkovRuntimeTest {
           a.entry);
     }
 
+    int findFromWithSkip(CharSequence in, int from, int lastRequired) {
+      return BitParallelGlushkovRuntime.findFromWithSkip(
+          in,
+          from,
+          a.initial,
+          a.accept,
+          a.nullable,
+          a.startsAnywhere,
+          a.follow,
+          a.followReverse,
+          a.asciiClasses,
+          a.rangeStarts,
+          a.rangeEnds,
+          a.rangeClasses,
+          a.entry,
+          lastRequired);
+    }
+
     int[] findBounds(CharSequence in, int from) {
       int[] bounds = new int[2];
       boolean found =
@@ -193,6 +211,31 @@ public class BitParallelGlushkovRuntimeTest {
             fails.append(
                 String.format("findFrom /%s/ on %-12s jdk=-1 reggie=%d%n", pat, q(in), rStart));
           }
+        }
+      }
+    }
+    assertEquals("", fails.toString(), "\n" + fails);
+  }
+
+  @Test
+  void findFromWithSkip_agreesWithFindFrom_acrossInputs() {
+    // For patterns with a fixed last required character, findFromWithSkip must return the same
+    // start position as findFrom on identical inputs.
+    String[] patterns = {"ab", "abc", "hello", "world", "a"};
+    String[] inputs = {"hello", "world", "abc", "xyz", "a", ""};
+    StringBuilder fails = new StringBuilder();
+    for (String pat : patterns) {
+      G g = g(pat);
+      // Derive lastRequired from the last char of the literal pattern (no special chars here).
+      int lastRequired = pat.charAt(pat.length() - 1);
+      for (String in : inputs) {
+        int expected = g.findFrom(in, 0);
+        int actual = g.findFromWithSkip(in, 0, lastRequired);
+        if (expected != actual) {
+          fails.append(
+              String.format(
+                  "findFromWithSkip /%s/ on %-12s findFrom=%d findFromWithSkip=%d%n",
+                  pat, q(in), expected, actual));
         }
       }
     }


### PR DESCRIPTION
### What does this PR do?

Implements three features from the open-issues design doc:

1. **Parse-and-reject for atomic groups and possessive quantifiers** (closes #41, #42): `(?>...)` and possessive quantifiers (`X*+`, `X++`, `X?+`, `X{n,m}+`) previously silently returned wrong results. They now throw `UnsupportedPatternException` immediately at parse time.

2. **Native atomic group semantics** (closes #41, #42): Full implementation of atomic groups via PikeVM thread pruning — AST field `GroupNode.atomic`, NFA `atomicEntry`/`atomicExit` state markers in `ThompsonBuilder`, and sibling-thread kill logic in `PikeVMMatcher` when a thread crosses an `atomicExit` boundary. Possessive quantifiers are desugared to atomic groups at parse time. Patterns with atomic groups are routed to `PIKEVM_CAPTURE` via a new `PatternAnalyzer` gate.

3. **First-byte skip optimisation for `startsAnywhere` patterns** (closes #74): `GlushkovAutomaton.findLastRequiredChar()` identifies a single ASCII character that must appear at the last position of every match. `BitParallelGlushkovRuntime.findFromWithSkip()` uses `String.indexOf` to jump past non-candidate regions, then scans from `max(start, reqPos - MAX_POSITIONS)`.

### Motivation

Issues #41 and #42 were correctness violations: Reggie was silently accepting `(?>...)` and `*+` syntax and returning wrong results (false positives), violating the correctness guarantee. Issue #74 is a performance enhancement that avoids O(n) scanning over regions that cannot contain a match.

### Related Issue(s)

Fixes #41, Fixes #42, Implements #74

### Change Type

- [x] Bug fix
- [x] New feature
- [x] Performance improvement
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [ ] Test improvement
- [ ] Build/CI change

### Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] All existing tests pass (`./gradlew build`)
- [x] I have added tests for my changes
- [x] I have updated documentation (if applicable)
- [ ] My commits are signed

### Performance Impact

The `findFromWithSkip` optimisation applies only to `BITPARALLEL_GLUSHKOV` patterns where `startsAnywhere=true` and a single required last character exists. For such patterns, `find()` skips over regions guaranteed to contain no match endpoint, reducing average-case scan cost. No regression on patterns where the optimisation does not apply (falls back to `findFrom`).

### Additional Notes

- `scratchAtomicPos` was simplified from a depth-indexed 2-D array to a single shared `int[]` during validation — this is correct because `addThread` is called sequentially (single-threaded DFS), so the scratch array is never accessed concurrently.
- The `StructuralHash` was updated to mix in `hasAtomicGroups` to prevent structural cache collisions between atomic and non-atomic variants of the same pattern.
- Fuzz gate: 34 divergences maintained (no new divergences introduced). 2,578 tests pass.