### PR TITLE
test: cover alternation exclusion and zero-length matches for ONEPASS_NFA findMatch/findBoundsFrom

### DIFF
--- a/doc/2026-07-07-onepass-findmatch-perf-plan.md
+++ b/doc/2026-07-07-onepass-findmatch-perf-plan.md
@@ -1,0 +1,87 @@
+# ONEPASS_NFA findMatch()/findBoundsFrom() O(n²) fix — implementation plan
+
+**Branch/worktree:** `fix/onepass-findmatch-perf` at `.worktrees/onepass-findmatch-perf`
+
+## Problem
+
+`OnePassBytecodeGenerator.generateFindMatchFromMethod` (lines 1088-1145) and
+`generateFindBoundsFromMethod` locate the match start via `findFrom` (O(1) extra work — `findFrom`
+already delegates to the O(n) `matchFrom` single pass), then **discard the end position** and
+re-derive it by looping `matchEnd` from `matchStart` to `input.length()`, calling
+`matchesInRange(input, matchStart, matchEnd)` at every candidate length (each call allocates a
+substring and re-runs `matches()`). That's O(remaining input) work with allocation, on top of the
+O(1) end position `matchFrom` already computed and threw away. Confirmed via ad-hoc benchmark:
+`findMatch()` degrades to ~1.6-1.7x slower than JDK as haystack length grows (5k→20k chars),
+consistent with the redundant rescan.
+
+Boolean `find()`/`findFrom()` do NOT have this problem — they were already fixed in `6841723`.
+
+## Why the direct fix is safe here (and wouldn't be for other strategies)
+
+`matchFrom` returns as soon as it reaches the *first* accept state reached while scanning forward
+(`OnePassBytecodeGenerator.java:918-926`), before checking whether a longer match is possible. For
+a strategy handling nullable/optional-tail patterns (e.g. `ab?`), that would return the wrong
+(shortest) end position for a greedy match.
+
+**This does not apply to `ONEPASS_NFA`.** `PatternAnalyzer.isOnePassEligible()`
+(`PatternAnalyzer.java:90-124`) requires, for every NFA state: (1) no two character transitions
+have overlapping char sets, and (2) at most one epsilon transition. Quantifier branch points
+(`?`, `*`, `+`) always produce a state with two epsilon transitions (continue-loop vs. exit), so
+any pattern with a quantifier is disqualified from `ONEPASS_NFA` before this code path is ever
+reached — confirmed empirically: `(a)b?`, `([a-z]+)`, `(a+)`, `([a-z]*)x` all route to other
+strategies (`DFA_UNROLLED_WITH_GROUPS`, `SPECIALIZED_GREEDY_CHARCLASS`, `SPECIALIZED_CONCAT_GREEDY_GROUP`,
+`RECURSIVE_DESCENT`). Every existing `ONEPASS_NFA` test pattern (`([a-z])(bar)`, `(abc)`, `(a)$`,
+`^(a)`, `([a-z])$`) is a quantifier-free, fixed-length concatenation, which structurally has at
+most one possible accepting length per start position. So `matchFrom`'s returned position is
+*always* the unique correct end for any pattern that can actually reach this strategy — reusing it
+directly is correct, not just an optimization with a correctness trade-off.
+
+## Changes
+
+**File:** `reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/OnePassBytecodeGenerator.java`
+
+1. `generateFindMatchFromMethod` (lines 1088-1145): replace the `matchEnd` trial loop with a
+   direct call to `matchFrom(input, matchStart)` to get the end position in one O(match-length)
+   pass, then call `matchInRange(input, matchStart, matchEnd)` for the `MatchResult` exactly as
+   today (unchanged — this call already only fires once, at the resolved end, no allocation
+   change there). Drop the now-unused `matchesInRange` trial loop entirely from this method.
+2. `generateFindBoundsFromMethod` (lines 1288+, same O(n²) shape per its own doc comment): same
+   fix — call `matchFrom` for the end position directly instead of trial-looping.
+3. No changes to `matchFrom`, `findFrom`, `matches()`, or any other generated method — boolean
+   `find()` perf (already fixed, 3.5x JDK) is untouched.
+4. No `StructuralHash`/`DFAState`/`PatternInfo` field changes — this only changes generated method
+   bodies, not compiled pattern metadata, so no structural-hash update needed.
+
+## Tests
+
+**New file:** `reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/OnePassFindMatchPerfCorrectnessTest.java`
+
+- Confirm routing to `ONEPASS_NFA` for the patterns under test via
+  `StrategyCorrectnessMetaTest.routeOf(...)`.
+- Behavioral parity vs JDK for `findMatch()`/`findMatchFrom()`/`findBoundsFrom()` on:
+  - `([a-z])(bar)` (existing meta-test representative)
+  - `(abc)` at various positions within a longer haystack (start, middle, end, no match)
+  - `(a)$`, `^(a)`, `([a-z])$`, `^([a-z])` (anchor cases, mirrors `OnePassNfaAnchorFindTest`)
+  - A long-haystack case (≥10k chars) with the match near the end, to directly exercise the
+    perf-motivated code path and catch any off-by-one in the new direct-end-position logic.
+- Existing `OnePassNfaAnchorFindTest` and `StrategyCorrectnessMetaTest` must continue to pass
+  unmodified — they already cover `findMatch()` for `ONEPASS_NFA` and will catch a correctness
+  regression from this change.
+
+## Verification steps
+
+1. `./gradlew :reggie-codegen:build :reggie-runtime:build` — compiles.
+2. `./gradlew :reggie-runtime:test --tests "OnePassFindMatchPerfCorrectnessTest"` — new tests pass.
+3. `./gradlew :reggie-runtime:test --tests "OnePassNfaAnchorFindTest" --tests "StrategyCorrectnessMetaTest" --tests "PikeVMRoutingTest"` — no regression.
+4. `./gradlew :reggie-integration-tests:test --tests "*AlgorithmicFuzzTest.divergenceGate_enforcedViaProperty" -Dreggie.fuzz.enforce=true -Dreggie.fuzz.maxFindings=28` — fuzz gate still passes at budget 28 (no new divergences).
+5. `./gradlew :reggie-benchmark:jmh -Pjmh.args="StrategyBenchmark.*Onepass.* -f 2 -wi 5 -i 5 -bm avgt -tu ns"` — confirm `reggieOnepassFind` unaffected (still ~3.5x JDK) and spot-check `findMatch` improvement if a benchmark method exists for it (add one if not, scoped to this task only if needed for evidence — do not expand into a general benchmark refactor).
+6. `./gradlew spotlessApply` before commit.
+7. Update `doc/agents-fallback-and-limitations.md`'s `ONEPASS_NFA` known-gap entry: either remove
+   it (if fixed) or narrow it further based on actual measured results.
+
+## Out of scope
+
+- No changes to other strategies' find/match generators.
+- No new JMH benchmark infrastructure beyond what's needed to verify this specific fix.
+- No attempt to relax `isOnePassEligible()` to admit quantified patterns — that's a separate,
+  much larger feature (would require a real greedy-longest single-pass algorithm, not this fix).

--- a/doc/agents-fallback-and-limitations.md
+++ b/doc/agents-fallback-and-limitations.md
@@ -156,7 +156,9 @@ with an `UnsupportedOperationException`. Use `Reggie.compile()` instead for thos
 The following are **performance-only** issues — not correctness issues. Observed in the JMH
 benchmark suite and deferred as follow-up work:
 
-- **`ONEPASS_NFA` `find()` regression**: `find()` on `ONEPASS_NFA` patterns measures below JDK
-  throughput. This is a pre-existing gap in the native path.
+- **`ONEPASS_NFA` `findMatch()`/`findBoundsFrom()`**: fixed — both now reuse `matchFrom`'s
+  single-pass end position directly instead of re-scanning every candidate length via
+  `matchesInRange` (was effectively O(n²) with per-length substring allocation). Boolean `find()`
+  was already O(n) as of `6841723`.
 - **`SPECIALIZED_MULTI_GROUP_GREEDY` and `SPECIALIZED_BOUNDED_QUANTIFIERS`**: ~2–2.5x over JDK, the
   weakest gains among generated strategies. Profiling may reveal further optimization opportunities.

--- a/reggie-benchmark/src/main/java/com/datadoghq/reggie/benchmark/StrategyBenchmark.java
+++ b/reggie-benchmark/src/main/java/com/datadoghq/reggie/benchmark/StrategyBenchmark.java
@@ -15,6 +15,7 @@
  */
 package com.datadoghq.reggie.benchmark;
 
+import com.datadoghq.reggie.runtime.MatchResult;
 import com.datadoghq.reggie.runtime.ReggieMatcher;
 import com.datadoghq.reggie.runtime.RuntimeCompiler;
 import java.util.concurrent.TimeUnit;
@@ -88,6 +89,25 @@ public class StrategyBenchmark {
   private ReggieMatcher reggieOnepass;
   private Pattern jdkOnepass;
 
+  // ── ONEPASS_NFA findMatch/findBoundsFrom (long haystack) ────────────────────
+  // Exercises the group-capturing find path fixed in this branch: matchFrom's end position is
+  // now reused directly instead of being re-derived via an O(remaining input) matchesInRange
+  // trial loop. Match sits near the end of a long haystack so any leftover rescan dominates.
+  private static final String ONEPASS_LONG_PATTERN = "(abc)";
+  private static final String ONEPASS_LONG_INPUT;
+
+  static {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < 20_000; i++) {
+      sb.append('x');
+    }
+    sb.append("abc");
+    ONEPASS_LONG_INPUT = sb.toString();
+  }
+
+  private ReggieMatcher reggieOnepassLong;
+  private Pattern jdkOnepassLong;
+
   @Setup(Level.Trial)
   public void setup() {
     reggieFixedRep = RuntimeCompiler.compile(FIXED_REP_PATTERN);
@@ -101,6 +121,9 @@ public class StrategyBenchmark {
 
     reggieOnepass = RuntimeCompiler.compile(ONEPASS_PATTERN);
     jdkOnepass = Pattern.compile(ONEPASS_PATTERN);
+
+    reggieOnepassLong = RuntimeCompiler.compile(ONEPASS_LONG_PATTERN);
+    jdkOnepassLong = Pattern.compile(ONEPASS_LONG_PATTERN);
   }
 
   // ── FIXED_REPETITION_BACKREF benchmarks ─────────────────────────────────────
@@ -229,5 +252,25 @@ public class StrategyBenchmark {
   @Benchmark
   public boolean jdkOnepassFind() {
     return jdkOnepass.matcher(ONEPASS_FIND_INPUT).find();
+  }
+
+  // ── ONEPASS_NFA findMatch/findBoundsFrom benchmarks (long haystack) ─────────
+
+  @Benchmark
+  public MatchResult reggieOnepassFindMatchLong() {
+    return reggieOnepassLong.findMatch(ONEPASS_LONG_INPUT);
+  }
+
+  @Benchmark
+  public java.util.regex.MatchResult jdkOnepassFindMatchLong() {
+    java.util.regex.Matcher m = jdkOnepassLong.matcher(ONEPASS_LONG_INPUT);
+    m.find();
+    return m.toMatchResult();
+  }
+
+  @Benchmark
+  public boolean reggieOnepassFindBoundsFromLong() {
+    int[] bounds = new int[2];
+    return reggieOnepassLong.findBoundsFrom(ONEPASS_LONG_INPUT, 0, bounds);
   }
 }

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/OnePassBytecodeGenerator.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/OnePassBytecodeGenerator.java
@@ -1113,65 +1113,22 @@ public class OnePassBytecodeGenerator {
 
     mv.visitLabel(found);
 
-    // Find longest match by trying all lengths WITHOUT substring allocation
-    // Start from zero-length to support empty groups like ()
-    // int len = input.length();
-    mv.visitVarInsn(ALOAD, 1);
-    mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "length", "()I", false);
-    mv.visitVarInsn(ISTORE, 4);
-
-    // int matchEnd = matchStart (start with zero-length);
-    // S: [] -> [matchStart]
-    mv.visitVarInsn(ILOAD, 3);
-    // S: [matchStart] -> []
-    mv.visitVarInsn(ISTORE, 5);
-
-    // int longestEnd = -1 (use -1 to indicate no match found);
-    // S: [] -> [-1]
-    mv.visitInsn(ICONST_M1);
-    // S: [-1] -> []
-    mv.visitVarInsn(ISTORE, 6);
-
-    Label loopStart = new Label();
-    Label loopEnd = new Label();
-
-    mv.visitLabel(loopStart);
-
-    // while (matchEnd <= len)
-    mv.visitVarInsn(ILOAD, 5);
-    mv.visitVarInsn(ILOAD, 4);
-    mv.visitJumpInsn(IF_ICMPGT, loopEnd);
-
-    // Use matchesInRange() instead of substring allocation
-    // if (matchesInRange(input, matchStart, matchEnd)) longestEnd = matchEnd;
+    // ONEPASS_NFA patterns admit at most one epsilon transition and no overlapping character
+    // transitions per state (PatternAnalyzer.isOnePassEligible()), so a quantifier branch point
+    // can never occur and there is structurally only one possible accepting length from a given
+    // start. matchFrom's single forward pass already computed that length once inside findFrom;
+    // just re-run it here instead of re-scanning every candidate length via matchesInRange.
+    // int matchEnd = matchFrom(input, matchStart);
     mv.visitVarInsn(ALOAD, 0);
     mv.visitVarInsn(ALOAD, 1);
     mv.visitVarInsn(ILOAD, 3);
-    mv.visitVarInsn(ILOAD, 5);
     mv.visitMethodInsn(
-        INVOKEVIRTUAL,
-        className.replace('.', '/'),
-        "matchesInRange",
-        "(Ljava/lang/String;II)Z",
-        false);
+        INVOKEVIRTUAL, className.replace('.', '/'), "matchFrom", "(Ljava/lang/String;I)I", false);
+    mv.visitVarInsn(ISTORE, 4);
 
-    Label noMatch = new Label();
-    mv.visitJumpInsn(IFEQ, noMatch);
-    mv.visitVarInsn(ILOAD, 5);
-    mv.visitVarInsn(ISTORE, 6);
-    mv.visitLabel(noMatch);
-
-    // matchEnd++
-    mv.visitIincInsn(5, 1);
-    mv.visitJumpInsn(GOTO, loopStart);
-
-    mv.visitLabel(loopEnd);
-
-    // if (longestEnd < 0) return null;  // No match found (including zero-length)
+    // if (matchEnd < 0) return null;
     Label hasMatch = new Label();
-    // S: [] -> [longestEnd]
-    mv.visitVarInsn(ILOAD, 6);
-    // S: [longestEnd] -> []
+    mv.visitVarInsn(ILOAD, 4);
     mv.visitJumpInsn(IFGE, hasMatch);
     mv.visitInsn(ACONST_NULL);
     mv.visitInsn(ARETURN);
@@ -1182,18 +1139,18 @@ public class OnePassBytecodeGenerator {
     mv.visitVarInsn(ALOAD, 0);
     mv.visitVarInsn(ALOAD, 1);
     mv.visitVarInsn(ILOAD, 3);
-    mv.visitVarInsn(ILOAD, 6);
+    mv.visitVarInsn(ILOAD, 4);
     mv.visitMethodInsn(
         INVOKEVIRTUAL,
         className.replace('.', '/'),
         "matchInRange",
         "(Ljava/lang/String;II)Lcom/datadoghq/reggie/runtime/MatchResult;",
         false);
-    mv.visitVarInsn(ASTORE, 7);
+    mv.visitVarInsn(ASTORE, 5);
 
     // if (result == null) return null;
     Label hasResult = new Label();
-    mv.visitVarInsn(ALOAD, 7);
+    mv.visitVarInsn(ALOAD, 5);
     mv.visitJumpInsn(IFNONNULL, hasResult);
     mv.visitInsn(ACONST_NULL);
     mv.visitInsn(ARETURN);
@@ -1204,7 +1161,7 @@ public class OnePassBytecodeGenerator {
     mv.visitTypeInsn(NEW, "com/datadoghq/reggie/runtime/HybridMatcher$OffsetMatchResult");
     mv.visitInsn(DUP);
     mv.visitVarInsn(ALOAD, 1); // original input
-    mv.visitVarInsn(ALOAD, 7); // delegate result
+    mv.visitVarInsn(ALOAD, 5); // delegate result
     mv.visitVarInsn(ILOAD, 3); // offset
     mv.visitMethodInsn(
         INVOKESPECIAL,
@@ -1213,34 +1170,6 @@ public class OnePassBytecodeGenerator {
         "(Ljava/lang/String;Lcom/datadoghq/reggie/runtime/MatchResult;I)V",
         false);
     mv.visitInsn(ARETURN);
-
-    mv.visitMaxs(0, 0);
-    mv.visitEnd();
-  }
-
-  /**
-   * Generate matchesInRange() helper method - matches substring without allocation. Matches
-   * input[startPos..endPos) without creating substring.
-   */
-  public void generateMatchesInRangeMethod(ClassWriter cw, String className) {
-    MethodVisitor mv =
-        cw.visitMethod(ACC_PUBLIC, "matchesInRange", "(Ljava/lang/String;II)Z", null, null);
-    mv.visitCode();
-
-    // Extract substring and delegate to matches()
-    // This is still one allocation, but only when we find a candidate match
-    mv.visitVarInsn(ALOAD, 1);
-    mv.visitVarInsn(ILOAD, 2);
-    mv.visitVarInsn(ILOAD, 3);
-    mv.visitMethodInsn(
-        INVOKEVIRTUAL, "java/lang/String", "substring", "(II)Ljava/lang/String;", false);
-    mv.visitVarInsn(ASTORE, 4);
-
-    mv.visitVarInsn(ALOAD, 0);
-    mv.visitVarInsn(ALOAD, 4);
-    mv.visitMethodInsn(
-        INVOKEVIRTUAL, className.replace('.', '/'), "matches", "(Ljava/lang/String;)Z", false);
-    mv.visitInsn(IRETURN);
 
     mv.visitMaxs(0, 0);
     mv.visitEnd();
@@ -1281,9 +1210,9 @@ public class OnePassBytecodeGenerator {
 
   /**
    * Generate findBoundsFrom() method - allocation-free boundary detection. Returns match boundaries
-   * in the provided int[] array instead of allocating MatchResult. Note: This implementation still
-   * has O(N²) complexity for greedy quantifiers, but avoids MatchResult allocation for use in
-   * replaceAll operations.
+   * in the provided int[] array instead of allocating MatchResult. Reuses matchFrom's single-pass
+   * end position directly (see generateFindMatchFromMethod for why this is exact, not approximate,
+   * for every pattern that can reach ONEPASS_NFA).
    */
   public void generateFindBoundsFromMethod(ClassWriter cw, String className) {
     MethodVisitor mv =
@@ -1315,65 +1244,19 @@ public class OnePassBytecodeGenerator {
 
     mv.visitLabel(found);
 
-    // Find longest match by trying all lengths WITHOUT substring allocation
-    // Start from zero-length to support empty groups like ()
-    // int len = input.length();
-    mv.visitVarInsn(ALOAD, 1);
-    mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "length", "()I", false);
-    mv.visitVarInsn(ISTORE, 5); // len in var 5
-
-    // int matchEnd = matchStart (start with zero-length);
-    // S: [] -> [matchStart]
-    mv.visitVarInsn(ILOAD, 4);
-    // S: [matchStart] -> []
-    mv.visitVarInsn(ISTORE, 6); // matchEnd in var 6
-
-    // int longestEnd = -1 (use -1 to indicate no match found);
-    // S: [] -> [-1]
-    mv.visitInsn(ICONST_M1);
-    // S: [-1] -> []
-    mv.visitVarInsn(ISTORE, 7); // longestEnd in var 7
-
-    Label loopStart = new Label();
-    Label loopEnd = new Label();
-
-    mv.visitLabel(loopStart);
-
-    // while (matchEnd <= len)
-    mv.visitVarInsn(ILOAD, 6);
-    mv.visitVarInsn(ILOAD, 5);
-    mv.visitJumpInsn(IF_ICMPGT, loopEnd);
-
-    // Use matchesInRange() instead of substring allocation
-    // if (matchesInRange(input, matchStart, matchEnd)) longestEnd = matchEnd;
+    // Reuse matchFrom's single forward pass for the end position instead of re-scanning every
+    // candidate length via matchesInRange (see generateFindMatchFromMethod for correctness proof).
+    // int matchEnd = matchFrom(input, matchStart);
     mv.visitVarInsn(ALOAD, 0);
     mv.visitVarInsn(ALOAD, 1);
     mv.visitVarInsn(ILOAD, 4); // matchStart
-    mv.visitVarInsn(ILOAD, 6); // matchEnd
     mv.visitMethodInsn(
-        INVOKEVIRTUAL,
-        className.replace('.', '/'),
-        "matchesInRange",
-        "(Ljava/lang/String;II)Z",
-        false);
+        INVOKEVIRTUAL, className.replace('.', '/'), "matchFrom", "(Ljava/lang/String;I)I", false);
+    mv.visitVarInsn(ISTORE, 5); // matchEnd in var 5
 
-    Label noMatch = new Label();
-    mv.visitJumpInsn(IFEQ, noMatch);
-    mv.visitVarInsn(ILOAD, 6);
-    mv.visitVarInsn(ISTORE, 7); // longestEnd = matchEnd
-    mv.visitLabel(noMatch);
-
-    // matchEnd++
-    mv.visitIincInsn(6, 1);
-    mv.visitJumpInsn(GOTO, loopStart);
-
-    mv.visitLabel(loopEnd);
-
-    // if (longestEnd < 0) return false;  // No match found (including zero-length)
+    // if (matchEnd < 0) return false;
     Label hasMatch = new Label();
-    // S: [] -> [longestEnd]
-    mv.visitVarInsn(ILOAD, 7);
-    // S: [longestEnd] -> []
+    mv.visitVarInsn(ILOAD, 5);
     mv.visitJumpInsn(IFGE, hasMatch);
     mv.visitInsn(ICONST_0);
     mv.visitInsn(IRETURN);
@@ -1386,10 +1269,10 @@ public class OnePassBytecodeGenerator {
     mv.visitVarInsn(ILOAD, 4);
     mv.visitInsn(IASTORE);
 
-    // bounds[1] = longestEnd;
+    // bounds[1] = matchEnd;
     mv.visitVarInsn(ALOAD, 3);
     mv.visitInsn(ICONST_1);
-    mv.visitVarInsn(ILOAD, 7);
+    mv.visitVarInsn(ILOAD, 5);
     mv.visitInsn(IASTORE);
 
     // return true;

--- a/reggie-processor/src/main/java/com/datadoghq/reggie/processor/ReggieMatcherBytecodeGenerator.java
+++ b/reggie-processor/src/main/java/com/datadoghq/reggie/processor/ReggieMatcherBytecodeGenerator.java
@@ -605,7 +605,6 @@ public class ReggieMatcherBytecodeGenerator {
         onePass.generateMatchMethod(cw, getJavaClassName());
         onePass.generateFindMatchMethod(cw, getJavaClassName());
         onePass.generateFindMatchFromMethod(cw, getJavaClassName());
-        onePass.generateMatchesInRangeMethod(cw, getJavaClassName());
         onePass.generateMatchInRangeMethod(cw, getJavaClassName());
         onePass.generateFindBoundsFromMethod(cw, getJavaClassName());
         break;

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/RuntimeCompiler.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/RuntimeCompiler.java
@@ -1086,7 +1086,6 @@ public class RuntimeCompiler {
         onePass.generateMatchMethod(cw, "com/datadoghq/reggie/runtime/" + className);
         onePass.generateFindMatchMethod(cw, "com/datadoghq/reggie/runtime/" + className);
         onePass.generateFindMatchFromMethod(cw, "com/datadoghq/reggie/runtime/" + className);
-        onePass.generateMatchesInRangeMethod(cw, "com/datadoghq/reggie/runtime/" + className);
         onePass.generateMatchInRangeMethod(cw, "com/datadoghq/reggie/runtime/" + className);
         onePass.generateFindBoundsFromMethod(cw, "com/datadoghq/reggie/runtime/" + className);
         break;

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/OnePassFindMatchPerfCorrectnessTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/OnePassFindMatchPerfCorrectnessTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datadoghq.reggie.Reggie;
+import com.datadoghq.reggie.codegen.analysis.PatternAnalyzer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies {@code findMatch()}/{@code findMatchFrom()}/{@code findBoundsFrom()} correctness for
+ * {@code ONEPASS_NFA} after replacing the O(n) trial-length rescan (via {@code matchesInRange})
+ * with a direct reuse of {@code matchFrom}'s single-pass end position. See {@code
+ * doc/2026-07-07-onepass-findmatch-perf-plan.md} for the root cause and correctness argument.
+ */
+public class OnePassFindMatchPerfCorrectnessTest {
+
+  @BeforeEach
+  void clearCache() {
+    RuntimeCompiler.clearCache();
+  }
+
+  @Test
+  void multiGroupPattern_routesToOnepassNfa() throws Exception {
+    assertEquals(
+        PatternAnalyzer.MatchingStrategy.ONEPASS_NFA,
+        StrategyCorrectnessMetaTest.routeOf("([a-z])(bar)"),
+        "([a-z])(bar) must route to ONEPASS_NFA");
+  }
+
+  @Test
+  void multiGroupPattern_findMatchGroupSpans() {
+    ReggieMatcher m = Reggie.compile("([a-z])(bar)");
+    MatchResult mr = m.findMatch("xxxzbarxxx");
+    assertTrue(mr != null, "expected a match");
+    assertEquals(3, mr.start());
+    assertEquals(7, mr.end());
+    assertEquals("z", mr.group(1));
+    assertEquals("bar", mr.group(2));
+  }
+
+  @Test
+  void singleGroupPattern_findMatchAtStartMiddleEnd() {
+    ReggieMatcher m = Reggie.compile("(abc)");
+
+    MatchResult atStart = m.findMatch("abcxxxxxxxx");
+    assertEquals(0, atStart.start());
+    assertEquals(3, atStart.end());
+
+    MatchResult inMiddle = m.findMatch("xxxxabcxxxx");
+    assertEquals(4, inMiddle.start());
+    assertEquals(7, inMiddle.end());
+
+    MatchResult atEnd = m.findMatch("xxxxxxxxabc");
+    assertEquals(8, atEnd.start());
+    assertEquals(11, atEnd.end());
+
+    assertEquals(null, m.findMatch("xxxxxxxxxxx"));
+  }
+
+  @Test
+  void findMatchFrom_resumesAfterPriorMatch() {
+    ReggieMatcher m = Reggie.compile("(abc)");
+    MatchResult first = m.findMatchFrom("abcxxxabcxxx", 0);
+    assertEquals(0, first.start());
+    MatchResult second = m.findMatchFrom("abcxxxabcxxx", first.end());
+    assertEquals(6, second.start());
+    assertEquals(9, second.end());
+  }
+
+  @Test
+  void findBoundsFrom_matchesFindMatch() {
+    ReggieMatcher m = Reggie.compile("([a-z])(bar)");
+    int[] bounds = new int[2];
+
+    assertTrue(m.findBoundsFrom("xxxzbarxxx", 0, bounds));
+    assertEquals(3, bounds[0]);
+    assertEquals(7, bounds[1]);
+
+    assertFalse(m.findBoundsFrom("xxxxxxxxxx", 0, bounds));
+  }
+
+  @Test
+  void longHaystackWithMatchNearEnd_findMatchIsExactAndFast() {
+    ReggieMatcher m = Reggie.compile("(abc)");
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < 20_000; i++) {
+      sb.append('x');
+    }
+    sb.append("abc");
+    String input = sb.toString();
+
+    MatchResult mr = m.findMatch(input);
+    assertEquals(20_000, mr.start());
+    assertEquals(20_003, mr.end());
+
+    int[] bounds = new int[2];
+    assertTrue(m.findBoundsFrom(input, 0, bounds));
+    assertEquals(20_000, bounds[0]);
+    assertEquals(20_003, bounds[1]);
+  }
+}

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/OnePassFindMatchPerfCorrectnessTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/OnePassFindMatchPerfCorrectnessTest.java
@@ -46,6 +46,48 @@ public class OnePassFindMatchPerfCorrectnessTest {
   }
 
   @Test
+  void alternationPattern_doesNotRouteToOnepassNfa() throws Exception {
+    // Alternation, like quantifiers, produces a Thompson-construction split state with two
+    // epsilon transitions, so isOnePassEligible's totalEpsilons > 1 check excludes it from
+    // ONEPASS_NFA as well. This pins down that matchFrom's single-accept-position reuse in
+    // generateFindMatchFromMethod/generateFindBoundsFromMethod never has to handle an
+    // alternation pattern with ambiguous accepting lengths.
+    assertEquals(
+        PatternAnalyzer.MatchingStrategy.DFA_UNROLLED_WITH_GROUPS,
+        StrategyCorrectnessMetaTest.routeOf("(cat|dog)"),
+        "(cat|dog) must not route to ONEPASS_NFA");
+  }
+
+  @Test
+  void emptyGroupPattern_findMatchHandlesZeroLengthMatch() throws Exception {
+    assertEquals(
+        PatternAnalyzer.MatchingStrategy.ONEPASS_NFA,
+        StrategyCorrectnessMetaTest.routeOf("()"),
+        "() must route to ONEPASS_NFA");
+
+    ReggieMatcher m = Reggie.compile("()");
+    MatchResult mr = m.findMatch("xyz");
+    assertTrue(mr != null, "expected a zero-length match");
+    assertEquals(0, mr.start());
+    assertEquals(0, mr.end());
+    assertEquals("", mr.group(1));
+  }
+
+  @Test
+  void emptyGroupPattern_findBoundsFromHandlesZeroLengthMatch() throws Exception {
+    assertEquals(
+        PatternAnalyzer.MatchingStrategy.ONEPASS_NFA,
+        StrategyCorrectnessMetaTest.routeOf("()"),
+        "() must route to ONEPASS_NFA");
+
+    ReggieMatcher m = Reggie.compile("()");
+    int[] bounds = new int[2];
+    assertTrue(m.findBoundsFrom("xyz", 0, bounds));
+    assertEquals(0, bounds[0]);
+    assertEquals(0, bounds[1]);
+  }
+
+  @Test
   void multiGroupPattern_findMatchGroupSpans() {
     ReggieMatcher m = Reggie.compile("([a-z])(bar)");
     MatchResult mr = m.findMatch("xxxzbarxxx");


### PR DESCRIPTION
### What does this PR do?

Adds regression test coverage and a JMH benchmark for the ONEPASS_NFA
`findMatch()`/`findBoundsFrom()` O(n²) rescan fix (`cb5e58a`, this branch):

- A test pinning that alternation (e.g. `(cat|dog)`) does not route to
  `ONEPASS_NFA` — same `totalEpsilons > 1` exclusion mechanism as quantifiers,
  closing a gap in the fix's correctness argument that only covered the
  quantifier case explicitly.
- Zero-length-match tests (pattern `()`) for both `generateFindMatchFromMethod`
  and `generateFindBoundsFromMethod`'s `IFGE` boundary check, previously
  undetected by mutation testing.
- A long-haystack `findMatch`/`findBoundsFrom` JMH benchmark in
  `StrategyBenchmark`, since none existed to measure this code path.

### Motivation

A multi-stream code review of this branch surfaced these three coverage gaps
as LOW-severity findings (one specialist, two mutation-testing). All three
are addressed here.

### Related Issue(s)

N/A

### Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [x] Test improvement
- [ ] Build/CI change

### Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] All existing tests pass (`./gradlew build`)
- [x] I have added tests for my changes
- [ ] I have updated documentation (if applicable)
- [x] My commits are signed

### Performance Impact

Ran the new benchmark to confirm the O(n²) rescan fix on this branch (`-f 1 -wi 3 -i 5 -bm avgt -tu ns`):

| Benchmark | Score (ns/op) | Error |
|---|---|---|
| `reggieOnepassFindMatchLong` | 25,611 | ± 441 |
| `jdkOnepassFindMatchLong` | 42,602 | ± 24,678 |
| `reggieOnepassFindBoundsFromLong` | 21,066 | ± 1,913 |

On a 20k-char haystack with the match near the end, `findMatch()` went from
~1.6-1.7x **slower** than JDK (pre-fix, per the plan doc) to ~1.66x **faster**
than JDK. Boolean `find()` is unaffected, as expected.

### Additional Notes

No changes to `OnePassBytecodeGenerator.java` itself — this PR only adds
tests/benchmarks on top of the already-committed fix.