### PR TITLE
perf: flatten BitStateMatcher metadata, localize find() before fallback

### DIFF
--- a/reggie-benchmark/src/main/java/com/datadoghq/reggie/benchmark/IastRegexpBenchmark.java
+++ b/reggie-benchmark/src/main/java/com/datadoghq/reggie/benchmark/IastRegexpBenchmark.java
@@ -34,6 +34,32 @@ import org.openjdk.jmh.annotations.*;
  *
  * <p>Still excluded: SQL Oracle tokenizer ({@code q'<.*?>'} and similar q-quoted literal variants)
  * — these require additional work to enable in the benchmark.
+ *
+ * <p>Every match/no-match input is measured at three input scales via {@code @Param("scale")} —
+ * SHORT (the original single-shot inputs this benchmark used to report on its own), MEDIUM, and
+ * LONG — instead of a single point estimate. A single short input (12-90 chars) conflates "how good
+ * is this engine on this pattern" with "how much does fixed per-call/per-step overhead dominate
+ * this one specific tiny input (e.g. BITSTATE_CAPTURE's per-step visited-bitmap/job-stack
+ * bookkeeping is a fixed cost per DFS step, so it looms disproportionately large on a 12-char LDAP
+ * input regardless of how the engine scales). Reporting the ratio at three scales instead lets a
+ * reader tell a fixed-cost artifact (ratio improves as input grows) apart from a genuine scaling
+ * problem (ratio stays flat or worsens).
+ *
+ * <p>Two scaling strategies are used, chosen per-pattern to match what actually varies:
+ *
+ * <ul>
+ *   <li><b>Matched-region growth</b> — for patterns whose match/capture itself can be arbitrarily
+ *       long (COMMAND's trailing {@code (.*)}, URL's AUTHORITY credentials, LDAP's LITERAL value):
+ *       MEDIUM/LONG grow the matched/captured span itself.
+ *   <li><b>Scan-prefix growth</b> — for patterns whose match is anchored to a fixed-width literal
+ *       found by scanning (URL's query-param branch, all three SQL dialects, QueryObfuscator,
+ *       LDAP's no-match case): MEDIUM/LONG prepend benign filler text (containing none of the
+ *       pattern's own trigger characters) before the actual match/non-match content, stressing
+ *       find()'s scan/prefilter cost rather than the match itself.
+ * </ul>
+ *
+ * <p>Patterns are compiled once per trial in {@link #setup()} and never inside a {@code @Benchmark}
+ * method, so compilation cost is excluded from measurements.
  */
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
@@ -42,6 +68,20 @@ import org.openjdk.jmh.annotations.*;
 @Measurement(iterations = 5, time = 1)
 @Fork(1)
 public class IastRegexpBenchmark {
+
+  @Param({"SHORT", "MEDIUM", "LONG"})
+  public String scale;
+
+  private static String pick(String scale, String shortV, String mediumV, String longV) {
+    switch (scale) {
+      case "SHORT":
+        return shortV;
+      case "MEDIUM":
+        return mediumV;
+      default:
+        return longV;
+    }
+  }
 
   // --- Pattern strings ---
 
@@ -122,67 +162,173 @@ public class IastRegexpBenchmark {
   private com.google.re2j.Pattern re2jQueryObfuscator;
   private com.google.re2j.Pattern re2jLdap;
 
-  // --- Test inputs ---
+  // --- Test inputs (built per-scale in setup(); see class doc for the growth strategy chosen
+  // per pattern) ---
 
-  // Command: a sudo invocation with arguments (find() always matches — tests match-path cost)
-  private static final String COMMAND_INPUT = "sudo apt-get install -y curl --verbose";
+  // Command: a sudo invocation with arguments (find() always matches — tests match-path cost).
+  // Matched-region growth: the trailing (.*) capture widens.
+  private String commandInput;
 
-  // URL: authority credentials match vs query-param match vs no match
-  private static final String URL_AUTH_MATCH = "https://admin:s3cr3t@internal.corp/api/v1/health";
-  private static final String URL_QUERY_MATCH =
-      "https://api.example.com/search?q=hello&password=hunter2&page=1";
-  private static final String URL_NO_MATCH = "https://api.example.com/health";
+  // URL: authority credentials match vs query-param match vs no match.
+  // AUTHORITY branch is matched-region growth (^-anchored, so scan-prefix filler isn't possible
+  // without breaking the anchor); QUERY branch and no-match are scan-prefix growth.
+  private String urlAuthMatch;
+  private String urlQueryMatch;
+  private String urlNoMatch;
 
-  // SQL ANSI: query with literals to redact vs schema-only query with no literals
-  private static final String SQL_MATCH =
-      "SELECT * FROM users WHERE id = 42 AND name = 'Alice' AND balance = 1234.56";
-  private static final String SQL_NO_MATCH = "SELECT id, name, email FROM users ORDER BY id";
+  // SQL (all three dialects): scan-prefix growth — benign filler (no digits/quotes/comment
+  // markers) prepended before the literal that triggers the match, or appended to the
+  // schema-only no-match query.
+  private String sqlMatch;
+  private String sqlNoMatch;
+  private String mysqlMatch;
+  private String mysqlNoMatch;
+  private String postgresqlMatch;
+  private String postgresqlNoMatch;
 
-  // SQL MySQL: MySQL-flavored query with both quote styles
-  private static final String MYSQL_MATCH =
-      "SELECT id, `name` FROM users WHERE id = 1 AND email = 'user@example.com' AND active = 1";
-  private static final String MYSQL_NO_MATCH =
-      "SELECT id, name FROM users WHERE active AND enabled";
+  // QueryObfuscator: scan-prefix growth — benign query params (none of the sensitive-key
+  // keywords) prepended/appended.
+  private String qobfMatch;
+  private String qobfNoMatch;
 
-  // SQL PostgreSQL: query with dollar-quoted literal
-  private static final String POSTGRESQL_MATCH =
-      "SELECT * FROM docs WHERE body = $$hello world$$ AND revision = 3";
-  private static final String POSTGRESQL_NO_MATCH = "SELECT id, title FROM docs ORDER BY id";
+  // LDAP tokenizer: LITERAL value length is matched-region growth; no-match is scan-prefix
+  // growth (repeated benign text with none of the pattern's comparison operators or parens).
+  private String ldapMatch;
+  private String ldapNoMatch;
 
-  // QueryObfuscator: HTTP query string with API key vs benign params
-  private static final String QOBF_MATCH = "api_key=abc123def456&user=alice&action=view";
-  private static final String QOBF_NO_MATCH = "user=alice&action=view&page=1&sort=asc";
-
-  // LDAP tokenizer: attribute-value pair (match) vs plain text (no match)
-  private static final String LDAP_MATCH = "(uid=jsmith)";
-  private static final String LDAP_NO_MATCH = "uid jsmith";
-
-  @Setup
+  @Setup(Level.Trial)
   public void setup() {
+    commandInput =
+        pick(
+            scale,
+            "sudo apt-get install -y curl --verbose",
+            "sudo apt-get install -y " + "curl ".repeat(20) + "--verbose",
+            "sudo apt-get install -y " + "curl ".repeat(2000) + "--verbose");
     reggieCommand = RuntimeCompiler.compile(COMMAND);
     jdkCommand = Pattern.compile(COMMAND);
     re2jCommand = com.google.re2j.Pattern.compile(COMMAND);
 
+    urlAuthMatch =
+        pick(
+            scale,
+            "https://admin:s3cr3t@internal.corp/api/v1/health",
+            "https://" + "a".repeat(20) + ":" + "b".repeat(20) + "@internal.corp/api/v1/health",
+            "https://"
+                + "a".repeat(2000)
+                + ":"
+                + "b".repeat(2000)
+                + "@internal.corp/api/v1/health");
+    urlQueryMatch =
+        pick(
+            scale,
+            "https://api.example.com/search?q=hello&password=hunter2&page=1",
+            "https://api.example.com/"
+                + "seg/".repeat(20)
+                + "search?q=hello&password=hunter2&page=1",
+            "https://api.example.com/"
+                + "seg/".repeat(2000)
+                + "search?q=hello&password=hunter2&page=1");
+    urlNoMatch =
+        pick(
+            scale,
+            "https://api.example.com/health",
+            "https://api.example.com/" + "seg/".repeat(20) + "health",
+            "https://api.example.com/" + "seg/".repeat(2000) + "health");
     reggieUrl = RuntimeCompiler.compile(URL_JDK);
     jdkUrl = Pattern.compile(URL_JDK);
     re2jUrl = com.google.re2j.Pattern.compile(URL_RE2J);
 
+    sqlMatch =
+        pick(
+            scale,
+            "SELECT * FROM users WHERE id = 42 AND name = 'Alice' AND balance = 1234.56",
+            "SELECT * FROM users WHERE "
+                + "col_x = col_y AND ".repeat(20)
+                + "id = 42 AND name = 'Alice' AND balance = 1234.56",
+            "SELECT * FROM users WHERE "
+                + "col_x = col_y AND ".repeat(2000)
+                + "id = 42 AND name = 'Alice' AND balance = 1234.56");
+    sqlNoMatch =
+        pick(
+            scale,
+            "SELECT id, name, email FROM users ORDER BY id",
+            "SELECT id, name, email FROM users WHERE "
+                + "col_x = col_y AND ".repeat(20)
+                + "id = id ORDER BY id",
+            "SELECT id, name, email FROM users WHERE "
+                + "col_x = col_y AND ".repeat(2000)
+                + "id = id ORDER BY id");
     reggieSqlAnsi = RuntimeCompiler.compile(SQL_ANSI);
     jdkSqlAnsi = Pattern.compile(SQL_ANSI);
     re2jSqlAnsi = com.google.re2j.Pattern.compile(SQL_ANSI);
 
+    mysqlMatch =
+        pick(
+            scale,
+            "SELECT id, `name` FROM users WHERE id = 1 AND email = 'user@example.com' AND active = 1",
+            "SELECT id, `name` FROM users WHERE "
+                + "col_x = col_y AND ".repeat(20)
+                + "id = 1 AND email = 'user@example.com' AND active = 1",
+            "SELECT id, `name` FROM users WHERE "
+                + "col_x = col_y AND ".repeat(2000)
+                + "id = 1 AND email = 'user@example.com' AND active = 1");
+    mysqlNoMatch =
+        pick(
+            scale,
+            "SELECT id, name FROM users WHERE active AND enabled",
+            "SELECT id, name FROM users WHERE "
+                + "col_x = col_y AND ".repeat(20)
+                + "active AND enabled",
+            "SELECT id, name FROM users WHERE "
+                + "col_x = col_y AND ".repeat(2000)
+                + "active AND enabled");
     reggieSqlMysql = RuntimeCompiler.compile(SQL_MYSQL);
     jdkSqlMysql = Pattern.compile(SQL_MYSQL);
     re2jSqlMysql = com.google.re2j.Pattern.compile(SQL_MYSQL);
 
+    postgresqlMatch =
+        pick(
+            scale,
+            "SELECT * FROM docs WHERE body = $$hello world$$ AND revision = 3",
+            "SELECT * FROM docs WHERE "
+                + "col_x = col_y AND ".repeat(20)
+                + "body = $$hello world$$ AND revision = 3",
+            "SELECT * FROM docs WHERE "
+                + "col_x = col_y AND ".repeat(2000)
+                + "body = $$hello world$$ AND revision = 3");
+    postgresqlNoMatch =
+        pick(
+            scale,
+            "SELECT id, title FROM docs ORDER BY id",
+            "SELECT id, title FROM docs WHERE " + "col_x = col_y AND ".repeat(20) + "id = id",
+            "SELECT id, title FROM docs WHERE " + "col_x = col_y AND ".repeat(2000) + "id = id");
     reggieSqlPostgresql = RuntimeCompiler.compile(SQL_POSTGRESQL);
     jdkSqlPostgresql = Pattern.compile(SQL_POSTGRESQL);
     re2jSqlPostgresql = com.google.re2j.Pattern.compile(SQL_POSTGRESQL);
 
+    qobfMatch =
+        pick(
+            scale,
+            "api_key=abc123def456&user=alice&action=view",
+            "region=us&locale=en&".repeat(20) + "api_key=abc123def456&user=alice&action=view",
+            "region=us&locale=en&".repeat(2000) + "api_key=abc123def456&user=alice&action=view");
+    qobfNoMatch =
+        pick(
+            scale,
+            "user=alice&action=view&page=1&sort=asc",
+            "user=alice&action=view&page=1&sort=asc&" + "region=us&locale=en&".repeat(20),
+            "user=alice&action=view&page=1&sort=asc&" + "region=us&locale=en&".repeat(2000));
     reggieQueryObfuscator = RuntimeCompiler.compile(QUERY_OBFUSCATOR);
     jdkQueryObfuscator = Pattern.compile(QUERY_OBFUSCATOR);
     re2jQueryObfuscator = com.google.re2j.Pattern.compile(QUERY_OBFUSCATOR);
 
+    ldapMatch =
+        pick(
+            scale,
+            "(uid=jsmith)",
+            "(uid=" + "jsmith".repeat(10) + ")",
+            "(uid=" + "jsmith".repeat(500) + ")");
+    ldapNoMatch = pick(scale, "uid jsmith", "uid jsmith ".repeat(20), "uid jsmith ".repeat(2000));
     reggieLdap = RuntimeCompiler.compile(LDAP_JDK);
     jdkLdap = Pattern.compile(LDAP_JDK);
     re2jLdap = com.google.re2j.Pattern.compile(LDAP_JDK);
@@ -192,24 +338,24 @@ public class IastRegexpBenchmark {
 
   @Benchmark
   public boolean reggieCommandFind() {
-    return reggieCommand.find(COMMAND_INPUT);
+    return reggieCommand.find(commandInput);
   }
 
   @Benchmark
   public boolean jdkCommandFind() {
-    return jdkCommand.matcher(COMMAND_INPUT).find();
+    return jdkCommand.matcher(commandInput).find();
   }
 
   @Benchmark
   public boolean re2jCommandFind() {
-    return re2jCommand.matcher(COMMAND_INPUT).find();
+    return re2jCommand.matcher(commandInput).find();
   }
 
   // ----- Command capture (span extraction) -----
 
   @Benchmark
   public long reggieCommandCapture() {
-    MatchResult r = reggieCommand.findMatch(COMMAND_INPUT);
+    MatchResult r = reggieCommand.findMatch(commandInput);
     if (r == null) {
       return -1L;
     }
@@ -218,7 +364,7 @@ public class IastRegexpBenchmark {
 
   @Benchmark
   public long jdkCommandCapture() {
-    java.util.regex.Matcher m = jdkCommand.matcher(COMMAND_INPUT);
+    java.util.regex.Matcher m = jdkCommand.matcher(commandInput);
     if (!m.find()) {
       return -1L;
     }
@@ -227,7 +373,7 @@ public class IastRegexpBenchmark {
 
   @Benchmark
   public long re2jCommandCapture() {
-    com.google.re2j.Matcher m = re2jCommand.matcher(COMMAND_INPUT);
+    com.google.re2j.Matcher m = re2jCommand.matcher(commandInput);
     if (!m.find()) {
       return -1L;
     }
@@ -238,32 +384,32 @@ public class IastRegexpBenchmark {
 
   @Benchmark
   public boolean reggieUrlAuthFind() {
-    return reggieUrl.find(URL_AUTH_MATCH);
+    return reggieUrl.find(urlAuthMatch);
   }
 
   @Benchmark
   public boolean jdkUrlAuthFind() {
-    return jdkUrl.matcher(URL_AUTH_MATCH).find();
+    return jdkUrl.matcher(urlAuthMatch).find();
   }
 
   @Benchmark
   public boolean re2jUrlAuthFind() {
-    return re2jUrl.matcher(URL_AUTH_MATCH).find();
+    return re2jUrl.matcher(urlAuthMatch).find();
   }
 
   @Benchmark
   public boolean reggieUrlQueryFind() {
-    return reggieUrl.find(URL_QUERY_MATCH);
+    return reggieUrl.find(urlQueryMatch);
   }
 
   @Benchmark
   public boolean jdkUrlQueryFind() {
-    return jdkUrl.matcher(URL_QUERY_MATCH).find();
+    return jdkUrl.matcher(urlQueryMatch).find();
   }
 
   @Benchmark
   public boolean re2jUrlQueryFind() {
-    return re2jUrl.matcher(URL_QUERY_MATCH).find();
+    return re2jUrl.matcher(urlQueryMatch).find();
   }
 
   // ----- URL capture (span extraction) -----
@@ -305,7 +451,7 @@ public class IastRegexpBenchmark {
 
   @Benchmark
   public long reggieUrlAuthCapture() {
-    MatchResult r = reggieUrl.findMatch(URL_AUTH_MATCH);
+    MatchResult r = reggieUrl.findMatch(urlAuthMatch);
     if (r == null) {
       return -1L;
     }
@@ -314,7 +460,7 @@ public class IastRegexpBenchmark {
 
   @Benchmark
   public long jdkUrlAuthCapture() {
-    java.util.regex.Matcher m = jdkUrl.matcher(URL_AUTH_MATCH);
+    java.util.regex.Matcher m = jdkUrl.matcher(urlAuthMatch);
     if (!m.find()) {
       return -1L;
     }
@@ -323,7 +469,7 @@ public class IastRegexpBenchmark {
 
   @Benchmark
   public long reggieUrlQueryCapture() {
-    MatchResult r = reggieUrl.findMatch(URL_QUERY_MATCH);
+    MatchResult r = reggieUrl.findMatch(urlQueryMatch);
     if (r == null) {
       return -1L;
     }
@@ -332,7 +478,7 @@ public class IastRegexpBenchmark {
 
   @Benchmark
   public long jdkUrlQueryCapture() {
-    java.util.regex.Matcher m = jdkUrl.matcher(URL_QUERY_MATCH);
+    java.util.regex.Matcher m = jdkUrl.matcher(urlQueryMatch);
     if (!m.find()) {
       return -1L;
     }
@@ -341,7 +487,7 @@ public class IastRegexpBenchmark {
 
   @Benchmark
   public long re2jUrlAuthCapture() {
-    com.google.re2j.Matcher m = re2jUrl.matcher(URL_AUTH_MATCH);
+    com.google.re2j.Matcher m = re2jUrl.matcher(urlAuthMatch);
     if (!m.find()) {
       return -1L;
     }
@@ -350,7 +496,7 @@ public class IastRegexpBenchmark {
 
   @Benchmark
   public long re2jUrlQueryCapture() {
-    com.google.re2j.Matcher m = re2jUrl.matcher(URL_QUERY_MATCH);
+    com.google.re2j.Matcher m = re2jUrl.matcher(urlQueryMatch);
     if (!m.find()) {
       return -1L;
     }
@@ -359,176 +505,176 @@ public class IastRegexpBenchmark {
 
   @Benchmark
   public boolean reggieUrlNoMatch() {
-    return reggieUrl.find(URL_NO_MATCH);
+    return reggieUrl.find(urlNoMatch);
   }
 
   @Benchmark
   public boolean jdkUrlNoMatch() {
-    return jdkUrl.matcher(URL_NO_MATCH).find();
+    return jdkUrl.matcher(urlNoMatch).find();
   }
 
   @Benchmark
   public boolean re2jUrlNoMatch() {
-    return re2jUrl.matcher(URL_NO_MATCH).find();
+    return re2jUrl.matcher(urlNoMatch).find();
   }
 
   // ===== SQL ANSI =====
 
   @Benchmark
   public boolean reggieSqlAnsiFind() {
-    return reggieSqlAnsi.find(SQL_MATCH);
+    return reggieSqlAnsi.find(sqlMatch);
   }
 
   @Benchmark
   public boolean jdkSqlAnsiFind() {
-    return jdkSqlAnsi.matcher(SQL_MATCH).find();
+    return jdkSqlAnsi.matcher(sqlMatch).find();
   }
 
   @Benchmark
   public boolean re2jSqlAnsiFind() {
-    return re2jSqlAnsi.matcher(SQL_MATCH).find();
+    return re2jSqlAnsi.matcher(sqlMatch).find();
   }
 
   @Benchmark
   public boolean reggieSqlAnsiNoMatch() {
-    return reggieSqlAnsi.find(SQL_NO_MATCH);
+    return reggieSqlAnsi.find(sqlNoMatch);
   }
 
   @Benchmark
   public boolean jdkSqlAnsiNoMatch() {
-    return jdkSqlAnsi.matcher(SQL_NO_MATCH).find();
+    return jdkSqlAnsi.matcher(sqlNoMatch).find();
   }
 
   @Benchmark
   public boolean re2jSqlAnsiNoMatch() {
-    return re2jSqlAnsi.matcher(SQL_NO_MATCH).find();
+    return re2jSqlAnsi.matcher(sqlNoMatch).find();
   }
 
   // ===== SQL MySQL =====
 
   @Benchmark
   public boolean reggieSqlMysqlFind() {
-    return reggieSqlMysql.find(MYSQL_MATCH);
+    return reggieSqlMysql.find(mysqlMatch);
   }
 
   @Benchmark
   public boolean jdkSqlMysqlFind() {
-    return jdkSqlMysql.matcher(MYSQL_MATCH).find();
+    return jdkSqlMysql.matcher(mysqlMatch).find();
   }
 
   @Benchmark
   public boolean re2jSqlMysqlFind() {
-    return re2jSqlMysql.matcher(MYSQL_MATCH).find();
+    return re2jSqlMysql.matcher(mysqlMatch).find();
   }
 
   @Benchmark
   public boolean reggieSqlMysqlNoMatch() {
-    return reggieSqlMysql.find(MYSQL_NO_MATCH);
+    return reggieSqlMysql.find(mysqlNoMatch);
   }
 
   @Benchmark
   public boolean jdkSqlMysqlNoMatch() {
-    return jdkSqlMysql.matcher(MYSQL_NO_MATCH).find();
+    return jdkSqlMysql.matcher(mysqlNoMatch).find();
   }
 
   @Benchmark
   public boolean re2jSqlMysqlNoMatch() {
-    return re2jSqlMysql.matcher(MYSQL_NO_MATCH).find();
+    return re2jSqlMysql.matcher(mysqlNoMatch).find();
   }
 
   // ===== SQL PostgreSQL =====
 
   @Benchmark
   public boolean reggieSqlPostgresqlFind() {
-    return reggieSqlPostgresql.find(POSTGRESQL_MATCH);
+    return reggieSqlPostgresql.find(postgresqlMatch);
   }
 
   @Benchmark
   public boolean jdkSqlPostgresqlFind() {
-    return jdkSqlPostgresql.matcher(POSTGRESQL_MATCH).find();
+    return jdkSqlPostgresql.matcher(postgresqlMatch).find();
   }
 
   @Benchmark
   public boolean re2jSqlPostgresqlFind() {
-    return re2jSqlPostgresql.matcher(POSTGRESQL_MATCH).find();
+    return re2jSqlPostgresql.matcher(postgresqlMatch).find();
   }
 
   @Benchmark
   public boolean reggieSqlPostgresqlNoMatch() {
-    return reggieSqlPostgresql.find(POSTGRESQL_NO_MATCH);
+    return reggieSqlPostgresql.find(postgresqlNoMatch);
   }
 
   @Benchmark
   public boolean jdkSqlPostgresqlNoMatch() {
-    return jdkSqlPostgresql.matcher(POSTGRESQL_NO_MATCH).find();
+    return jdkSqlPostgresql.matcher(postgresqlNoMatch).find();
   }
 
   @Benchmark
   public boolean re2jSqlPostgresqlNoMatch() {
-    return re2jSqlPostgresql.matcher(POSTGRESQL_NO_MATCH).find();
+    return re2jSqlPostgresql.matcher(postgresqlNoMatch).find();
   }
 
   // ===== Query Obfuscator =====
 
   @Benchmark
   public boolean reggieQueryObfuscatorFind() {
-    return reggieQueryObfuscator.find(QOBF_MATCH);
+    return reggieQueryObfuscator.find(qobfMatch);
   }
 
   @Benchmark
   public boolean jdkQueryObfuscatorFind() {
-    return jdkQueryObfuscator.matcher(QOBF_MATCH).find();
+    return jdkQueryObfuscator.matcher(qobfMatch).find();
   }
 
   @Benchmark
   public boolean re2jQueryObfuscatorFind() {
-    return re2jQueryObfuscator.matcher(QOBF_MATCH).find();
+    return re2jQueryObfuscator.matcher(qobfMatch).find();
   }
 
   @Benchmark
   public boolean reggieQueryObfuscatorNoMatch() {
-    return reggieQueryObfuscator.find(QOBF_NO_MATCH);
+    return reggieQueryObfuscator.find(qobfNoMatch);
   }
 
   @Benchmark
   public boolean jdkQueryObfuscatorNoMatch() {
-    return jdkQueryObfuscator.matcher(QOBF_NO_MATCH).find();
+    return jdkQueryObfuscator.matcher(qobfNoMatch).find();
   }
 
   @Benchmark
   public boolean re2jQueryObfuscatorNoMatch() {
-    return re2jQueryObfuscator.matcher(QOBF_NO_MATCH).find();
+    return re2jQueryObfuscator.matcher(qobfNoMatch).find();
   }
 
   // ===== LDAP tokenizer =====
 
   @Benchmark
   public boolean reggieLdapFind() {
-    return reggieLdap.find(LDAP_MATCH);
+    return reggieLdap.find(ldapMatch);
   }
 
   @Benchmark
   public boolean jdkLdapFind() {
-    return jdkLdap.matcher(LDAP_MATCH).find();
+    return jdkLdap.matcher(ldapMatch).find();
   }
 
   @Benchmark
   public boolean re2jLdapFind() {
-    return re2jLdap.matcher(LDAP_MATCH).find();
+    return re2jLdap.matcher(ldapMatch).find();
   }
 
   @Benchmark
   public boolean reggieLdapNoMatch() {
-    return reggieLdap.find(LDAP_NO_MATCH);
+    return reggieLdap.find(ldapNoMatch);
   }
 
   @Benchmark
   public boolean jdkLdapNoMatch() {
-    return jdkLdap.matcher(LDAP_NO_MATCH).find();
+    return jdkLdap.matcher(ldapNoMatch).find();
   }
 
   @Benchmark
   public boolean re2jLdapNoMatch() {
-    return re2jLdap.matcher(LDAP_NO_MATCH).find();
+    return re2jLdap.matcher(ldapNoMatch).find();
   }
 }

--- a/reggie-benchmark/src/main/java/com/datadoghq/reggie/benchmark/IastRegexpBenchmark.java
+++ b/reggie-benchmark/src/main/java/com/datadoghq/reggie/benchmark/IastRegexpBenchmark.java
@@ -58,8 +58,6 @@ import org.openjdk.jmh.annotations.*;
  *       find()'s scan/prefilter cost rather than the match itself.
  * </ul>
  *
-<<<<<<< HEAD
-=======
  * <p>Scan-prefix filler for the SQL dialects and QueryObfuscator is capped well below {@code
  * BitStateMatcher}'s fallback budget ({@code stateCount * (input.length() + 1) <= 1 << 18}): those
  * patterns are pinned to {@code BITSTATE_CAPTURE} and have large NFAs (roughly 100 states for the
@@ -68,7 +66,6 @@ import org.openjdk.jmh.annotations.*;
  * reggieQueryObfuscator*} silently delegate to the PikeVM fallback and report its throughput
  * instead of BitState's.
  *
->>>>>>> origin/main
  * <p>Patterns are compiled once per trial in {@link #setup()} and never inside a {@code @Benchmark}
  * method, so compilation cost is excluded from measurements.
  */
@@ -80,19 +77,6 @@ import org.openjdk.jmh.annotations.*;
 @Fork(1)
 public class IastRegexpBenchmark {
 
-<<<<<<< HEAD
-  @Param({"SHORT", "MEDIUM", "LONG"})
-  public String scale;
-
-  private static String pick(String scale, String shortV, String mediumV, String longV) {
-    switch (scale) {
-      case "SHORT":
-        return shortV;
-      case "MEDIUM":
-        return mediumV;
-      default:
-        return longV;
-=======
   /** Input scale for a benchmark trial; see the class doc for what each scale stresses. */
   public enum Scale {
     SHORT,
@@ -113,7 +97,6 @@ public class IastRegexpBenchmark {
         return longV;
       default:
         throw new IllegalArgumentException("Unhandled scale: " + scale);
->>>>>>> origin/main
     }
   }
 
@@ -280,11 +263,7 @@ public class IastRegexpBenchmark {
                 + "col_x = col_y AND ".repeat(20)
                 + "id = 42 AND name = 'Alice' AND balance = 1234.56",
             "SELECT * FROM users WHERE "
-<<<<<<< HEAD
-                + "col_x = col_y AND ".repeat(2000)
-=======
                 + "col_x = col_y AND ".repeat(100)
->>>>>>> origin/main
                 + "id = 42 AND name = 'Alice' AND balance = 1234.56");
     sqlNoMatch =
         pick(
@@ -294,11 +273,7 @@ public class IastRegexpBenchmark {
                 + "col_x = col_y AND ".repeat(20)
                 + "id = id ORDER BY id",
             "SELECT id, name, email FROM users WHERE "
-<<<<<<< HEAD
-                + "col_x = col_y AND ".repeat(2000)
-=======
                 + "col_x = col_y AND ".repeat(100)
->>>>>>> origin/main
                 + "id = id ORDER BY id");
     reggieSqlAnsi = RuntimeCompiler.compile(SQL_ANSI);
     jdkSqlAnsi = Pattern.compile(SQL_ANSI);
@@ -312,11 +287,7 @@ public class IastRegexpBenchmark {
                 + "col_x = col_y AND ".repeat(20)
                 + "id = 1 AND email = 'user@example.com' AND active = 1",
             "SELECT id, `name` FROM users WHERE "
-<<<<<<< HEAD
-                + "col_x = col_y AND ".repeat(2000)
-=======
                 + "col_x = col_y AND ".repeat(100)
->>>>>>> origin/main
                 + "id = 1 AND email = 'user@example.com' AND active = 1");
     mysqlNoMatch =
         pick(
@@ -326,11 +297,7 @@ public class IastRegexpBenchmark {
                 + "col_x = col_y AND ".repeat(20)
                 + "active AND enabled",
             "SELECT id, name FROM users WHERE "
-<<<<<<< HEAD
-                + "col_x = col_y AND ".repeat(2000)
-=======
                 + "col_x = col_y AND ".repeat(100)
->>>>>>> origin/main
                 + "active AND enabled");
     reggieSqlMysql = RuntimeCompiler.compile(SQL_MYSQL);
     jdkSqlMysql = Pattern.compile(SQL_MYSQL);
@@ -344,22 +311,14 @@ public class IastRegexpBenchmark {
                 + "col_x = col_y AND ".repeat(20)
                 + "body = $$hello world$$ AND revision = 3",
             "SELECT * FROM docs WHERE "
-<<<<<<< HEAD
-                + "col_x = col_y AND ".repeat(2000)
-=======
                 + "col_x = col_y AND ".repeat(100)
->>>>>>> origin/main
                 + "body = $$hello world$$ AND revision = 3");
     postgresqlNoMatch =
         pick(
             scale,
             "SELECT id, title FROM docs ORDER BY id",
             "SELECT id, title FROM docs WHERE " + "col_x = col_y AND ".repeat(20) + "id = id",
-<<<<<<< HEAD
-            "SELECT id, title FROM docs WHERE " + "col_x = col_y AND ".repeat(2000) + "id = id");
-=======
             "SELECT id, title FROM docs WHERE " + "col_x = col_y AND ".repeat(100) + "id = id");
->>>>>>> origin/main
     reggieSqlPostgresql = RuntimeCompiler.compile(SQL_POSTGRESQL);
     jdkSqlPostgresql = Pattern.compile(SQL_POSTGRESQL);
     re2jSqlPostgresql = com.google.re2j.Pattern.compile(SQL_POSTGRESQL);
@@ -368,24 +327,14 @@ public class IastRegexpBenchmark {
         pick(
             scale,
             "api_key=abc123def456&user=alice&action=view",
-<<<<<<< HEAD
-            "region=us&locale=en&".repeat(20) + "api_key=abc123def456&user=alice&action=view",
-            "region=us&locale=en&".repeat(2000) + "api_key=abc123def456&user=alice&action=view");
-=======
             "region=us&locale=en&".repeat(1) + "api_key=abc123def456&user=alice&action=view",
             "region=us&locale=en&".repeat(2) + "api_key=abc123def456&user=alice&action=view");
->>>>>>> origin/main
     qobfNoMatch =
         pick(
             scale,
             "user=alice&action=view&page=1&sort=asc",
-<<<<<<< HEAD
-            "user=alice&action=view&page=1&sort=asc&" + "region=us&locale=en&".repeat(20),
-            "user=alice&action=view&page=1&sort=asc&" + "region=us&locale=en&".repeat(2000));
-=======
             "user=alice&action=view&page=1&sort=asc&" + "region=us&locale=en&".repeat(1),
             "user=alice&action=view&page=1&sort=asc&" + "region=us&locale=en&".repeat(2));
->>>>>>> origin/main
     reggieQueryObfuscator = RuntimeCompiler.compile(QUERY_OBFUSCATOR);
     jdkQueryObfuscator = Pattern.compile(QUERY_OBFUSCATOR);
     re2jQueryObfuscator = com.google.re2j.Pattern.compile(QUERY_OBFUSCATOR);

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BitStateMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BitStateMatcher.java
@@ -127,6 +127,11 @@ final class BitStateMatcher extends ReggieMatcher {
   private final LazyDFACache rejectDfa;
   private final NfaStep rejectStep;
 
+  // Scratch output for localizeForFind(), reused across calls to avoid a two-int allocation per
+  // find()/findFrom()/findMatchFrom() call — safe because a single matcher instance is never
+  // shared across threads or concurrent calls (see class-level thread-safety contract).
+  private final int[] localizeScratch = new int[2];
+
   BitStateMatcher(NFA nfa, String pattern) {
     super(pattern);
     this.nfa = nfa;
@@ -230,7 +235,7 @@ final class BitStateMatcher extends ReggieMatcher {
       fallbackCount++;
       return fallback().matches(input);
     }
-    return search(input, 0, input.length(), false, true);
+    return search(input, 0, input.length(), input.length(), false, true);
   }
 
   @Override
@@ -239,14 +244,17 @@ final class BitStateMatcher extends ReggieMatcher {
     if (singleFirstCharAscii >= 0 && input.indexOf(singleFirstCharAscii) < 0) {
       return false;
     }
-    if (rejectDfa != null && rejectDfa.findFrom(input, 0, rejectStep) < 0) {
+    int regionEnd = input.length();
+    if (!localizeForFind(input, 0, regionEnd)) {
       return false;
     }
-    if (exceedsBudget(input.length())) {
+    int scanStart = localizeScratch[0];
+    int spanEnd = localizeScratch[1];
+    if (exceedsBudget(spanEnd - scanStart)) {
       fallbackCount++;
       return fallback().find(input);
     }
-    return search(input, 0, input.length(), true, false);
+    return search(input, scanStart, spanEnd, regionEnd, true, false);
   }
 
   @Override
@@ -256,14 +264,17 @@ final class BitStateMatcher extends ReggieMatcher {
     if (singleFirstCharAscii >= 0 && input.indexOf(singleFirstCharAscii, clamped) < 0) {
       return -1;
     }
-    if (rejectDfa != null && rejectDfa.findFrom(input, clamped, rejectStep) < 0) {
+    int regionEnd = input.length();
+    if (!localizeForFind(input, clamped, regionEnd)) {
       return -1;
     }
-    if (exceedsBudget(input.length() - clamped)) {
+    int scanStart = localizeScratch[0];
+    int spanEnd = localizeScratch[1];
+    if (exceedsBudget(spanEnd - scanStart)) {
       fallbackCount++;
       return fallback().findFrom(input, start);
     }
-    boolean won = search(input, clamped, input.length(), true, false);
+    boolean won = search(input, scanStart, spanEnd, regionEnd, true, false);
     return won ? winCaptures[0] : -1;
   }
 
@@ -273,7 +284,7 @@ final class BitStateMatcher extends ReggieMatcher {
       fallbackCount++;
       return fallback().match(input);
     }
-    boolean won = search(input, 0, input.length(), false, true);
+    boolean won = search(input, 0, input.length(), input.length(), false, true);
     return won ? buildCaptureResult(input, winCaptures, groupCount) : null;
   }
 
@@ -289,14 +300,17 @@ final class BitStateMatcher extends ReggieMatcher {
     if (singleFirstCharAscii >= 0 && input.indexOf(singleFirstCharAscii, clamped) < 0) {
       return null;
     }
-    if (rejectDfa != null && rejectDfa.findFrom(input, clamped, rejectStep) < 0) {
+    int regionEnd = input.length();
+    if (!localizeForFind(input, clamped, regionEnd)) {
       return null;
     }
-    if (exceedsBudget(input.length() - clamped)) {
+    int scanStart = localizeScratch[0];
+    int spanEnd = localizeScratch[1];
+    if (exceedsBudget(spanEnd - scanStart)) {
       fallbackCount++;
       return fallback().findMatchFrom(input, start);
     }
-    boolean won = search(input, clamped, input.length(), true, false);
+    boolean won = search(input, scanStart, spanEnd, regionEnd, true, false);
     return won ? buildCaptureResult(input, winCaptures, groupCount) : null;
   }
 
@@ -307,7 +321,7 @@ final class BitStateMatcher extends ReggieMatcher {
       return fallback().matchesBounded(input, start, end);
     }
     String region = input.subSequence(start, end).toString();
-    return search(region, 0, region.length(), false, true);
+    return search(region, 0, region.length(), region.length(), false, true);
   }
 
   @Override
@@ -317,11 +331,57 @@ final class BitStateMatcher extends ReggieMatcher {
       return fallback().matchBounded(input, start, end);
     }
     String region = input.subSequence(start, end).toString();
-    boolean won = search(region, 0, region.length(), false, true);
+    boolean won = search(region, 0, region.length(), region.length(), false, true);
     if (!won) return null;
     MatchResult r = buildCaptureResult(region, winCaptures, groupCount);
     if (start == 0) return r;
     return shiftResult(r, start, input.toString());
+  }
+
+  /**
+   * Computes localized {@code (scanStart, spanEnd)} search bounds for an unanchored find-family
+   * call over {@code input[from, regionEnd)}, using {@link #rejectDfa}'s sound bounds to avoid
+   * paying the full-region {@link #fallback()} cost when only a narrow sub-region can possibly
+   * contain a match.
+   *
+   * <p>{@link LazyDFACache#findFrom} returns the leftmost position where the reject-DFA's
+   * over-approximating language matches, at or after {@code from}. Because the real pattern's
+   * language is a subset of the over-approximation's (soundness), no real match can start before
+   * that position — so it is a sound lower bound on the real leftmost match start, and every
+   * position in {@code [from, scanStart)} can be skipped entirely, independent of whether the
+   * budget is exceeded. This alone often keeps a search under budget that the raw {@code [from,
+   * regionEnd)} span would have exceeded.
+   *
+   * <p>If the narrowed span still exceeds budget, {@link LazyDFACache#findEnd} additionally bounds
+   * how far any match beginning at/after {@code scanStart} can extend (same soundness argument,
+   * upper-bound direction — see its javadoc) — narrowing {@code spanEnd} accordingly. This mirrors
+   * {@code PikeVMMatcher.findPosFrom}'s identical use of {@code findEnd} to tighten its own scan
+   * loop without touching the true region end used for anchor checks (see {@link #search}'s {@code
+   * regionEnd} parameter doc).
+   *
+   * @return {@code false} if {@link #rejectDfa} proves no match exists in {@code [from, regionEnd)}
+   *     (caller should return its own no-match result immediately, no search needed); {@code true}
+   *     otherwise, with the bounds to search written to {@link #localizeScratch} (which may still
+   *     exceed budget — the caller must still check {@link #exceedsBudget})
+   */
+  private boolean localizeForFind(String input, int from, int regionEnd) {
+    int scanStart = from;
+    if (rejectDfa != null) {
+      scanStart = rejectDfa.findFrom(input, from, rejectStep);
+      if (scanStart < 0) {
+        return false;
+      }
+    }
+    int spanEnd = regionEnd;
+    if (rejectDfa != null && exceedsBudget(spanEnd - scanStart)) {
+      int hi = rejectDfa.findEnd(input, scanStart, regionEnd, rejectStep);
+      if (hi >= scanStart && !exceedsBudget(hi - scanStart)) {
+        spanEnd = hi;
+      }
+    }
+    localizeScratch[0] = scanStart;
+    localizeScratch[1] = spanEnd;
+    return true;
   }
 
   // findAll / findMatchInto are inherited from ReggieMatcher's default implementations, built on
@@ -368,11 +428,26 @@ final class BitStateMatcher extends ReggieMatcher {
    * PikeVMMatcher.runMatches} only accepting when {@code pos == regionEnd}); the DFS simply
    * backtracks and keeps exploring other continuations.
    *
+   * <p>{@code regionEnd} is the TRUE end of the caller's region — always {@code input.length()} for
+   * {@code find}/{@code findFrom}/{@code findMatchFrom}, even when {@code spanEnd} has been
+   * narrowed below it (see {@link #localizeForFind}). It is used only for {@code $}/{@code \z}/
+   * {@code \b}/end-multiline anchor checks, which must see the real end of input regardless of how
+   * far the DFS itself has been bounded to scan — mirrors {@code PikeVMMatcher.findPosFrom}'s
+   * separation of its narrowed {@code scanLimit} from the unnarrowed {@code regionEnd} it still
+   * threads through every anchor call, for the identical reason. {@code spanEnd} is the actual
+   * scan/consume bound: the seed-reinjection loop and the consuming-leaf transition both stop
+   * there. For every caller except the find family, {@code regionEnd == spanEnd}.
+   *
    * <p>On success, {@link #winCaptures} holds the winning capture snapshot (slot 0/1 = the whole
    * match span) and this method returns {@code true}.
    */
   private boolean search(
-      String input, int scanStart, int spanEnd, boolean unanchored, boolean requireFullMatch) {
+      String input,
+      int scanStart,
+      int spanEnd,
+      int regionEnd,
+      boolean unanchored,
+      boolean requireFullMatch) {
     int spanLen = spanEnd - scanStart;
     ensureVisitedCapacity((long) stateCount * (spanLen + 1));
     visitedGeneration++;
@@ -433,7 +508,7 @@ final class BitStateMatcher extends ReggieMatcher {
         // Anchor origin is pinned to absolute 0 (regionStart argument), matching PikeVMMatcher's
         // find/findFrom semantics: ^/\A never fire at a findFrom(start>0) offset, only at true
         // input start.
-        if (!PikeVMMatcher.checkAnchor(anchor, input, pos, 0, spanEnd)) continue;
+        if (!PikeVMMatcher.checkAnchor(anchor, input, pos, 0, regionEnd)) continue;
         pushEpsilonChildrenReversed(sid, pos);
         continue;
       }

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BitStateMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BitStateMatcher.java
@@ -252,7 +252,7 @@ final class BitStateMatcher extends ReggieMatcher {
     int spanEnd = localizeScratch[1];
     if (exceedsBudget(spanEnd - scanStart)) {
       fallbackCount++;
-      return fallback().find(input);
+      return fallback().findFrom(input, scanStart) >= 0;
     }
     return search(input, scanStart, spanEnd, regionEnd, true, false);
   }
@@ -272,7 +272,7 @@ final class BitStateMatcher extends ReggieMatcher {
     int spanEnd = localizeScratch[1];
     if (exceedsBudget(spanEnd - scanStart)) {
       fallbackCount++;
-      return fallback().findFrom(input, start);
+      return fallback().findFrom(input, scanStart);
     }
     boolean won = search(input, scanStart, spanEnd, regionEnd, true, false);
     return won ? winCaptures[0] : -1;
@@ -308,7 +308,7 @@ final class BitStateMatcher extends ReggieMatcher {
     int spanEnd = localizeScratch[1];
     if (exceedsBudget(spanEnd - scanStart)) {
       fallbackCount++;
-      return fallback().findMatchFrom(input, start);
+      return fallback().findMatchFrom(input, scanStart);
     }
     boolean won = search(input, scanStart, spanEnd, regionEnd, true, false);
     return won ? buildCaptureResult(input, winCaptures, groupCount) : null;

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BitStateMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BitStateMatcher.java
@@ -81,6 +81,14 @@ final class BitStateMatcher extends ReggieMatcher {
   private final CharSet[][] transitionCharSets;
   private final int[][] transitionTargets;
 
+  // Flattened per-state anchor/group metadata, indexed by state id, so the hot DFS loop never
+  // dereferences the heavyweight NFA.NFAState object (statesById[sid]) just to read these 3
+  // fields on every pop -- async-profiler showed that pointer-chase as the single largest DFS
+  // leaf-frame cost. null / -1 sentinels replace NFAState's null AnchorType / boxed Integer.
+  private final NFA.AnchorType[] anchorBySid;
+  private final int[] enterGroupBySid;
+  private final int[] exitGroupBySid;
+
   // Input-independent structures, preallocated once (design §5): live capture slots and the
   // winning snapshot. Sized 2 * (groupCount + 1): slot 2*g is group g's start, 2*g+1 its end.
   private final int[] caps;
@@ -139,8 +147,15 @@ final class BitStateMatcher extends ReggieMatcher {
     epsilonTargets = new int[stateCount][];
     transitionCharSets = new CharSet[stateCount][];
     transitionTargets = new int[stateCount][];
+    anchorBySid = new NFA.AnchorType[stateCount];
+    enterGroupBySid = new int[stateCount];
+    exitGroupBySid = new int[stateCount];
     for (int i = 0; i < stateCount; i++) {
       NFA.NFAState s = statesById[i];
+
+      anchorBySid[i] = s.anchor;
+      enterGroupBySid[i] = s.enterGroup == null ? -1 : s.enterGroup;
+      exitGroupBySid[i] = s.exitGroup == null ? -1 : s.exitGroup;
 
       List<NFA.NFAState> eps = s.getEpsilonTransitions();
       int[] epsIds = new int[eps.size()];
@@ -413,26 +428,27 @@ final class BitStateMatcher extends ReggieMatcher {
         caps[0] = pos;
       }
 
-      NFA.NFAState s = statesById[sid];
-
-      if (s.anchor != null) {
+      NFA.AnchorType anchor = anchorBySid[sid];
+      if (anchor != null) {
         // Anchor origin is pinned to absolute 0 (regionStart argument), matching PikeVMMatcher's
         // find/findFrom semantics: ^/\A never fire at a findFrom(start>0) offset, only at true
         // input start.
-        if (!PikeVMMatcher.checkAnchor(s.anchor, input, pos, 0, spanEnd)) continue;
+        if (!PikeVMMatcher.checkAnchor(anchor, input, pos, 0, spanEnd)) continue;
         pushEpsilonChildrenReversed(sid, pos);
         continue;
       }
 
       // Group-entry/-exit capture writes, with undo (design §3.3). Pushed before this state's
       // children so the RESTORE pops only after the whole subtree below this state is done.
-      if (s.enterGroup != null) {
-        int slot = 2 * s.enterGroup;
+      int enterGroup = enterGroupBySid[sid];
+      if (enterGroup >= 0) {
+        int slot = 2 * enterGroup;
         pushRestore(slot, caps[slot]);
         caps[slot] = pos;
       }
-      if (s.exitGroup != null) {
-        int slot = 2 * s.exitGroup + 1;
+      int exitGroup = exitGroupBySid[sid];
+      if (exitGroup >= 0) {
+        int slot = 2 * exitGroup + 1;
         pushRestore(slot, caps[slot]);
         caps[slot] = pos;
       }
@@ -530,18 +546,32 @@ final class BitStateMatcher extends ReggieMatcher {
     ensureStackCapacity(1);
   }
 
-  /** Grows the job stack, if needed, to fit {@code extra} more pushes beyond {@link #stackTop}. */
+  /**
+   * Grows the job stack, if needed, to fit {@code extra} more pushes beyond {@link #stackTop}.
+   *
+   * <p>Deliberately just the size check: profiling showed this method costing real self-time on the
+   * DFS hot path even though it almost never actually grows the stack (typical patterns never
+   * exceed their initial, stateCount-derived capacity) -- keeping the common case a single compare,
+   * with the doubling loop and array copies split into the separate, rarely-invoked {@link
+   * #growStack}, lets the JIT inline this trivial check at every call site instead of paying a real
+   * method-call for a branch that's almost always not taken.
+   */
   private void ensureStackCapacity(int extra) {
     int need = stackTop + extra;
     if (need > stackA.length) {
-      int newCap = stackA.length * 2;
-      while (newCap < need) {
-        newCap *= 2;
-      }
-      stackA = Arrays.copyOf(stackA, newCap);
-      stackB = Arrays.copyOf(stackB, newCap);
-      stackC = Arrays.copyOf(stackC, newCap);
+      growStack(need);
     }
+  }
+
+  /** Cold path for {@link #ensureStackCapacity(int)}: doubles the job stack to fit {@code need}. */
+  private void growStack(int need) {
+    int newCap = stackA.length * 2;
+    while (newCap < need) {
+      newCap *= 2;
+    }
+    stackA = Arrays.copyOf(stackA, newCap);
+    stackB = Arrays.copyOf(stackB, newCap);
+    stackC = Arrays.copyOf(stackC, newCap);
   }
 
   // -------------------------------------------------------------------------

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BitStateMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BitStateMatcher.java
@@ -357,7 +357,10 @@ final class BitStateMatcher extends ReggieMatcher {
    * upper-bound direction — see its javadoc) — narrowing {@code spanEnd} accordingly. This mirrors
    * {@code PikeVMMatcher.findPosFrom}'s identical use of {@code findEnd} to tighten its own scan
    * loop without touching the true region end used for anchor checks (see {@link #search}'s {@code
-   * regionEnd} parameter doc).
+   * regionEnd} parameter doc). The probe itself is capped at {@code scanStart +
+   * maxBudgetableSpan()}: scanning any further can only produce an {@code hi} that still exceeds
+   * budget, so probing past that point would just pay for a scan whose result gets discarded — this
+   * way the probe never costs more than the search it is trying to avoid.
    *
    * @return {@code false} if {@link #rejectDfa} proves no match exists in {@code [from, regionEnd)}
    *     (caller should return its own no-match result immediately, no search needed); {@code true}
@@ -374,9 +377,12 @@ final class BitStateMatcher extends ReggieMatcher {
     }
     int spanEnd = regionEnd;
     if (rejectDfa != null && exceedsBudget(spanEnd - scanStart)) {
-      int hi = rejectDfa.findEnd(input, scanStart, regionEnd, rejectStep);
-      if (hi >= scanStart && !exceedsBudget(hi - scanStart)) {
-        spanEnd = hi;
+      int probeLimit = Math.min(regionEnd, scanStart + maxBudgetableSpan());
+      if (probeLimit > scanStart) {
+        int hi = rejectDfa.findEnd(input, scanStart, probeLimit, rejectStep);
+        if (hi >= scanStart && !exceedsBudget(hi - scanStart)) {
+          spanEnd = hi;
+        }
       }
     }
     localizeScratch[0] = scanStart;
@@ -402,6 +408,16 @@ final class BitStateMatcher extends ReggieMatcher {
 
   private boolean exceedsBudget(int spanLen) {
     return (long) stateCount * (spanLen + 1) > BUDGET_CELLS;
+  }
+
+  /**
+   * Largest {@code spanLen} for which {@link #exceedsBudget} is false, i.e. the widest span a
+   * {@link #search} call could still afford. Used by {@link #localizeForFind} to cap its {@link
+   * LazyDFACache#findEnd} probe: any {@code hi} beyond {@code scanStart + maxBudgetableSpan()}
+   * would exceed budget anyway, so the probe never needs to scan past it.
+   */
+  private int maxBudgetableSpan() {
+    return (int) Math.max(0, BUDGET_CELLS / stateCount - 1);
   }
 
   private PikeVMMatcher fallback() {

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BitStateMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BitStateMatcher.java
@@ -524,11 +524,7 @@ final class BitStateMatcher extends ReggieMatcher {
         // Anchor origin is pinned to absolute 0 (regionStart argument), matching PikeVMMatcher's
         // find/findFrom semantics: ^/\A never fire at a findFrom(start>0) offset, only at true
         // input start.
-<<<<<<< HEAD
         if (!PikeVMMatcher.checkAnchor(anchor, input, pos, 0, regionEnd)) continue;
-=======
-        if (!PikeVMMatcher.checkAnchor(anchor, input, pos, 0, spanEnd)) continue;
->>>>>>> origin/main
         pushEpsilonChildrenReversed(sid, pos);
         continue;
       }


### PR DESCRIPTION
### What does this PR do?

Flattens `BitStateMatcher`'s anchor/group metadata layout, splits `ensureStackCapacity`, rescales `IastRegexpBenchmark` across SHORT/MEDIUM/LONG inputs, and localizes the `find()`/`findFrom()`/`findMatchFrom()` scan region via `rejectDfa` before falling back to `PikeVMMatcher`.

### Motivation

Reduce `BitStateMatcher` overhead on the hot path, and avoid paying the full-region fallback cost for unanchored finds when only a narrow sub-region can possibly contain a match.

### Related Issue(s)



### Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [ ] Test improvement
- [ ] Build/CI change

### Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] All existing tests pass (`./gradlew build`)
- [ ] I have added tests for my changes
- [ ] I have updated documentation (if applicable)
- [ ] My commits are signed

### Performance Impact

Rescaled `IastRegexpBenchmark` across SHORT/MEDIUM/LONG inputs; localized find-family calls now often stay under `BitStateMatcher.BUDGET_CELLS` instead of falling back.

### Additional Notes

Base of a stacked PR: #105 (TDFA capture-engine spike) is stacked on top of this branch.