### PR TITLE
feat: TDFA Phase 0/0.5 spike — Laurikari register-vector DFA for capture tags

### DIFF
--- a/doc/2026-07-10-tdfa-capture-engine-design.md
+++ b/doc/2026-07-10-tdfa-capture-engine-design.md
@@ -1,0 +1,345 @@
+# TDFA (tagged-DFA) capture engine — design
+
+Status: **draft / not started**. This is a forward design for a multi-week investment, written
+to support a go/no-go decision. No code changes are proposed alongside this document.
+
+## 1. Problem
+
+`BitStateMatcher` (the bounded-backtracking DFS capture engine) falls back to `PikeVMMatcher`
+(plain PikeVM thread simulation) whenever `stateCount * (spanLen + 1) > BUDGET_CELLS`
+(`BitStateMatcher.BUDGET_CELLS = 1 << 18`). For `SQL_ANSI` (97 NFA states) this threshold is
+~2700 input characters; the LONG-scale case of the `IastRegexpBenchmark` `SqlAnsiFind`/
+`SqlMysqlFind`/`SqlPostgresqlFind` benchmarks (`@Param("scale")`, added in
+`reggie-benchmark/.../IastRegexpBenchmark.java` on this branch, `perf/bitstate-hot-loop-flattening`
+commit `a5287c7` — the scale parameter does not exist on `main`) exceeds it, so every `find()` at
+that scale is served entirely by `PikeVMMatcher`'s full thread simulation.
+
+Measured effect (full SHORT→MEDIUM→LONG run, 53 methods × 3 scales, all 42 scaled inputs
+independently verified to match/not-match as intended before trusting the throughput numbers):
+LONG-scale input for these three benchmarks is `"col_x = col_y AND ".repeat(2000)` plus a fixed
+~75-char match/no-match suffix, ≈37KB. reggie/RE2J on `find()` drops from ~1.6x ahead at
+SHORT/MEDIUM to a genuine loss at LONG:
+
+| benchmark | reggie/jdk SHORT→MED→LONG | reggie/re2j SHORT→MED→LONG |
+|---|---|---|
+| `SqlAnsiFind` | 0.63x → 0.62x → 0.33x | 1.63x → 1.64x → **0.86x** |
+| `SqlMysqlFind` | 0.66x → 0.60x → 0.31x | 1.75x → 1.67x → **0.84x** |
+| `SqlPostgresqlFind` | 0.51x → 0.45x → 0.23x | 1.73x → 1.68x → **0.86x** |
+
+The MEDIUM→LONG degradation is real but ~2x, not the ~2000x an earlier draft of this section
+claimed — that figure had no benchmark backing it (caught by adversarial review; struck here,
+no replacement source exists) and is retracted. The correct, evidence-backed claim is narrower:
+these three patterns cross from *winning* against RE2J to *losing* against it specifically between
+MEDIUM and LONG scale, consistent with LONG being the only scale that crosses the `BUDGET_CELLS`
+threshold above.
+
+**Open, unattributed observation from the same run** (not folded into the analysis below, no
+root cause established yet): `LdapFind`, `UrlAuthFind`, and `UrlAuthCapture` degrade far worse
+over the same SHORT→LONG range — down to 0.02x–0.09x vs JDK at LONG (a 10–50x loss, not SQL's
+~3x), and `UrlQueryFind` drops to 0.93x vs RE2J at LONG (SQL's `Find` cases don't cross 1.0x until
+LONG either). Whether this is the same `BUDGET_CELLS` mechanism or a different bottleneck — LDAP's
+`LITERAL` group and the URL `AUTHORITY` branch are both "matched-region growth" inputs, unlike
+SQL's "scan-prefix growth" — is unconfirmed and out of scope for this document; flagged here so it
+isn't lost.
+
+Async-profiler confirmed the cost is real interpreter tax inside `PikeVMMatcher`'s own
+thread-simulation loop (per-character subset advance + capture-array bookkeeping across all live
+threads), not allocation or GC. Two cheaper mitigations were spiked and rejected before this
+document:
+
+- **Fixed-size windowed `BitStateMatcher` scan** (sequential windows sized to fit `BUDGET_CELLS`,
+  each an independent `search()` call). 2.9–3.4x real speedup, but **unsound**: `search()`'s
+  consuming-leaf bound hard-caps consumption at the window boundary, so a match whose content
+  (e.g. `SQL_ANSI`'s unbounded-width `'...'` literal or `/*...*/` comment) spans wider than one
+  window is silently missed. Rejected per the "only proceed if valid" gate.
+- **Dynamic window** (extend the window only while some thread is provably still alive). Requires
+  knowing *which* start position is responsible for keeping the DFA state alive at the boundary —
+  but `RejectDfaFactory`'s (and `PikeVMMatcher.findStep`'s) shared self-anchoring design discards
+  that attribution by construction: `RejectDfaFactory.build()`'s step function unions a fresh
+  `startAll` closure into *every* step's result unconditionally (`RejectDfaFactory.java`, the
+  `union(tc, startAll)` line), not only on death. This is why `LazyDFACache.findFrom`/`findEnd`
+  degrade to non-localizing behavior on patterns like `SQL_ANSI` whose broad alternation (7+
+  branches covering common characters) keeps some thread alive almost everywhere in prose-like
+  filler — the merged DFA state essentially never reaches a genuine `DEAD` transition. Recovering
+  per-candidate attribution to make the window boundary decision soundly is exactly tag/priority
+  tracking — i.e. the same investment as a TDFA, not a smaller one.
+- **A non-self-anchoring find-DFA for the anchored case**, extending `PikeVMMatcher.findDfaEligible`
+  (currently restricted to patterns whose only anchors are `START`/`STRING_START`/
+  `START_MULTILINE`, handled via the mid-line/after-newline reinject-closure split in the
+  constructor around `PikeVMMatcher.java:255-282`) to end anchors and `\b`. Analysis: naively
+  dropping the every-step reinject and relying only on `LazyDFACache.findFrom`'s restart-on-`DEAD`
+  is **incorrect** — restart-on-`DEAD` only tries a new start at wherever the *previous* attempt
+  died, silently skipping intermediate candidate starts that could independently match. A
+  single-scalar "leftmost live start" tag fixes that correctness gap but reintroduces the same
+  state-space/cache-reuse tension the tag machinery below has to solve anyway, for none of the
+  capture payoff. Not pursued as a separate, smaller project — folded into this design instead.
+
+Net: there is no cheap fix left on the table. The next tier is a genuinely tagged automaton.
+
+## 2. Goals / non-goals
+
+**Goals**
+- Eliminate the fallback-cliff class of regression: give `find()`/`findFrom()`/`match()` an O(n)
+  (or near-O(n), budget-bounded) path with real capture-group boundaries, for the pattern class
+  BitState/PikeVM already serve natively (no backrefs, no lookaround assertions, no atomic
+  groups — the existing `noAssertionsOrBackrefs`/`findDfaEligible`-style eligibility boundary).
+- Preserve today's leftmost-first (Perl/PCRE greedy) priority semantics exactly, for the patterns
+  TDFA is eligible for — this is the same semantics `PikeVMMatcher`'s thread ordering already
+  implements and that `CorrectnessTest` already asserts against JDK `Pattern`. This is explicitly
+  the *wrong* semantics for `usePosixLastMatch` patterns (see §5's eligibility note) — those must
+  stay excluded, not be given leftmost-first tags.
+- Keep the existing fallback architecture pattern: eligible-but-too-large inputs degrade
+  gracefully to `PikeVMMatcher`, exactly as `BitStateMatcher` degrades today. No correctness
+  regression is acceptable; performance regression on ineligible/oversized inputs is acceptable
+  (status quo).
+
+**Non-goals**
+- Do not attempt backreferences, lookaround assertions, or atomic groups in the TDFA itself —
+  those stay on `PikeVMMatcher`/`BackrefBacktrackMatcher` exactly as today.
+- Do not change public API, `Reggie.compile()` semantics, or bytecode generation strategy
+  selection in this phase. This is a `reggie-runtime` matcher-internal change, mirroring how
+  `BitStateMatcher` itself was introduced as an additional native strategy alongside PikeVM.
+
+## 3. Background: the two existing self-anchoring DFA builders
+
+Both `RejectDfaFactory.build()` and `PikeVMMatcher`'s boolean `findDfa`/`matchesDfa` construction
+share the same shape: subset-construct over the NFA via `LazyDFACache`, with a step function that
+unions in a fresh start-closure at every character (the "self-anchoring" trick that makes one scan
+implicitly try every start position at once, in O(n) instead of the O(n²) that trying each start
+independently would cost). This buys correctness and speed for the *boolean* question ("does a
+match exist from here"), but the union at merge time is exactly what erases which candidate start
+produced which surviving thread — there is no way to ask a self-anchoring DFA "which start is
+still alive" without also tracking that as part of the state, which is the core idea below.
+
+`PikeVMMatcher.findDfaEligible` already demonstrates the one case where *no* tag tracking is
+needed: `START`/`STRING_START`/`START_MULTILINE` anchors are **past-context-only** — whether they
+fire at a position depends only on whether the previous character was `\n` (or it's position 0),
+which the step function already knows locally without threading any extra state. That's why they
+can be handled by splitting the reinject closure into "mid-line" vs "after-newline" variants
+(`reinjectClosureIds` / `reinjectAfterNlClosureIds`) instead of needing per-position tags. End
+anchors (`$`, `\Z`, `\z`, `END_MULTILINE`) and `\b` don't have this property in general — `\b`
+needs one character of lookahead (feasible, symmetric to lookbehind), but "is this the true end of
+string" is a property of `regionEnd`, which the *caller* (`search()`/`findPosFrom()`) already
+threads separately from the scan bound (see `BitStateMatcher.search`'s `regionEnd` parameter,
+added specifically so a narrowed scan bound never corrupts `$`/`\z`/`\b`/`END_MULTILINE` checks).
+The TDFA should keep that same separation: anchor *evaluation* stays a per-step/per-accept check
+against the true end of input, not something baked into subset-construction identity.
+
+## 4. What a TDFA adds: tags and registers
+
+Standard reference: Ville Laurikari, *NFAs with Tagged Transitions, their Conversion to Deterministic
+Automata and Application to Regular Expression Recognition* (2000) — the algorithm RE2/RE2J's
+authors describe but did not implement (confirmed via RE2J 1.8 source inspection this session:
+RE2J has no BitState/OnePass/TDFA tier, only a plain per-thread PikeVM `Machine.java`). This is new
+ground *relative to RE2J*, but **not relative to this codebase**: `PatternAnalyzer` already has an
+unrelated "Tagged DFA" mechanism — `MatchingStrategyResult.useTaggedDFA`
+(`PatternAnalyzer.java:3420`) drives `DFAUnrolledBytecodeGenerator.generateTaggedDFAMatching`
+(`DFAUnrolledBytecodeGenerator.java:1557`) for the `DFA_UNROLLED_WITH_GROUPS` strategy
+(`PatternAnalyzer.java:3376`, "<20 states — unrolled with inline group tracking"), and is hashed
+into `StructuralHash.java:85/135`. That mechanism solves a narrower, different problem:
+compile-time-unrolled bytecode with inline group tracking and priority-cut semantics, bounded to
+small (<20-state) explicit DFAs — it does not do Laurikari-style register-based determinization
+over arbitrarily large NFAs at runtime, which is what this design proposes. The two are
+architecturally distinct, but the shared "Tagged DFA" vocabulary is a real collision risk during
+implementation and code review — this is why the classes proposed below are named `Laurikari*`
+rather than `Tagged*`, to keep them unambiguously distinct from `useTaggedDFA`/
+`DFA_UNROLLED_WITH_GROUPS` in searches and reviews.
+
+**Tags.** Each capture-group boundary (`NFA.NFAState.enterGroup`/`exitGroup`, nullable `Integer`
+group-number fields already present in the Thompson construction) becomes a *tag*: a marker that
+must record the current input position whenever the NFA transitions through it. `groupCount`
+explicit capture groups → `2 * (groupCount + 1)` tags (open + close per group, plus the implicit
+whole-match group 0) — the same slot count `PikeVMMatcher.java:192`'s
+`int slotCount = 2 * (groupCount + 1)` already uses for `clistCaptures`/`nlistCaptures`.
+
+**Registers.** A tagged DFA state doesn't just carry an NFA-state subset (like `StateSetKey`
+today); it carries, per NFA state in the subset, a mapping from tag id → *register* (an integer
+naming a memory cell that holds a recorded position or "unset"). Transitions carry register
+*operations*: `copy(r_dst, r_src)`, `set-to-current-pos(r_dst)`, or `set-unset(r_dst)`. Concretely
+this generalizes what `PikeVMMatcher.clistCaptures[stateId]` already does at runtime (an
+`int[stateCount][slotCount]` capture array copied thread-to-thread on every step) into something
+computed and cached **once per (DFA-state, char) transition**, ahead of time, instead of being
+recomputed by walking live threads on every character of every search.
+
+**Priority/conflict resolution.** When two NFA states carrying *different* register mappings merge
+into the same subset during determinization (i.e., two "threads" reach the same NFA state), the
+existing `PikeVMMatcher` thread-list ordering already defines which one wins: earlier-added threads
+have priority (this is exactly the leftmost-first / greedy-first semantics `clistIds`/`nlistIds`
+maintain today by appending in priority order and never re-adding a state already in the list —
+see `inClist`/`inNlist` guards). The TDFA's determinization must replicate that same ordering rule
+at *build* time: when constructing the subset for a given (state, char) transition, process
+predecessor NFA states in the same priority order PikeVM's `addThread` does, and when a target NFA
+state is already in the new subset, discard the lower-priority arrival's register mapping instead
+of merging it. This is the same rule, moved from run time to build time — not a new semantics
+decision.
+
+## 5. Architecture sketch
+
+New sibling classes to the existing DFA machinery, following the same shape `LazyDFACache` /
+`RejectDfaFactory` already establish:
+
+- `LaurikariDFACache` (sibling to `LazyDFACache`): lazily-materialized, subset-constructed DFA whose
+  states are `(NFA-subset, register-mapping)` pairs, keyed for interning the same way
+  `StateSetKey` interns plain subsets today. Bounded at a cap (mirroring
+  `LazyDFACache.DEFAULT_CAP`/`BitStateMatcher.BUDGET_CELLS`); on overflow, **freeze and fall back**
+  — exactly the existing `FALLBACK` sentinel / `frozen` field pattern in `LazyDFACache`, just handed
+  off to `PikeVMMatcher` instead of to raw NFA stepping.
+- `LaurikariNfaStep`: like `NfaStep`, but returns both the next state-id set and the register
+  operations to apply, so the caller can update its own register-file array.
+- A new matcher, e.g. `LaurikariDfaMatcher extends ReggieMatcher`, or an extension of
+  `BitStateMatcher`'s existing "NATIVE" role — parallel to how `BitStateMatcher` today decides
+  per-call whether it's within budget and only asks `PikeVMMatcher` for oversized/ineligible
+  inputs. Eligibility gate: reuse `noAssertionsOrBackrefs`-style checks (no backrefs, no lookaround,
+  no atomic groups) — the same class of pattern `RejectDfaFactory`/`findDfaEligible` already carve
+  out, extended (per §3) to cover end anchors and `\b` via per-step/accept-time checks against the
+  true `regionEnd`, not via subset-identity fracturing — **and additionally excluding
+  `usePosixLastMatch` patterns** (see the eligibility note at the end of this list).
+
+**Relationship to `HybridMatcher`.** `RuntimeCompiler.shouldUseHybrid`/`compileHybrid`
+(`RuntimeCompiler.java:763-841`) already builds a "DFA for fast matching, NFA for group extraction"
+matcher today, for `MatchingStrategy.OPTIMIZED_NFA`-eligible patterns and for
+`usePosixLastMatch` patterns specifically. That is the same top-level shape TDFA's value
+proposition in §4 is pitched on (replacing per-thread capture-array copying with a cheaper,
+precomputed mechanism) — but `HybridMatcher`'s NFA extraction pass only runs over the *already
+DFA-bounded matched substring*, so its cost is independent of haystack size; it is not exposed to
+the `BUDGET_CELLS` fallback-cliff this design exists to fix. `PatternAnalyzer` already routes
+capture-ambiguous/`usePosixLastMatch` patterns to `HybridMatcher` specifically *because* the
+DFA-then-JDK-NFA extraction path gives correct POSIX-last-match group spans where leftmost-first
+NFA priority (what TDFA replicates, per §4) does not — so TDFA must not compete for that pattern
+class; see the eligibility exclusion above. For the general capturing patterns `HybridMatcher`
+already serves cheaply, TDFA offers no motivating win (Hybrid's cost model is already
+haystack-size-independent) — TDFA's target is specifically the fallback-cliff class in §1, which is
+disjoint from what `HybridMatcher` handles today. Phase 2 (§7) should confirm this stays disjoint
+in `PatternAnalyzer`'s eventual strategy table rather than assume it.
+
+**Eligibility gate must also exclude `usePosixLastMatch` patterns.** `PatternAnalyzer` sets
+`usePosixLastMatch` (`PatternAnalyzer.java:3426`, `needsPosixSemantics` driven purely by AST shape —
+capturing groups inside a repeating quantifier, e.g. `(a|a)+`) independently of the
+backref/lookaround/atomic-group checks `findDfaEligible`/`noAssertionsOrBackrefs` perform; grep
+confirms neither method references it. A capture-ambiguous pattern like `(a|a)+` would pass the
+gate as literally described above and get routed through leftmost-first tagged determinization,
+reproducing the exact wrong-group-span bug `usePosixLastMatch`/`HybridMatcher` routing exists to
+avoid — and critically, §6's proposed oracle (`PikeVMMatcher`) is *also* leftmost-first, so
+differential fuzzing against it would not catch this specific divergence either. The eligibility
+gate must check `usePosixLastMatch` explicitly, not rely on the backref/lookaround/atomic-group
+checks to cover it, and any fuzz corpus for this pattern class needs `java.util.regex` (not
+`PikeVMMatcher`) as the oracle.
+
+**Register-file management at runtime.** Once a `LaurikariDFACache` transition is resolved, applying
+its register ops to a small `int[]` register file per active scan is O(registers-touched-this-step),
+not O(live-threads) — this is the actual performance win: it replaces PikeVM's per-character,
+per-thread capture-array copy with a per-character, precomputed, DFA-transition-indexed op list.
+
+**State-space bounding.** Register mappings are structurally bounded the same way plain subsets
+are (finitely many NFA states × finitely many distinct "which predecessor thread's mapping won"
+outcomes per merge), so in principle the reachable `(subset, mapping)` space is still finite, but
+it can be much larger than the plain-subset space `LazyDFACache` already builds for the same
+pattern — this is the paper's well-known practical risk, and needs the same lazy-materialize +
+cap + freeze-to-fallback discipline `LazyDFACache` already uses, not upfront full determinization.
+
+**Explicit guardrail: no post-hoc minimization by subset-equivalence.** The interning described
+above (hash-consing exact `(subset, mapping)` state identity during determinization) is safe —
+it is what determinization already is. Do **not** additionally minimize the resulting automaton by
+classical Hopcroft/Moore-style equivalence (merging two states whose *future* NFA-subset behavior
+is identical): this is a well-known Laurikari-family correctness pitfall — two states can agree on
+every future transition while holding different live register mappings, and merging them silently
+corrupts which register produced which capture. If state-space size ever needs a second lever
+beyond cap-and-fallback, the correct technique is *operation-aware* minimization/register
+allocation (already named, without being resolved, in `doc/2026-07-05-reggie-vs-re2j-algorithm-research.md`
+item 2) — not naive subset-equivalence. This is called out explicitly here because nothing in the
+existing `LazyDFACache`/`RejectDfaFactory` code this design models itself on performs any
+minimization at all (they intern by exact subset identity only), so there is no established local
+precedent to lean on if a future implementer reaches for it as a blowup mitigation.
+
+## 6. Correctness strategy
+
+- **Ground truth**: `PikeVMMatcher`'s existing thread simulation (already checked against JDK
+  `Pattern` via `CorrectnessTest`) is the oracle. Every `LaurikariDFACache`-served `find`/`match`/
+  `findFrom` call must be differentially fuzzed against the same call on `PikeVMMatcher` over the
+  existing fuzz corpus infrastructure — this work must introduce zero *net-new* divergences on top
+  of whatever `AlgorithmicFuzzTest.KNOWN_FINDINGS_BUDGET` currently is (re-check the live constant;
+  as of this writing it is 28, not 0 — the `project_reggie_prod_readiness` memory note's "zero known
+  divergences" claim is stale relative to the current fuzz window) before any pattern class is
+  allowed to route to the new engine.
+- **Priority/merge correctness is the highest-risk correctness surface**, not the plain-subset
+  transitions (those are already proven by `LazyDFACache`/`RejectDfaFactory`'s existing tests).
+  Needs dedicated adversarial cases: nested groups with empty-body iterations (the same class
+  `groupBodyNullable`/trailing-empty-iteration rebind logic in `PikeVMMatcher` exists to handle
+  correctly today), unrolled-quantifier multi-anchor paths (`clistViaMultipleAnchors`'s reason for
+  existing), and alternation branches with shared prefixes but different capture groups.
+- **Anchor correctness**: end-anchor/`\b` checks must be verified identical to
+  `PikeVMMatcher.checkAnchor`'s existing switch-case semantics, using the same `regionEnd`-vs-scan-
+  bound separation already fixed once for `BitStateMatcher.search` this session — do not
+  re-introduce that class of bug in the new engine.
+
+## 7. Phased rollout (de-risking the most uncertain parts first)
+
+**Phase 0 — spike, boolean/localization-only tag.** Build a `LaurikariDFACache` variant with exactly
+*one* tag: "leftmost live start position" (no per-group captures). This is the "single min-start
+tag" middle ground identified during the dynamic-window analysis — a strict, much smaller subset
+of the full design (trivial conflict resolution: smaller start always wins, no group-ambiguity
+logic) that directly fixes the motivating fallback-cliff problem (real localization for `find()`
+on `SQL_ANSI`-shaped patterns) even if full capture tags are never built. Success criteria: (a)
+correct localization on the exact adversarial case that broke the windowed-scan prototype
+(unbounded-width literal/comment spanning what would have been a window boundary), (b) state count
+for `SQL_ANSI`-class patterns stays within a cache budget comparable to `LazyDFACache.DEFAULT_CAP`,
+(c) measurable win over the current full-`PikeVMMatcher`-punt on the LONG-scale IAST benchmarks.
+
+**Phase 0 passing is necessary but NOT sufficient evidence for Phase 1's feasibility.** With one
+tag under a total order (smaller start always wins), every register-merge has exactly one possible
+outcome — the state-space dimension §5 names as the actual risk driver ("finitely many... outcomes
+per merge") is pinned at 1 in this spike. Phase 1's real risk comes from `2 * (groupCount + 1)`
+*independent* open/close tags whose winning predecessor can differ tag-by-tag across nesting,
+alternation, and quantifier unrolling — a thread can be "ahead" on one group's tag and "behind" on
+another simultaneously, which does not collapse via a total order the way a single scalar does.
+Phase 0 cannot exercise that combinatorial mechanism at all, so its success measures only the
+cap-and-fallback plumbing, not the actual multi-tag blowup risk.
+
+**Phase 0.5 — intermediate checkpoint, 2-3 independent tags.** Before committing to the full
+`2 * (groupCount + 1)`-tag Phase 1, spike a small, fixed number of independent tags (e.g. two
+nested groups, or one group inside a quantifier) specifically to exercise cross-tag merge conflicts
+— the mechanism Phase 0 cannot. This is the cheapest available signal on whether the real
+multi-tag state-space blowup is tractable before the multi-week Phase 1 investment. Only proceed to
+Phase 1 if this checkpoint's state-space growth is still within a workable budget.
+
+**Phase 1 — full capture tags**, only if Phase 0 *and* Phase 0.5 succeed: extend to
+`2 * (groupCount + 1)` tags per the full design in §4, gated on the eligibility boundary in §5
+(including the `usePosixLastMatch` exclusion), differentially fuzzed per §6.
+
+**Phase 2 — integration**: wire into `BitStateMatcher`'s existing decision point (budget check →
+fallback selection) as a new, preferred-when-eligible tier, or as a new strategy in
+`PatternAnalyzer`'s strategy selection — decide based on Phase 1 findings about how cleanly it
+composes with the existing bytecode-generation dual-path rule (`RuntimeCompiler.java` /
+`ReggieMatcherBytecodeGenerator.java`) if compile-time codegen support is later desired. Runtime-
+only integration (skip bytecode generation) is the lower-risk default for this phase.
+
+## 8. Effort and risk
+
+This is a multi-week R&D effort, not a spike-sized change — comparable in scope to the original
+`BitStateMatcher` capture-engine build (shipped in PR #94, 2026-07-07) but with a genuinely novel
+determinization algorithm (subset construction is well-understood in this codebase; tagged subset
+construction with priority-ordered register-merge is not) rather than an adaptation of an existing
+technique. Key risks:
+
+| Risk | Mitigation |
+|---|---|
+| Tagged state-space blowup makes the cache unusable for real patterns | Phase 0.5's multi-tag checkpoint measures this — Phase 0 alone does NOT, since its single total-ordered tag can't exercise cross-tag merge conflicts (§7) |
+| Priority/merge conflict resolution subtly diverges from PikeVM's leftmost-first semantics on some AST shape | Differential fuzzing against `PikeVMMatcher` as oracle before any pattern class routes to the new engine (§6) |
+| Anchor handling (end anchors, `\b`) reintroduces the `regionEnd`-vs-scan-bound bug class already found and fixed once this session | Explicit test mirroring `BitStateMatcher.search`'s `regionEnd` separation; do not bake anchor satisfaction into subset identity |
+| `usePosixLastMatch` capture-ambiguous patterns (e.g. `(a|a)+`) silently get leftmost-first tags, reproducing the wrong-group-span bug `HybridMatcher` exists to avoid | Eligibility gate explicitly excludes `usePosixLastMatch` (§5); fuzz that pattern class against `java.util.regex`, not `PikeVMMatcher`, since PikeVMMatcher shares the same blind spot |
+| Effort doesn't pay off if the fallback-cliff pattern class is rare in practice | Phase 0's success criteria are tied directly to the measured IAST LONG-scale regression, not a hypothetical |
+
+## 9. Alternatives if this is not greenlit
+
+Two cheaper mitigations remain available independent of this design, already identified this
+session and not requiring any of the above:
+
+1. **Raise `BUDGET_CELLS`** (`BitStateMatcher.java:61`) to push the fallback-cliff threshold
+   further out. Cheap, does not eliminate the cliff, just documents/moves it — reasonable as an
+   interim step regardless of whether TDFA is pursued.
+2. **Accept and document the residual cliff** as a known, structural, PikeVM-simulation-overhead
+   limitation (consistent with how `doc/agents-fallback-and-limitations.md` already documents
+   other performance-only gaps).
+
+Both are non-exclusive with pursuing this design later; neither requires reverting if TDFA work
+starts.

--- a/doc/2026-07-10-tdfa-capture-engine-impl-plan.md
+++ b/doc/2026-07-10-tdfa-capture-engine-impl-plan.md
@@ -1,0 +1,479 @@
+# TDFA (tagged-DFA) capture engine — Implementation Plan
+
+**Date:** 2026-07-10
+**Design:** [doc/2026-07-10-tdfa-capture-engine-design.md](2026-07-10-tdfa-capture-engine-design.md)
+**Status:** not started — this plan is for a go/no-go decision, same as the design doc. Phase 0 is
+the only phase authorized to start without a further checkpoint; every later phase is gated on the
+previous one's exit criteria (see design §7).
+
+---
+
+## 0. Prerequisites and conventions
+
+- Build/test: `./gradlew :reggie-runtime:test :reggie-integration-tests:test`
+- Spotless: `./gradlew spotlessApply` before every push
+- Debug tool: `./gradlew :reggie-runtime:debugPattern -Ppattern="..."` to inspect strategy/bytecode
+  routing for any pattern touched by this work
+- New runtime classes go in `reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/`; new tests
+  in the sibling `src/test` tree, mirroring `RejectDfaFactoryTest`'s reflection-based access pattern
+  for package-private classes
+- **Naming: this is `Laurikari*`, not `Tagged*`, on purpose.** The codebase already has an
+  unrelated "Tagged DFA" mechanism — `PatternAnalyzer.MatchingStrategyResult.useTaggedDFA`
+  (`PatternAnalyzer.java:3420`) drives `DFAUnrolledBytecodeGenerator.generateTaggedDFAMatching`
+  for the `DFA_UNROLLED_WITH_GROUPS` strategy (compile-time-unrolled bytecode, inline group
+  tracking, bounded to <20-state explicit DFAs — a different technique for a different, smaller
+  problem than what this plan builds). Every new class here (`LaurikariNfaStep`,
+  `LaurikariDFACache`, `LaurikariDfaMatcher`, `LaurikariEligibility`, ...) is named after the
+  algorithm (design §4) specifically to stay unambiguous from `useTaggedDFA`/
+  `DFA_UNROLLED_WITH_GROUPS` in grep/search and code review. Do not rename these back to
+  `Tagged*` even if it reads more naturally — that's the collision this naming avoids.
+- **Two distinct correctness oracles are in play, not one** — the design doc's §6 says
+  "`PikeVMMatcher` is the oracle," which is correct for isolating this-engine-specific bugs
+  quickly, but the project's actual system-of-record fuzz harness
+  (`reggie-integration-tests/.../AlgorithmicFuzzTest.java` +
+  `.../fuzz/RegexFuzzOracle.java`) uses **JDK `Pattern` as the oracle**, per
+  `RegexFuzzOracle.java:30`'s class doc ("The JDK is the oracle; any divergence is reported...").
+  This plan uses both, at different stages:
+  - **Fast, engine-isolating checks** (Phases 0–1, run constantly during development): new engine
+    vs `PikeVMMatcher`, same call, same input — cheap, in-process, no fuzz-harness plumbing needed.
+  - **System-of-record validation** (Phase 1 exit, Phase 2): once the new engine is wired to
+    actually receive real patterns, extend `AlgorithmicFuzzTest`'s existing pattern-generation
+    window to include its eligible shapes and let the existing JDK-oracle harness catch anything
+    the PikeVMMatcher-only comparison missed (this also protects against the class of bug where
+    the new engine and `PikeVMMatcher` agree with each other but both diverge from JDK — unlikely
+    given `PikeVMMatcher`'s current fuzz baseline (see below), but not provably impossible).
+  - `usePosixLastMatch` patterns are explicitly excluded from eligibility (design §5) — their
+    correctness is unaffected by this work and continues to be covered by whatever already exercises
+    `HybridMatcher`.
+- **Current fuzz baseline is NOT zero** — `AlgorithmicFuzzTest.java:64` declares
+  `KNOWN_FINDINGS_BUDGET = 28` for the currently-active 25k–50k pattern window (two tracked bugs,
+  B-CGG-1/B-SQG-1, per that file's own class-doc history). The `project_reggie_prod_readiness`
+  memory note this plan and its design doc both cited ("fuzzer currently at zero known
+  divergences") is stale relative to that constant — **re-check the live value of
+  `KNOWN_FINDINGS_BUDGET` before treating any number in this plan as current**; every "must not
+  regress the baseline" criterion below means "must not increase whatever that constant is at
+  the time," not literally zero.
+- No commits without being asked; this plan produces code across several PRs, one per phase at
+  minimum (see §5 below) — do not batch phases into a single PR.
+
+---
+
+## 1. Phase 0 — boolean/localization-only single-tag spike
+
+**Goal** (design §7): prove a `LaurikariDFACache` with exactly one tag ("leftmost live start
+position") gives sound, tight localization for `find()` on `SQL_ANSI`-shaped patterns, without
+committing to full capture semantics yet.
+
+**Explicitly NOT this phase's job** (see design §7's "necessary but not sufficient" caveat):
+proving the multi-tag state-space is tractable. That's Phase 0.5. Do not read a Phase 0 pass as
+evidence for Phase 1's feasibility.
+
+### Task 0.1 — `LaurikariNfaStep` interface
+
+**File (new):** `reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariNfaStep.java`
+
+```java
+/**
+ * One tagged-NFA step: given active (state, register-mapping) pairs and a character, returns the
+ * next active state ids together with the register operations each transition carries.
+ *
+ * <p>Phase 0 uses exactly one tag (register slot 0 = "candidate start position"); later phases
+ * generalize {@code registerCount}. Kept as a separate interface from {@link NfaStep} rather than
+ * changing NfaStep's shape, matching how {@link RejectDfaFactory}/{@link PikeVMMatcher} already
+ * keep multiple independent NfaStep-shaped lambdas per purpose.
+ */
+@FunctionalInterface
+interface LaurikariNfaStep {
+  /**
+   * @param curStates active NFA state ids (subset)
+   * @param curRegs curStates[i]'s register file, i.e. curRegs[i] is state curStates[i]'s tag-0
+   *     value (the candidate start position that reached it, or -1 if none has)
+   * @param c the character being consumed
+   * @return next active state ids and their per-state register files, merged/deduped per the
+   *     priority rule in design §4 (earlier-priority arrival's register wins on merge)
+   */
+  LaurikariStepResult apply(int[] curStates, int[] curRegs, int c);
+}
+```
+
+**New small value type**, same file or `LaurikariStepResult.java`:
+```java
+final class LaurikariStepResult {
+  final int[] states;
+  final int[] regs; // regs[i] corresponds to states[i]
+  LaurikariStepResult(int[] states, int[] regs) { this.states = states; this.regs = regs; }
+}
+```
+
+**Completion criterion:** compiles; no behavior yet.
+
+### Task 0.2 — `LaurikariDFACache` (single-register specialization)
+
+**File (new):** `reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDFACache.java`
+
+Model directly on `LazyDFACache` (read that class in full before starting — this task is a
+close structural port, not a fresh design):
+- State key changes from `StateSetKey` (subset only) to a new `LaurikariStateSetKey` that hashes/equals
+  on `(sortedStates, perStateRegisterValue)` pairs — two states with the same subset but different
+  register values are different DFA states (design §5's "State-space bounding" paragraph).
+- Keep `DEFAULT_CAP`, `UNCACHED`/`DEAD`/`FALLBACK` sentinels, and the `frozen` freeze-on-cap-hit
+  behavior verbatim — same lazy-materialize discipline, same fallback contract.
+- `findFrom`/`findEnd` equivalents don't apply in the same shape here — Phase 0's actual entry
+  point is closer to a direct replacement for `RejectDfaFactory`'s self-anchoring find, but instead
+  of unioning a fresh `startAll` closure every step (which erases attribution, design §1/§3), each
+  merge keeps the **smaller** register value in a genuine tie (that's the whole point: this DFA can
+  answer "which start is this" because ties resolve by an explicit rule instead of by an
+  unconditional union).
+- Do **not** implement the general `N`-tag register-merge machinery here — hardcode single-register
+  (`int`, not `int[]`) for this phase; Task 0.5.x is where it generalizes. Keeping Phase 0's
+  implementation deliberately narrow is what makes it fast to build and easy to reason about; don't
+  let scope creep from "this will need to generalize eventually" pull Phase 1's machinery in early.
+
+**Completion criterion:** unit tests (new `LaurikariDFACacheTest`, modeled on
+`RejectDfaFactoryTest`'s reflection-based access pattern) covering:
+- Simple literal, alternation with multiple leading chars (same base cases as
+  `RejectDfaFactoryTest` — confirms the plain-subset side of this still works).
+- **The adversarial case that killed the windowed-scan prototype** (design §1): a pattern with an
+  unbounded-width literal/comment construct (reuse `SQL_ANSI`'s `'...'`/`/*...*/` shape, or a
+  minimal standalone repro) over an input where the real match's content spans wider than
+  `BUDGET_CELLS`'s implied window — must correctly report the true leftmost start, not silently
+  narrow past it.
+- A case exercising genuine merge ties (two distinct start positions both reaching the same NFA
+  state at the same position) — confirms the "smaller register wins" rule, not just the trivial
+  single-candidate path.
+
+### Task 0.3 — Spike harness / measurement
+
+Not a shippable matcher yet — a throwaway (but committed, since it's the evidence this phase exists
+to produce) test or small `main()` that:
+1. Builds `LaurikariDFACache` over `SQL_ANSI`'s NFA (reuse `IastRegexpBenchmark.SQL_ANSI`'s pattern
+   string, or the compiled NFA if more convenient).
+2. Runs it over the LONG-scale input from `IastRegexpBenchmark` (confirm branch has the rescale —
+   it does now, this branch is rebased onto `perf/bitstate-hot-loop-flattening`).
+3. Reports: (a) the localized start/end bounds returned vs. the real match's actual bounds (must be
+   exact for a single-tag scheme — there's no ambiguity to approximate away), (b) total distinct
+   DFA states materialized, (c) wall-clock vs. the current full-`PikeVMMatcher`-punt path.
+
+**Exit criteria for Phase 0** (verbatim from design §7 — do not relax these):
+- (a) correct localization on the adversarial unbounded-width-literal case.
+- (b) state count for `SQL_ANSI`-class patterns stays within a budget comparable to
+  `LazyDFACache.DEFAULT_CAP` (4096).
+- (c) measurable win over the current full-`PikeVMMatcher`-punt on the LONG-scale IAST benchmarks
+  (re-run `IastRegexpBenchmark`'s `SqlAnsiFind`/`SqlMysqlFind`/`SqlPostgresqlFind` at LONG scale;
+  compare against the numbers already recorded in the design doc's §1 table).
+
+**If Phase 0 fails (b) specifically** (state count blows up even for one tag): stop here. That's a
+worse signal than anything Phase 0.5 could add — if a single scalar tag already blows up the state
+space for `SQL_ANSI`-class patterns, multi-tag will not do better. Fall back to design §9's cheaper
+mitigations (raise `BUDGET_CELLS`, or document the cliff) instead of proceeding.
+
+---
+
+## 2. Phase 0.5 — intermediate checkpoint: 2–3 independent tags
+
+**Goal** (design §7): the cheapest available signal on whether real multi-tag state-space blowup is
+tractable, before committing to Phase 1's full `2 * (groupCount + 1)`-tag machinery. This phase
+exists specifically because Phase 0's single total-ordered tag cannot exercise cross-tag merge
+conflicts at all (design §7's "necessary but not sufficient" analysis) — don't skip it under
+schedule pressure; skipping it converts this plan back into the un-derisked version the adversarial
+review flagged.
+
+### Task 0.5.1 — Generalize register file to `int[]` (small, fixed N)
+
+Extend `LaurikariDFACache`/`LaurikariNfaStep` in place (or throw away Phase 0's implementation and
+rebuild this specific class if the single-register specialization doesn't generalize cleanly —
+acceptable either way, since that code's job was to be a fast, disposable spike, not a foundation)
+to carry a small fixed-size `int[]` register file per state instead of one scalar. Conflict
+resolution: **whole-mapping priority discard**, exactly as design §4 specifies — when two arrivals
+reach the same target NFA state, the lower-priority arrival's entire register mapping is dropped,
+not merged tag-by-tag. This is the same rule as Phase 1; Phase 0.5's job is to validate it doesn't
+explode the state space at small N, not to invent a different rule.
+
+### Task 0.5.1a — Hand-derive tags for exactly the three Task 0.5.2 patterns
+
+**This task exists to break a circularity**: Task 0.5.2's patterns are real capturing-group
+patterns, but the *general* mechanism for deriving a tag id from an arbitrary `NFA.NFAState
+.enterGroup`/`exitGroup` and emitting the matching register op is Phase 1's Task 1.1/1.2 —
+which is gated on Phase 0.5 passing. Do not pull that general mechanism forward. Instead, for
+each of the three fixed patterns below, hand-pick which NFA transitions carry which of the 2-3
+tags, hardcoded per pattern (a short `switch`/`if` on the pattern string, or three separate
+tiny test-only builder methods — throwaway code, not shipped past this phase):
+- `(a+)(b+)`: 2 tags, one pair (open/close) *per group is overkill for this checkpoint's purpose* —
+  use exactly 2 tags total, one for group 1's close position and one for group 2's open position
+  (the two boundaries that actually move independently under backtracking); that's enough to
+  exercise cross-tag merge conflicts without needing a full 4-tag (2-group × open/close) model yet.
+- `(ab)+`: 2 tags — the loop body's single group's open and close, re-set on every iteration
+  (tests the loop-back re-set semantics directly, Laurikari's flagged subtlety).
+- `((a)|())*`: 3 tags — outer group open/close plus inner group open (the inner group's close is
+  the interesting nullable case: does it get correctly left unset when the empty alternative wins).
+
+Task 1.1/1.2 in Phase 1 **generalize this hand-rolled, pattern-specific derivation into an
+automatic, pattern-independent mechanism** driven by `enterGroup`/`exitGroup` directly — this task
+is intentionally the narrow, disposable version of that work, scoped to exactly three known
+patterns, not a preview of the general case.
+
+### Task 0.5.2 — Adversarial multi-tag test patterns
+
+Specifically chosen to exercise cross-tag divergence (design §7's "ahead on one tag, behind on
+another" scenario):
+- Two independent, non-nested capturing groups: `(a+)(b+)` over inputs where greedy backtracking
+  forces re-evaluation of both groups' boundaries.
+- One group inside a quantifier: `(ab)+` — tests the loop-back register semantics Laurikari's paper
+  flags as the classic subtlety (design §4's algorithmic-soundness review flagged this as the
+  highest-risk correctness surface for exactly this reason).
+- Nested groups with an empty-body iteration option: `((a)|())*` — exercises the same
+  `groupBodyNullable`-class scenario `PikeVMMatcher`'s trailing-empty-iteration rebind logic exists
+  to handle correctly today (design §6).
+
+### Task 0.5.3 — Measure and report
+
+Same three metrics as Phase 0 (state count, correctness vs. `PikeVMMatcher` on the adversarial set,
+wall-clock), but the state-count number is the one that actually matters here — compare its growth
+rate from 1→2→3 tags. Roughly linear-in-practice growth is a green light for Phase 1; anything that
+looks combinatorial already at N=3 is a stop signal (extrapolate, don't wait to hit the wall at
+N=`2*(groupCount+1)` for a real multi-group pattern).
+
+**Exit criteria for Phase 0.5:**
+- State-space growth from Phase 0 (N=1) through this checkpoint (N=2-3) stays within a workable
+  budget (no fixed number given in the design — this is a judgment call informed by the actual
+  measured curve, not a threshold to hit).
+- All three adversarial patterns in Task 0.5.2 produce capture output identical to `PikeVMMatcher`.
+- If either fails: stop here, same fallback as Phase 0's failure path (design §9). Do not proceed to
+  Phase 1 on the strength of Phase 0 alone (that's precisely the mistake the adversarial review
+  caught).
+
+---
+
+## 3. Phase 1 — full capture tags
+
+**Precondition:** Phase 0 **and** Phase 0.5 both passed their exit criteria.
+
+### Task 1.1 — Tag numbering
+
+Derive `2 * (groupCount + 1)` tags from `NFA.NFAState.enterGroup`/`exitGroup` (nullable `Integer`
+group-number fields — not `GroupEntry`/`GroupExit`, which don't exist; see design §4's corrected
+wording). Tag `2*g` = group `g`'s open, `2*g+1` = group `g`'s close, matching
+`PikeVMMatcher.java:192`'s existing `slotCount = 2 * (groupCount + 1)` layout exactly, so the
+eventual `MatchResult` construction can reuse `PikeVMMatcher`'s/`BitStateMatcher`'s existing
+`buildCaptureResult`-shaped helpers without a slot-numbering translation layer.
+
+### Task 1.2 — Full priority-ordered register-merge determinization
+
+Generalize Phase 0.5's `int[]`-register machinery to the real tag count. Determinization loop
+structure (design §4):
+1. For each `(DFA-state, char)` pair not yet cached, compute consuming transitions from every NFA
+   state in the current subset, in the same priority order `PikeVMMatcher.addThread` already
+   walks epsilon closures — grep `PikeVMMatcher.java` for `addThread` and replicate its traversal
+   order exactly, don't re-derive priority ordering from scratch.
+2. For each NFA transition consumed, compute the register ops it carries: `copy` for pass-through
+   tags, `set-to-current-pos` for the tag(s) matching this transition's `enterGroup`/`exitGroup`
+   (if any), `set-unset` where applicable (e.g. re-entering a group after a prior non-participating
+   alternation branch).
+3. When two arrivals target the same NFA state in the new subset, keep only the higher-priority
+   arrival's full register mapping (whole-mapping discard, not per-tag merge — design §4).
+4. Intern the resulting `(subset, register-mapping)` pair via `LaurikariStateSetKey`, exactly as
+   Phase 0.5 already does.
+
+**Do not add a minimization pass** (design §5's explicit guardrail) — if this task's state-space
+growth needs a second lever beyond cap-and-fallback, that's a separate, later investigation
+(operation-aware minimization, not classical subset-equivalence), not something to reach for here
+under time pressure.
+
+### Task 1.3 — Eligibility gate
+
+**New function**, e.g. `LaurikariEligibility.isEligible(NFA nfa)` (or a static method alongside the
+new matcher class) implementing design §5's gate exactly:
+- No assertions, no backrefs (same check as `RejectDfaFactory.build`'s guard / `PikeVMMatcher
+  .noAssertionsOrBackrefs`).
+- No atomic groups (same check as `findDfaEligible`).
+- Anchors: `START`/`STRING_START`/`START_MULTILINE` handled via the reinject-closure split
+  (port `PikeVMMatcher`'s `reinjectClosureIds`/`reinjectAfterNlClosureIds` construction); end
+  anchors (`$`/`\Z`/`\z`/`END_MULTILINE`) and `\b` handled as per-step/per-accept checks against the
+  caller-supplied `regionEnd`, **not** folded into subset/register identity (design §3) — reuse
+  `PikeVMMatcher.checkAnchor`'s exact switch-case semantics rather than reimplementing anchor logic.
+- **`usePosixLastMatch` explicitly excluded** — this is a separate check from the above (grep
+  confirms `findDfaEligible`/`noAssertionsOrBackrefs` never reference it; do not assume the
+  backref/lookaround/atomic-group checks cover it). Wire this from
+  `PatternAnalyzer.MatchingStrategyResult.usePosixLastMatch` (`PatternAnalyzer.java:3426`) if the
+  eligibility check runs at the `PatternAnalyzer` layer, or thread the flag through to wherever the
+  NFA-level gate runs otherwise.
+
+**Test:** a dedicated `LaurikariEligibilityTest` with one case per exclusion reason (lookahead,
+backref, atomic group, `\b`/end-anchor inside a loop — mirroring `findDfaEligible`'s own
+loop-reachability check — and `(a|a)+`-shaped `usePosixLastMatch` patterns), confirming each is
+correctly rejected, plus positive cases confirming ordinary capturing patterns pass.
+
+### Task 1.4 — `LaurikariDfaMatcher`
+
+**New file:** `reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcher.java`,
+implementing `ReggieMatcher` (mirror `BitStateMatcher`'s shape: constructor takes `(NFA nfa, String
+pattern)`, lazily-constructed `PikeVMMatcher fallback`, `fallbackCount()` observability method for
+test pinning, same as `BitStateMatcher.fallbackCount()`). At this phase, **do not wire it into
+`PatternAnalyzer`/`RuntimeCompiler` routing yet** — that's Phase 2. Build and test it standalone,
+constructed directly in tests the way `RejectDfaFactoryTest`/a hypothetical `LaurikariDFACacheTest`
+already do.
+
+### Task 1.5 — Fast correctness checks (dev-loop oracle: `PikeVMMatcher`)
+
+Property-based/parameterized test comparing `LaurikariDfaMatcher` against `PikeVMMatcher` directly,
+same pattern + input, across:
+- `find`/`findFrom`/`match`/`matches`/`findMatch`/`findMatchFrom` — every `ReggieMatcher` method
+  `LaurikariDfaMatcher` implements.
+- The Phase 0.5 adversarial set (Task 0.5.2) plus new cases: alternation branches with shared
+  prefixes but different capture groups (design §6), unrolled-quantifier multi-anchor paths
+  (mirroring what `PikeVMMatcher.clistViaMultipleAnchors` exists to handle).
+- Anchor-boundary cases specifically re-testing the `regionEnd`-vs-scan-bound separation (design
+  §6's "do not re-introduce that class of bug" — this is the same bug class fixed once already this
+  session in `BitStateMatcher.search`; write the equivalent test here proactively rather than
+  waiting to rediscover it).
+
+### Task 1.6 — System-of-record validation (oracle: JDK, via existing fuzz harness)
+
+**Task 1.6a — build the matcher-injectable oracle variant first.** `RegexFuzzOracle.check(String
+pattern, String input)` (`RegexFuzzOracle.java:97`) hard-codes
+`Reggie.compile(pattern, ReggieOptions.builder().allowJdkFallback().build())` to produce the
+`ReggieMatcher` it exercises — there is no parameter or seam to inject a caller-supplied matcher
+instance, and since Phase 2 hasn't wired `LaurikariDfaMatcher` into strategy selection,
+`compile()` can never route to it yet. Task 1.6 cannot proceed without first adding an overload (or
+sibling class, e.g. `RegexFuzzOracle.checkAgainst(String pattern, String input, ReggieMatcher
+candidate)`) that runs the same JDK-oracle comparison logic against an explicitly-supplied matcher
+instead of one obtained via `compile()`. This is new, unscoped-elsewhere plumbing — treat it as its
+own small task, not an assumed detail of Task 1.6b below.
+
+**Task 1.6b — extend the fuzz window.** Using Task 1.6a's new oracle entry point, extend
+`AlgorithmicFuzzTest`'s pattern-generation window (see that file's `BASE_SEED`/window-advance
+convention, already documented in its own class doc) to include `LaurikariEligibility`-eligible
+shapes, exercised directly against `LaurikariDfaMatcher` instances built by hand in the test (not
+through the full compile pipeline, since Phase 2 hasn't wired routing). This is the check that
+would catch a bug where the new engine and `PikeVMMatcher` happen to agree with each other but both
+diverge from JDK.
+
+**Exit criteria for Phase 1:**
+- Task 1.5 and Task 1.6b both introduce zero *net-new* divergences on top of whatever
+  `KNOWN_FINDINGS_BUDGET` currently is in `AlgorithmicFuzzTest.java` at the time this phase runs
+  (re-check the live constant — see §0's note; do not assume it is still 28, and do not assume it is
+  zero).
+- `LaurikariEligibilityTest`'s full exclusion matrix passes, including the `usePosixLastMatch` case.
+
+---
+
+## 4. Phase 2 — integration
+
+**Precondition:** Phase 1 passed.
+
+### Task 2.1 — Choose and wire the integration point
+
+Design §7 defers this decision to Phase 1 findings; this task is where that decision gets made and
+executed. Two concrete options, both already scoped in the design:
+- **Option A**: wire into `BitStateMatcher`'s existing decision point — when a call would exceed
+  `BUDGET_CELLS` (`BitStateMatcher.java:61`) and the pattern is `LaurikariEligibility`-eligible, try
+  `LaurikariDfaMatcher` before falling all the way through to `PikeVMMatcher`. Smallest-blast-radius
+  option: only changes behavior for calls that were already hitting the fallback cliff.
+- **Option B**: a new `MatchingStrategy` value (mirror the `COUNTING_GLUSHKOV` enum-addition
+  pattern used for a prior new strategy: `PatternAnalyzer.java`'s `MatchingStrategy` enum at line
+  3335, plus the exhaustive switches in `RuntimeCompiler.isNfaBacked()`/`generateBytecode()` and
+  `PatternDebugger.main()` — see `BITSTATE_CAPTURE`'s existing switch arms, e.g.
+  `PatternDebugger.java:103`, as the concrete template). Larger blast radius, but makes the new
+  engine a first-class, directly-selectable strategy rather than a fallback-of-a-fallback.
+  **This option also triggers AGENTS.md's dual-path rule** ("bytecode-generation changes must
+  update both `RuntimeCompiler.java` and `ReggieMatcherBytecodeGenerator.java`") —
+  `reggie-processor/src/main/java/com/datadoghq/reggie/processor/ReggieMatcherBytecodeGenerator.java`
+  has a `default: throw new IllegalStateException("Unknown strategy: " + strategy)` catch-all
+  (around line 741) that would fire the first time `PatternAnalyzer` recommends the new strategy
+  for an `@RegexPattern`-annotated (compile-time) pattern, unless this file gets an explicit carve-out
+  — follow `BITSTATE_CAPTURE`'s existing precedent there (folds into the `PIKEVM_CAPTURE` branch,
+  `ReggieMatcherBytecodeGenerator.java:108-115`: "v1 intentionally does not add a [...]-backed
+  codegen path for the annotation-processor pipeline") rather than building full compile-time
+  codegen support in this phase.
+
+Recommendation if no strong signal emerges from Phase 1: start with **Option A** — it composes
+trivially with the existing fallback architecture (design §2's goal of "keep the existing fallback
+pattern" is satisfied for free), requires no `PatternAnalyzer`/enum/bytecode-dual-path changes, and
+directly targets the motivating problem (design §1's fallback cliff) without opening the larger
+question of where TDFA ranks against every other native strategy. Option B can be revisited later
+as a separate, smaller follow-up once Option A is shipped and validated in practice.
+
+### Task 2.1a — Confirm `HybridMatcher` disjointness against the real strategy table
+
+Design §5 explicitly requires this, not an assumption: "Phase 2 ... should confirm this stays
+disjoint in `PatternAnalyzer`'s eventual strategy table rather than assume it." Task 1.3's
+`usePosixLastMatch` exclusion is necessary but was decided in Phase 1, before real routing
+existed — it is not sufficient on its own to call this confirmed. Concretely: once Task 2.1's
+integration point is wired, take every pattern already routed to `HybridMatcher` today via
+`RuntimeCompiler.shouldUseHybrid` (patterns where `PatternAnalyzer.hasGroupsInRepeatingQuantifiers`
+sets `usePosixLastMatch = true` — e.g. `(fo|foo)`, `(a|ab)`, `(.1[1])+`, `(.c)+`; existing coverage
+in `PikeVMRoutingTest`/`DfaUnrolledGroupAndFindRegressionTest`, which assert routing to
+`DFA_UNROLLED_WITH_GROUPS`/`usePosixLastMatch`, not literally to a `shouldUseHybrid` string — grep
+for `usePosixLastMatch`/`DFA_UNROLLED_WITH_GROUPS` in those files, not `shouldUseHybrid`) through
+the new integration point and confirm none of them get redirected to `LaurikariDfaMatcher` instead
+of `HybridMatcher`. This is a real test to write and run, not a design-review checkbox.
+
+### Task 2.2 — Observability
+
+`fallbackCount()`-equivalent (already present on `LaurikariDfaMatcher` per Task 1.4) plus, if Option A
+is chosen, a way to distinguish "served by TDFA" from "served by BitState's own bounded DFS" from
+"punted all the way to PikeVMMatcher" for the same kind of reflection-based test verification used
+throughout this investigation (e.g. `BitStateMatcher.fallbackCount()`'s existing test-only accessor
+pattern).
+
+### Task 2.3 — Re-run the motivating benchmark
+
+Re-run `IastRegexpBenchmark`'s `SqlAnsiFind`/`SqlMysqlFind`/`SqlPostgresqlFind` at all three scales
+and confirm the LONG-scale loss documented in the design doc's §1 table is closed (reggie/RE2J back
+above 1.0x at LONG, not just improved). If the open, unattributed `LdapFind`/`UrlAuthFind`/
+`UrlQueryFind` degradation from the same benchmark run (design §1) turns out to share this
+mechanism, re-run those too and note it — but do not assume it does; that's still an open question
+this plan does not resolve.
+
+**Exit criteria for Phase 2 / overall project:**
+- Chosen integration point wired, tested, `spotlessApply`-clean.
+- Task 2.1a's `HybridMatcher` disjointness check passes with zero pattern reassigned away from it.
+- Benchmark re-run confirms the win is real end-to-end, not just at the isolated matcher level.
+- Zero *net-new* divergences on top of `AlgorithmicFuzzTest`'s `KNOWN_FINDINGS_BUDGET` at the time
+  (re-check the live constant, same caveat as Phase 1's exit criteria).
+
+---
+
+## 5. Sequencing and PR boundaries
+
+One PR per phase minimum, each independently reviewable and each leaving the tree in a shippable
+state (even if the shipped state is "new dead code behind an eligibility gate that nothing routes
+to yet," for Phases 0/0.5/1):
+1. Phase 0 PR: `LaurikariNfaStep`, `LaurikariDFACache` (single-register), spike harness/test, measured
+   results reported in the PR description (not just "looks fine" — the actual numbers against the
+   exit criteria).
+2. Phase 0.5 PR: register-file generalization to small fixed N, the hand-derived per-pattern tag
+   assignments (Task 0.5.1a), adversarial tests, growth-curve measurement reported in the PR
+   description.
+3. Phase 1 PR: full tag count, eligibility gate, `LaurikariDfaMatcher`, the fuzz-oracle
+   matcher-injection seam (Task 1.6a), and both correctness passes (Task 1.5 fast dev-loop + Task
+   1.6b fuzz-harness).
+4. Phase 2 PR: integration wiring, the `HybridMatcher` disjointness check (Task 2.1a), and
+   benchmark re-run results in the PR description.
+
+Do not open Phase N+1's PR before Phase N's exit criteria are confirmed and reported — that
+ordering is the entire point of the phased design (design §7's core fix for the "Phase 0 doesn't
+de-risk Phase 1" gap).
+
+---
+
+## 6. Kill criteria (any phase)
+
+Stop and fall back to design §9's cheaper mitigations (raise `BUDGET_CELLS`, or document the
+residual cliff) if, at any phase boundary:
+- State-space growth is combinatorial rather than roughly linear in tag count (Phase 0.5's core
+  question, but re-check at Phase 1 with the real tag count too — Phase 0.5 extrapolates from N≤3,
+  it doesn't prove N=`2*(groupCount+1)` behaves the same).
+- Correctness divergences against either oracle (`PikeVMMatcher` or JDK) can't be driven to zero
+  **within 2 engineer-weeks of focused debugging on a single divergence, or after 3 independent
+  root-cause attempts on it, whichever comes first** — priority/merge correctness was flagged
+  (design §6) as the highest-risk correctness surface, and Laurikari-family tag semantics are
+  genuinely subtle; a persistent, unexplained divergence is a stronger stop signal here than in
+  most of this codebase's other native-strategy work, precisely because there's no existing local
+  implementation to diff against when something goes wrong. (These numbers are a starting default,
+  not derived from any historical data point in this codebase — whoever runs this phase should
+  adjust them explicitly, in writing, rather than silently drifting past an unstated threshold.)
+- The measured end-to-end win (Phase 2, Task 2.3) doesn't materialize even after Phase 1 passed in
+  isolation — possible if the integration point chosen in Task 2.1 doesn't actually intercept the
+  calls that were hitting the cliff (verify Task 2.2's observability confirms real routing before
+  concluding a lack of speedup is the engine's fault, not the wiring's).

--- a/reggie-benchmark/build.gradle
+++ b/reggie-benchmark/build.gradle
@@ -9,6 +9,7 @@ repositories {
 
 dependencies {
     implementation project(':reggie-runtime')
+    implementation project(':reggie-codegen')
     annotationProcessor project(':reggie-processor')
 
     // Integration tests for benchmark patterns

--- a/reggie-benchmark/src/main/java/com/datadoghq/reggie/runtime/LaurikariPhase0Benchmark.java
+++ b/reggie-benchmark/src/main/java/com/datadoghq/reggie/runtime/LaurikariPhase0Benchmark.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import com.datadoghq.reggie.codegen.automaton.NFA;
+import com.datadoghq.reggie.codegen.automaton.ThompsonBuilder;
+import com.datadoghq.reggie.codegen.parsing.RegexParser;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Real-JMH counterpart to {@code LaurikariPhase0SpikeTest}'s ad-hoc {@code nanoTime} measurement,
+ * closing the Phase 0 exit-criterion-(c) gap flagged by adversarial verification (impl plan Task
+ * 0.3): {@code findLeftmostStart} measured under the same JMH harness (warmup/fork/measurement
+ * discipline) as {@code IastRegexpBenchmark}'s {@code reggieSqlAnsiFind}/{@code
+ * reggieSqlMysqlFind}/{@code reggieSqlPostgresqlFind} (the "current full-{@code
+ * PikeVMMatcher}-punt" baseline this design targets, since at LONG scale those calls already exceed
+ * {@code BitStateMatcher.BUDGET_CELLS} and fall through to {@code PikeVMMatcher}'s thread
+ * simulation), against the exact same LONG-scale inputs (mirrored verbatim from {@code
+ * IastRegexpBenchmark.java}'s {@code setup()}).
+ *
+ * <p>Package placement note: this class lives in {@code com.datadoghq.reggie.runtime} (matching the
+ * package it benchmarks) even though it is physically under {@code reggie-benchmark}'s source tree,
+ * to reach {@link LaurikariDFACache}/{@link LaurikariNfaStep}/{@link LaurikariStepResult}, which
+ * are package-private with no production entry point yet (Phase 0 has none — see those classes'
+ * javadoc). The project has no {@code module-info.java} anywhere, so this split package is plain
+ * classpath-mode Java, not a module violation.
+ *
+ * <p>The step-function driver (closure + consuming-transition + merge) duplicates {@code
+ * LaurikariDFACacheTest}'s and {@code LaurikariPhase0SpikeTest}'s test-only driver verbatim, for
+ * the same legitimate reason those two duplicate each other: Phase 0 has no shared production
+ * wiring point, and this is disposable spike-measurement scaffolding, not a place to introduce a
+ * shared abstraction ahead of Phase 1's actual generalization.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class LaurikariPhase0Benchmark {
+
+  // --- SQL_ANSI/MYSQL/POSTGRESQL, mirrored verbatim from IastRegexpBenchmark.java:101-116 -------
+  private static final String SQL_ANSI =
+      "(?i)(?m)[-+]?(?:x'[0-9a-f]+'|0x[0-9a-f]+|b'[0-9a-f]+'|0b[0-9a-f]+"
+          + "|\\d*\\.\\d+(?:E[-+]?\\d+[fd]?)?|\\b\\d+(?:E[-+]?\\d+[fd]?)?)"
+          + "|'(?:''|[^'])*'|--.*$|/\\*[\\s\\S]*\\*/";
+  private static final String SQL_MYSQL =
+      "(?i)(?m)[-+]?(?:x'[0-9a-f]+'|0x[0-9a-f]+|b'[0-9a-f]+'|0b[0-9a-f]+"
+          + "|\\d*\\.\\d+(?:E[-+]?\\d+[fd]?)?|\\b\\d+(?:E[-+]?\\d+[fd]?)?)"
+          + "|\"(?:\\\\\"|[^\"])*\"|'(?:\\\\'|[^'])*'|--.*$|/\\*[\\s\\S]*\\*/";
+  private static final String SQL_POSTGRESQL =
+      "(?i)(?m)[-+]?(?:x'[0-9a-f]+'|0x[0-9a-f]+|b'[0-9a-f]+'|0b[0-9a-f]+"
+          + "|\\d*\\.\\d+(?:E[-+]?\\d+[fd]?)?|\\b\\d+(?:E[-+]?\\d+[fd]?)?)"
+          + "|\\$(?:[a-zA-Z_]\\w*)?\\$|'(?:''|[^'])*'|--.*$|/\\*[\\s\\S]*\\*/";
+
+  // --- LONG-scale sqlMatch/mysqlMatch/postgresqlMatch, mirrored verbatim from
+  // --- IastRegexpBenchmark.java's setup() (the third pick(scale, ...) argument = LONG).
+  // -----------
+  private static final String SQL_MATCH_LONG =
+      "SELECT * FROM users WHERE "
+          + "col_x = col_y AND ".repeat(2000)
+          + "id = 42 AND name = 'Alice' AND balance = 1234.56";
+  private static final String MYSQL_MATCH_LONG =
+      "SELECT id, `name` FROM users WHERE "
+          + "col_x = col_y AND ".repeat(2000)
+          + "id = 1 AND email = 'user@example.com' AND active = 1";
+  private static final String POSTGRESQL_MATCH_LONG =
+      "SELECT * FROM docs WHERE "
+          + "col_x = col_y AND ".repeat(2000)
+          + "body = $$hello world$$ AND revision = 3";
+
+  // --- Test-only LaurikariNfaStep driver, duplicated verbatim from LaurikariDFACacheTest ---------
+
+  private static NFA nfa(String pattern, int groupCount) throws Exception {
+    return new ThompsonBuilder().build(new RegexParser().parse(pattern), groupCount);
+  }
+
+  private static NFA.NFAState[] statesById(NFA nfa) {
+    NFA.NFAState[] arr = new NFA.NFAState[nfa.getStates().size()];
+    for (NFA.NFAState s : nfa.getStates()) {
+      arr[s.id] = s;
+    }
+    return arr;
+  }
+
+  private static int[][] closureWithAges(
+      NFA.NFAState[] statesById, int stateCount, int[] seedStates, int[] seedAges) {
+    int[] ages = new int[stateCount];
+    Arrays.fill(ages, -1);
+    Deque<Integer> worklist = new ArrayDeque<>();
+    for (int i = 0; i < seedStates.length; i++) {
+      int id = seedStates[i];
+      if (seedAges[i] > ages[id]) {
+        ages[id] = seedAges[i];
+        worklist.push(id);
+      }
+    }
+    while (!worklist.isEmpty()) {
+      int id = worklist.pop();
+      int age = ages[id];
+      for (NFA.NFAState e : statesById[id].getEpsilonTransitions()) {
+        if (age > ages[e.id]) {
+          ages[e.id] = age;
+          worklist.push(e.id);
+        }
+      }
+    }
+    return denseToSeed(ages, stateCount);
+  }
+
+  private static int[][] denseToSeed(int[] denseAges, int stateCount) {
+    int count = 0;
+    for (int v : denseAges) {
+      if (v >= 0) count++;
+    }
+    int[] states = new int[count];
+    int[] ages = new int[count];
+    int oi = 0;
+    for (int id = 0; id < stateCount; id++) {
+      if (denseAges[id] >= 0) {
+        states[oi] = id;
+        ages[oi] = denseAges[id];
+        oi++;
+      }
+    }
+    return new int[][] {states, ages};
+  }
+
+  private static LaurikariNfaStep laurikariStep(NFA nfa) {
+    NFA.NFAState[] statesById = statesById(nfa);
+    int stateCount = statesById.length;
+    int startId = nfa.getStartState().id;
+    return (curStates, curRegs, c) -> {
+      int[] rawAges = new int[stateCount];
+      Arrays.fill(rawAges, -1);
+      for (int i = 0; i < curStates.length; i++) {
+        NFA.NFAState s = statesById[curStates[i]];
+        int age = curRegs[i][0];
+        for (NFA.Transition t : s.getTransitions()) {
+          if (t.chars.contains((char) c)) {
+            int cand = age + 1;
+            if (cand > rawAges[t.target.id]) rawAges[t.target.id] = cand;
+          }
+        }
+      }
+      int[][] consumedSeed = denseToSeed(rawAges, stateCount);
+      int[][] consumedClosed =
+          closureWithAges(statesById, stateCount, consumedSeed[0], consumedSeed[1]);
+      int[][] freshClosed =
+          closureWithAges(statesById, stateCount, new int[] {startId}, new int[] {0});
+
+      int[] merged = new int[stateCount];
+      Arrays.fill(merged, -1);
+      for (int i = 0; i < consumedClosed[0].length; i++) {
+        merged[consumedClosed[0][i]] = consumedClosed[1][i];
+      }
+      for (int i = 0; i < freshClosed[0].length; i++) {
+        int id = freshClosed[0][i];
+        int age = freshClosed[1][i];
+        if (age > merged[id]) merged[id] = age;
+      }
+      int[][] out = denseToSeed(merged, stateCount);
+      int[] outStates = out[0];
+      int[] outAges = out[1];
+      int[][] outRegs = new int[outStates.length][];
+      for (int i = 0; i < outStates.length; i++) {
+        outRegs[i] = new int[] {outAges[i]};
+      }
+      return new LaurikariStepResult(outStates, outRegs);
+    };
+  }
+
+  private static final class Built {
+    final LaurikariDFACache cache;
+    final LaurikariNfaStep step;
+
+    Built(LaurikariDFACache cache, LaurikariNfaStep step) {
+      this.cache = cache;
+      this.step = step;
+    }
+  }
+
+  private static Built build(String pattern) throws Exception {
+    NFA nfa = nfa(pattern, 0);
+    NFA.NFAState[] statesById = statesById(nfa);
+    int stateCount = statesById.length;
+    int startId = nfa.getStartState().id;
+
+    int[][] startClosure =
+        closureWithAges(statesById, stateCount, new int[] {startId}, new int[] {0});
+
+    int[] acceptIds = new int[nfa.getAcceptStates().size()];
+    int ai = 0;
+    for (NFA.NFAState s : nfa.getAcceptStates()) {
+      acceptIds[ai++] = s.id;
+    }
+
+    int[] startStates = startClosure[0];
+    int[] startAges = startClosure[1];
+    int[][] startRegs = new int[startStates.length][];
+    for (int i = 0; i < startStates.length; i++) {
+      startRegs[i] = new int[] {startAges[i]};
+    }
+
+    LaurikariDFACache cache = new LaurikariDFACache(startStates, startRegs, acceptIds);
+    return new Built(cache, laurikariStep(nfa));
+  }
+
+  private Built sqlAnsi;
+  private Built sqlMysql;
+  private Built sqlPostgresql;
+
+  @Setup(Level.Trial)
+  public void setup() throws Exception {
+    sqlAnsi = build(SQL_ANSI);
+    sqlMysql = build(SQL_MYSQL);
+    sqlPostgresql = build(SQL_POSTGRESQL);
+  }
+
+  @Benchmark
+  public int laurikariSqlAnsiFindLong() {
+    return sqlAnsi.cache.findLeftmostStart(SQL_MATCH_LONG, 0, sqlAnsi.step);
+  }
+
+  @Benchmark
+  public int laurikariSqlMysqlFindLong() {
+    return sqlMysql.cache.findLeftmostStart(MYSQL_MATCH_LONG, 0, sqlMysql.step);
+  }
+
+  @Benchmark
+  public int laurikariSqlPostgresqlFindLong() {
+    return sqlPostgresql.cache.findLeftmostStart(POSTGRESQL_MATCH_LONG, 0, sqlPostgresql.step);
+  }
+}

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDFACache.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDFACache.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Arrays;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Laurikari-style lazily-materialized DFA cache: same lazily-materialized/ASCII-table caching
+ * structure as {@link LazyDFACache}, but each interned DFA state is keyed on (NFA state subset,
+ * per-state register vector) via {@link LaurikariStateSetKey} instead of on the subset alone.
+ *
+ * <p>Generalized from Phase 0's single-scalar "age" register to a fixed-size {@code int[]} register
+ * file per state (impl-plan Task 0.5.1). This class is deliberately agnostic to what the vector
+ * holds or how ties between colliding arrivals were resolved — that is entirely the calling {@link
+ * LaurikariNfaStep}'s business (see its class javadoc for the two coexisting tie-break
+ * disciplines). This class only interns whatever {@code (states, regs)} pairs the step function
+ * returns and caches transitions between the resulting DFA states.
+ *
+ * <p>{@link #findLeftmostStart} is Phase 0's specific find()-localization entry point: it assumes
+ * register slot 0 is an "age" value (candidate's characters-consumed-since-self-anchoring) and
+ * recovers the leftmost start as {@code (pos + 1) - age} the moment an accept state is reached. It
+ * is meaningless to call this method with a step function that doesn't populate slot 0 this way
+ * (e.g. Phase 0.5's multi-tag capture checkpoint, which instead reads {@link #acceptRegs}
+ * directly).
+ */
+final class LaurikariDFACache {
+
+  /** Same VarHandle/publication discipline as {@link LazyDFACache#TABLES_VH}. */
+  static final VarHandle TABLES_VH;
+
+  /** Same VarHandle/publication discipline as {@link LazyDFACache#INT_ARRAY_VH}. */
+  static final VarHandle INT_ARRAY_VH;
+
+  /** Same architecture gate as {@link LazyDFACache#NEEDS_INT_ARRAY_ACQUIRE}. */
+  static final boolean NEEDS_INT_ARRAY_ACQUIRE;
+
+  static {
+    try {
+      TABLES_VH = MethodHandles.arrayElementVarHandle(int[][].class);
+      INT_ARRAY_VH = MethodHandles.arrayElementVarHandle(int[].class);
+    } catch (Exception e) {
+      throw new ExceptionInInitializerError(e);
+    }
+    String arch = System.getProperty("os.arch", "");
+    NEEDS_INT_ARRAY_ACQUIRE =
+        !arch.equals("x86")
+            && !arch.equals("x86_64")
+            && !arch.equals("amd64")
+            && !arch.equals("i386");
+  }
+
+  static final int DEFAULT_CAP = 4096;
+  static final int UNCACHED = -1;
+  static final int DEAD = -2;
+  static final int FALLBACK = -3;
+
+  private final ConcurrentHashMap<LaurikariStateSetKey, Integer> stateIndex;
+  final int[][] asciiTables; // asciiTables[id] = int[128] or null
+  final int[][]
+      nfaStateSets; // nfaStateSets[id] = NFA state IDs, order per the driving step's convention
+  final int[][][] regs; // regs[id][i] = register vector for nfaStateSets[id][i]
+  final boolean[] accepting;
+  private final int[] acceptStateIds;
+  private final AtomicInteger nextId;
+  private volatile boolean frozen;
+  private final int cap;
+
+  LaurikariDFACache(int[] startStateSet, int[][] startRegs, int[] acceptStateIds) {
+    this(startStateSet, startRegs, acceptStateIds, DEFAULT_CAP);
+  }
+
+  // package-private for tests
+  LaurikariDFACache(int[] startStateSet, int[][] startRegs, int[] acceptStateIds, int cap) {
+    this.cap = cap;
+    this.acceptStateIds = acceptStateIds;
+    this.stateIndex = new ConcurrentHashMap<>();
+    this.asciiTables = new int[cap][];
+    this.nfaStateSets = new int[cap][];
+    this.regs = new int[cap][][];
+    this.accepting = new boolean[cap];
+    this.nextId = new AtomicInteger(1); // 0 = start state
+    nfaStateSets[0] = startStateSet;
+    regs[0] = startRegs;
+    accepting[0] = firstAcceptIndex(startStateSet) >= 0;
+    stateIndex.put(new LaurikariStateSetKey(startStateSet, startRegs), 0);
+  }
+
+  /**
+   * O(n) DFA-based search for the leftmost start position of the first completable match in {@code
+   * input}, scanning left-to-right from {@code scanFrom} while maintaining a single interned
+   * (subset, register-vector) DFA state.
+   *
+   * <p>Phase 0-specific: assumes register slot 0 is an "age" value and {@code step} merges a fresh
+   * self-anchored (age 0) candidate into every application (see {@link LaurikariNfaStep}'s class
+   * javadoc, value-based discipline). Unlike {@link LazyDFACache#findFrom}, there is no separate
+   * {@code matchStart}/restart-on-DEAD bookkeeping: the current DFA state always reflects every
+   * live start candidate at once, and the leftmost start is recovered directly from the winning age
+   * the moment an accepting state is reached: {@code (pos + 1) - age}.
+   *
+   * @return the leftmost match start position (0-based), or {@code -1} if no match exists at or
+   *     after {@code scanFrom}
+   */
+  int findLeftmostStart(String input, int scanFrom, LaurikariNfaStep step) {
+    if (input == null) return -1;
+    int len = input.length();
+    if (accepting[0]) {
+      // Zero-length match: state 0 (freshly self-anchored, age 0) is already accepting.
+      return scanFrom - acceptAge(0);
+    }
+    int dfaState = 0;
+    for (int pos = scanFrom; pos < len; pos++) {
+      int c = input.charAt(pos);
+      int[] table =
+          NEEDS_INT_ARRAY_ACQUIRE
+              ? (int[]) TABLES_VH.getAcquire(asciiTables, dfaState)
+              : asciiTables[dfaState];
+      int next =
+          (table != null && c < 128)
+              ? (NEEDS_INT_ARRAY_ACQUIRE ? (int) INT_ARRAY_VH.getAcquire(table, c) : table[c])
+              : UNCACHED;
+      if (next == UNCACHED) {
+        next = lookupOrCompute(dfaState, c, step);
+      }
+      if (next == FALLBACK) {
+        // Cache is frozen; delegate the remaining scan to a plain (uncached) NFA-level
+        // re-simulation that tracks ages the same way the cached transitions do. This does NOT
+        // need LazyDFACache.nfaFallbackFindFrom's O(n^2) retry-per-start-position loop: because
+        // every LaurikariNfaStep application already merges in a fresh self-anchored (age 0)
+        // candidate, a single forward pass carrying per-state ages is enough to recover the true
+        // leftmost start the moment an accepting state is reached.
+        return nfaFallbackFindLeftmostStart(
+            input, pos, nfaStateSets[dfaState], regs[dfaState], step);
+      }
+      if (next == DEAD) {
+        // Unreachable in practice: LaurikariNfaStep's step 3/4 always merge in a fresh
+        // closure(startNfaState) at age 0, so the merged result can only be empty if the start
+        // state's own closure is empty (a degenerate NFA). Kept for parity with LazyDFACache's
+        // DEAD handling and as a defensive stop rather than continuing with an unusable state.
+        return -1;
+      }
+      dfaState = next;
+      if (accepting[dfaState]) {
+        return (pos + 1) - acceptAge(dfaState);
+      }
+    }
+    return -1;
+  }
+
+  int lookupOrCompute(int state, int c, LaurikariNfaStep step) {
+    LaurikariStepResult result = step.apply(nfaStateSets[state], regs[state], c);
+    if (result.states.length == 0) {
+      cacheEntry(state, c, DEAD);
+      return DEAD;
+    }
+
+    LaurikariStateSetKey key = new LaurikariStateSetKey(result.states, result.regs);
+    Integer id = stateIndex.get(key);
+
+    if (id == null && !frozen) {
+      id =
+          stateIndex.computeIfAbsent(
+              key,
+              k -> {
+                int newId = nextId.getAndIncrement();
+                if (newId < cap) {
+                  nfaStateSets[newId] = k.getStates();
+                  regs[newId] = k.getRegs();
+                  accepting[newId] = firstAcceptIndex(k.getStates()) >= 0;
+                  return newId;
+                }
+                return null; // over cap: don't insert, keeps map bounded at cap entries
+              });
+      if (id == null) {
+        frozen = true;
+        return FALLBACK;
+      }
+    }
+    if (id == null) return FALLBACK;
+
+    cacheEntry(state, c, id);
+    return id;
+  }
+
+  void cacheEntry(int state, int c, int value) {
+    if (c >= 128) return;
+    int[] table = asciiTables[state];
+    if (table == null) {
+      int[] t = new int[128];
+      Arrays.fill(t, UNCACHED);
+      t[c] = value;
+      TABLES_VH.setRelease(asciiTables, state, t);
+    } else {
+      INT_ARRAY_VH.setRelease(table, c, value);
+    }
+  }
+
+  /**
+   * NFA fallback for {@link #findLeftmostStart} when the cache is frozen. Continues stepping the
+   * raw (state, register) set forward from {@code frozenPos} using {@code step} directly (no
+   * caching), returning as soon as an accepting state is reached — see {@link #findLeftmostStart}'s
+   * FALLBACK comment for why a single pass suffices here, unlike {@link LazyDFACache}'s
+   * boolean-only fallback.
+   *
+   * @param frozenPos position in the input where the FALLBACK transition was encountered
+   * @param nfaStates NFA state subset at {@code frozenPos} (before consuming that position's char)
+   * @param nfaRegs {@code nfaStates}' parallel register vectors
+   */
+  private int nfaFallbackFindLeftmostStart(
+      String input, int frozenPos, int[] nfaStates, int[][] nfaRegs, LaurikariNfaStep step) {
+    int len = input.length();
+    int[] states = nfaStates;
+    int[][] r = nfaRegs;
+    for (int pos = frozenPos; pos < len; pos++) {
+      LaurikariStepResult result = step.apply(states, r, input.charAt(pos));
+      states = result.states;
+      r = result.regs;
+      if (states.length == 0) {
+        // Unreachable in practice; see findLeftmostStart's DEAD comment.
+        return -1;
+      }
+      int idx = firstAcceptIndex(states);
+      if (idx >= 0) {
+        return (pos + 1) - r[idx][0];
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * @return the age (register slot 0) of the winning accept-state candidate present in the DFA
+   *     state {@code dfaState}'s subset, per Phase 0's value-based tie-break (larger age wins among
+   *     accept-state members — see {@link #firstAcceptIndex}'s javadoc for why "first" and "larger
+   *     age" coincide when this method's caller uses this class as intended).
+   */
+  private int acceptAge(int dfaState) {
+    int idx = firstAcceptIndex(nfaStateSets[dfaState]);
+    return regs[dfaState][idx][0];
+  }
+
+  /**
+   * @return the register vector of the accept-state member of {@code dfaState}'s subset (per Task
+   *     0.5.3's multi-tag capture checkpoint, which reads this directly instead of {@link
+   *     #findLeftmostStart}'s age-specific math), or {@code null} if no accept state is present.
+   */
+  int[] acceptRegs(int dfaState) {
+    int idx = firstAcceptIndex(nfaStateSets[dfaState]);
+    return idx < 0 ? null : regs[dfaState][idx];
+  }
+
+  /**
+   * @return the index within {@code states} of the first accept-state member (by array order), or
+   *     {@code -1} if none of {@code states} is an accept state. "First" is safe for both
+   *     coexisting tie-break disciplines: Phase 0's value-based driver never presents more than one
+   *     accept-state member per subset in practice (a single shared NFA accept state per pattern,
+   *     see {@code LaurikariDFACacheTest}'s traced examples), so "first" and "largest age" coincide
+   *     trivially; Phase 0.5's priority-order driver's whole-mapping-discard already guarantees at
+   *     most one entry per NFA state id, and "first" here means "highest priority", matching {@code
+   *     PikeVMMatcher}'s "first accepting thread in priority order is highest priority" convention.
+   */
+  private int firstAcceptIndex(int[] states) {
+    for (int i = 0; i < states.length; i++) {
+      if (isAcceptState(states[i])) return i;
+    }
+    return -1;
+  }
+
+  private boolean isAcceptState(int state) {
+    for (int t : acceptStateIds) {
+      if (t == state) return true;
+    }
+    return false;
+  }
+
+  // package-private for tests: current number of materialized (interned) DFA states, used to
+  // check that the cache stays bounded by NFA structure rather than growing with input length.
+  int stateCount() {
+    return Math.min(nextId.get(), cap);
+  }
+}

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariNfaStep.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariNfaStep.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+/**
+ * One tagged-NFA step: given active (state, register-vector) pairs and a character, returns the
+ * next active state ids together with each one's winning register vector.
+ *
+ * <p>Generalized from Phase 0's single-scalar "age" register (design doc §4/§5) to a fixed-size
+ * {@code int[]} register file per state, per impl-plan Task 0.5.1: {@code curRegs[i]}/the returned
+ * {@code regs[i]} is now a vector, not a bare {@code int}. {@link LaurikariDFACache} itself is
+ * agnostic to what the vector holds or how ties are resolved — it only interns whatever {@code
+ * (states, regs)} pairs a step implementation returns. Two tie-break disciplines coexist across
+ * this codebase's step implementations, and each is free to pick whichever fits its own semantics:
+ *
+ * <ul>
+ *   <li><b>Value-based ("larger wins"):</b> Phase 0's find()-localization driver (see {@code
+ *       LaurikariDFACacheTest}/{@code LaurikariPhase0SpikeTest}/{@code LaurikariPhase0Benchmark})
+ *       wraps its scalar age in a length-1 vector and keeps comparing values directly — correct
+ *       because age is a genuine total order and doesn't need positional information. Callers using
+ *       this discipline may freely canonicalize {@code states}/{@code regs} order (e.g. sort
+ *       ascending by state id) since order carries no meaning for them.
+ *   <li><b>Priority-order ("whole-mapping discard"):</b> Phase 0.5's multi-tag capture checkpoint
+ *       (design §4) has no single scalar to compare when two arrivals reach the same target NFA
+ *       state, so it instead tracks explicit priority — mirroring {@code PikeVMMatcher.addThread}'s
+ *       insertion-order-through-epsilons DFS (first visit wins, later arrivals' entire register
+ *       mapping is discarded rather than merged tag-by-tag). For this discipline, {@code
+ *       curStates}'/{@code states}' array ORDER *is* the priority (index 0 = highest priority) and
+ *       must be preserved verbatim across steps — {@code LaurikariStateSetKey}'s order-sensitive
+ *       {@code equals}/{@code hashCode} (plain {@link java.util.Arrays#equals}, no sorting) exists
+ *       specifically so two different priority orderings of the same underlying subset intern as
+ *       distinct DFA states, matching classical tagged-DFA determinization.
+ * </ul>
+ *
+ * <p>Kept as a separate interface from {@link NfaStep} rather than changing NfaStep's shape,
+ * matching how {@link RejectDfaFactory}/{@link PikeVMMatcher} already keep multiple independent
+ * NfaStep-shaped lambdas per purpose.
+ */
+@FunctionalInterface
+interface LaurikariNfaStep {
+  /**
+   * @param curStates active NFA state ids (subset); order is meaningful or not, per the
+   *     implementation's tie-break discipline (see class javadoc)
+   * @param curRegs curStates[i]'s register vector
+   * @param c the character being consumed
+   * @return next active state ids and their per-state winning register vectors, after
+   *     epsilon-closure and this step's merge/tie-break rule
+   */
+  LaurikariStepResult apply(int[] curStates, int[][] curRegs, int c);
+}

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariStateSetKey.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariStateSetKey.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import java.util.Arrays;
+
+/**
+ * Interning key for a Laurikari DFA state: an active NFA state subset together with each state's
+ * per-candidate register vector (see {@link LaurikariNfaStep} for what the registers hold).
+ *
+ * <p>Unlike {@link StateSetKey}, which hashes and compares only the state-id array, this key also
+ * hashes and compares the parallel register array: two Laurikari DFA states are the same only if
+ * both the subset and every state's register vector match, since a given subset with different
+ * registers represents different match-priority candidates.
+ *
+ * <p><b>Deliberately order-sensitive.</b> {@code states}/{@code regs} are compared with plain
+ * {@link Arrays#equals}/{@link Arrays#deepEquals} — no sorting, here or in the constructor. This
+ * matters for {@link LaurikariNfaStep}'s priority-order tie-break discipline (see its class
+ * javadoc): two different priority orderings of the same underlying subset are genuinely different
+ * DFA states there, since order-of-arrival is exactly what tag-vector comparison alone cannot
+ * recover. Phase 0's value-based ("larger age wins") driver instead canonicalizes to ascending
+ * state-id order before construction, since order carries no meaning for it — either convention
+ * works with this key as long as the caller who feeds it is consistent with itself.
+ */
+final class LaurikariStateSetKey {
+  private final int[] states;
+  private final int[][] regs;
+  private final int hash;
+
+  LaurikariStateSetKey(int[] states, int[][] regs) {
+    this.states = states;
+    this.regs = regs;
+    this.hash = 31 * Arrays.hashCode(states) + Arrays.deepHashCode(regs);
+  }
+
+  int[] getStates() {
+    return states;
+  }
+
+  int[][] getRegs() {
+    return regs;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof LaurikariStateSetKey)) return false;
+    LaurikariStateSetKey other = (LaurikariStateSetKey) o;
+    return Arrays.equals(states, other.states) && Arrays.deepEquals(regs, other.regs);
+  }
+
+  @Override
+  public int hashCode() {
+    return hash;
+  }
+}

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariStepResult.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariStepResult.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+/**
+ * Result of one {@link LaurikariNfaStep} application: the next active NFA state subset together
+ * with each state's per-candidate register vector (see {@link LaurikariNfaStep} for what the
+ * registers hold and, critically, whether {@code states}' array order carries meaning for a given
+ * step implementation).
+ *
+ * <p>{@code states} and {@code regs} are parallel arrays: {@code regs[i]} is the winning register
+ * vector for {@code states[i]}, after whatever closure/merge tie-break the producing {@link
+ * LaurikariNfaStep} implements. No defensive copy is taken, matching {@link StateSetKey}'s
+ * convention of trusting the caller to hand over arrays it will not mutate afterward.
+ */
+final class LaurikariStepResult {
+  final int[] states;
+  final int[][] regs; // regs[i] is states[i]'s register vector
+
+  LaurikariStepResult(int[] states, int[][] regs) {
+    this.states = states;
+    this.regs = regs;
+  }
+}

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDFACacheTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDFACacheTest.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datadoghq.reggie.codegen.automaton.NFA;
+import com.datadoghq.reggie.codegen.automaton.ThompsonBuilder;
+import com.datadoghq.reggie.codegen.parsing.RegexParser;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link LaurikariDFACache}, the Phase-0 Laurikari-style localization spike that
+ * recovers the exact leftmost start of the first completable match in a single left-to-right scan
+ * by tracking a per-candidate "age" register through DFA-state interning (see {@link
+ * LaurikariNfaStep} and {@link LaurikariStateSetKey} for what "age" means and why it is used
+ * instead of an absolute start position).
+ *
+ * <p>{@link LaurikariDFACache}, {@link LaurikariNfaStep}, {@link LaurikariStepResult}, and {@link
+ * LaurikariStateSetKey} are all package-private with no public entry point, but since this test
+ * lives in the same package it can use them directly (unlike {@code RejectDfaFactoryTest}, which
+ * needs reflection to reach {@code RejectDfaFactory}'s own package-private {@code build} method).
+ *
+ * <p>This test builds its own {@link LaurikariNfaStep} driver (closure + consuming-transition +
+ * merge, over the raw {@link NFA} built by {@link ThompsonBuilder}) rather than depend on any
+ * production wiring point, since Phase 0 does not have one yet: see the class doc of {@link
+ * LaurikariNfaStep} for the exact algorithm this driver implements. This is legitimate test-only
+ * duplication of the production algorithm — the real matcher-construction wiring is a later phase's
+ * concern.
+ */
+class LaurikariDFACacheTest {
+
+  // --- Test-only LaurikariNfaStep driver -------------------------------------------------------
+  //
+  // Mirrors RejectDfaFactory's closure()/transitionTargets() shape (including its "cross every
+  // anchor state as epsilon" over-approximation — anchor eligibility is a later phase's concern,
+  // not Phase 0's), but threads a per-state age register through closure and merge instead of
+  // doing an unconditional attribution-erasing union.
+
+  private static NFA nfa(String pattern, int groupCount) throws Exception {
+    return new ThompsonBuilder().build(new RegexParser().parse(pattern), groupCount);
+  }
+
+  private static NFA.NFAState[] statesById(NFA nfa) {
+    NFA.NFAState[] arr = new NFA.NFAState[nfa.getStates().size()];
+    for (NFA.NFAState s : nfa.getStates()) {
+      arr[s.id] = s;
+    }
+    return arr;
+  }
+
+  /**
+   * Epsilon-closure of {@code (seedStates[i], seedAges[i])}, crossing every anchor state as epsilon
+   * exactly like {@code RejectDfaFactory.closure()} (same sound-over-approximation reasoning: Phase
+   * 0 is a localization spike, anchor eligibility is deferred). When two paths reach the same state
+   * with different ages, the larger age wins (older candidate = more leftmost), matching {@link
+   * LaurikariNfaStep}'s tie-break rule. Ages only ever increase while propagating (epsilon consumes
+   * no character), so a monotone worklist relaxation (rather than a single visited-once DFS) is
+   * used to let a later, larger-age arrival re-open already-visited states.
+   *
+   * @return {@code {states, ages}}, both sorted ascending by state id (parallel arrays)
+   */
+  private static int[][] closureWithAges(
+      NFA.NFAState[] statesById, int stateCount, int[] seedStates, int[] seedAges) {
+    int[] ages = new int[stateCount];
+    Arrays.fill(ages, -1);
+    Deque<Integer> worklist = new ArrayDeque<>();
+    for (int i = 0; i < seedStates.length; i++) {
+      int id = seedStates[i];
+      if (seedAges[i] > ages[id]) {
+        ages[id] = seedAges[i];
+        worklist.push(id);
+      }
+    }
+    while (!worklist.isEmpty()) {
+      int id = worklist.pop();
+      int age = ages[id];
+      for (NFA.NFAState e : statesById[id].getEpsilonTransitions()) {
+        if (age > ages[e.id]) {
+          ages[e.id] = age;
+          worklist.push(e.id);
+        }
+      }
+    }
+    return denseToSeed(ages, stateCount);
+  }
+
+  /** Converts a dense per-id age array ({@code -1} = absent) to sorted parallel (states, ages). */
+  private static int[][] denseToSeed(int[] denseAges, int stateCount) {
+    int count = 0;
+    for (int v : denseAges) {
+      if (v >= 0) count++;
+    }
+    int[] states = new int[count];
+    int[] ages = new int[count];
+    int oi = 0;
+    for (int id = 0; id < stateCount; id++) {
+      if (denseAges[id] >= 0) {
+        states[oi] = id;
+        ages[oi] = denseAges[id];
+        oi++;
+      }
+    }
+    return new int[][] {states, ages};
+  }
+
+  /**
+   * Builds the {@link LaurikariNfaStep} implementing Phase 0's step function: (1) consuming
+   * transitions with age+1, (2) closure of the consuming targets, (3) a separate fresh
+   * self-anchoring closure({@code startId}) at age 0, and (4) a larger-age-wins merge of (2) and
+   * (3) — see {@link LaurikariNfaStep}'s class javadoc for the full rationale.
+   */
+  private static LaurikariNfaStep laurikariStep(NFA nfa) {
+    NFA.NFAState[] statesById = statesById(nfa);
+    int stateCount = statesById.length;
+    int startId = nfa.getStartState().id;
+    return (curStates, curRegs, c) -> {
+      int[] rawAges = new int[stateCount];
+      Arrays.fill(rawAges, -1);
+      for (int i = 0; i < curStates.length; i++) {
+        NFA.NFAState s = statesById[curStates[i]];
+        int age = curRegs[i][0];
+        for (NFA.Transition t : s.getTransitions()) {
+          if (t.chars.contains((char) c)) {
+            int cand = age + 1;
+            if (cand > rawAges[t.target.id]) rawAges[t.target.id] = cand;
+          }
+        }
+      }
+      int[][] consumedSeed = denseToSeed(rawAges, stateCount);
+      int[][] consumedClosed =
+          closureWithAges(statesById, stateCount, consumedSeed[0], consumedSeed[1]);
+      int[][] freshClosed =
+          closureWithAges(statesById, stateCount, new int[] {startId}, new int[] {0});
+
+      int[] merged = new int[stateCount];
+      Arrays.fill(merged, -1);
+      for (int i = 0; i < consumedClosed[0].length; i++) {
+        merged[consumedClosed[0][i]] = consumedClosed[1][i];
+      }
+      for (int i = 0; i < freshClosed[0].length; i++) {
+        int id = freshClosed[0][i];
+        int age = freshClosed[1][i];
+        if (age > merged[id]) merged[id] = age;
+      }
+      int[][] out = denseToSeed(merged, stateCount);
+      int[] outStates = out[0];
+      int[] outAges = out[1];
+      int[][] outRegs = new int[outStates.length][];
+      for (int i = 0; i < outStates.length; i++) {
+        outRegs[i] = new int[] {outAges[i]};
+      }
+      return new LaurikariStepResult(outStates, outRegs);
+    };
+  }
+
+  /** {@link LaurikariDFACache} + its driving {@link LaurikariNfaStep}, built for one pattern. */
+  private static final class Built {
+    final LaurikariDFACache cache;
+    final LaurikariNfaStep step;
+
+    Built(LaurikariDFACache cache, LaurikariNfaStep step) {
+      this.cache = cache;
+      this.step = step;
+    }
+  }
+
+  private static Built build(String pattern, int groupCount) throws Exception {
+    NFA nfa = nfa(pattern, groupCount);
+    NFA.NFAState[] statesById = statesById(nfa);
+    int stateCount = statesById.length;
+    int startId = nfa.getStartState().id;
+
+    // Seed state set for LaurikariDFACache's state 0: plain closure(startId) at age 0 — the
+    // cache's own constructor re-derives an all-zero age array for it, matching how
+    // LazyDFACache's constructor seeds nfaStateSets[0] from startStateSet.
+    int[][] startClosure =
+        closureWithAges(statesById, stateCount, new int[] {startId}, new int[] {0});
+
+    int[] acceptIds = new int[nfa.getAcceptStates().size()];
+    int ai = 0;
+    for (NFA.NFAState s : nfa.getAcceptStates()) {
+      acceptIds[ai++] = s.id;
+    }
+
+    int[] startStates = startClosure[0];
+    int[] startAges = startClosure[1];
+    int[][] startRegs = new int[startStates.length][];
+    for (int i = 0; i < startStates.length; i++) {
+      startRegs[i] = new int[] {startAges[i]};
+    }
+
+    LaurikariDFACache cache = new LaurikariDFACache(startStates, startRegs, acceptIds);
+    return new Built(cache, laurikariStep(nfa));
+  }
+
+  // --- (a) Basic sanity: exact leftmost start for simple literal / multi-leading-char patterns --
+
+  @Test
+  void simpleLiteral_findsExactStart_orMinusOneWhenAbsent() throws Exception {
+    Built b = build("abc", 0);
+
+    // "abc" appears starting at index 3.
+    assertEquals(3, b.cache.findLeftmostStart("xxxabcxxx", 0, b.step));
+    // Not present at all.
+    assertEquals(-1, b.cache.findLeftmostStart("xxxxxxxxx", 0, b.step));
+    // Overlaps the literal's own characters but never the full sequence.
+    assertEquals(-1, b.cache.findLeftmostStart("cabxbca", 0, b.step));
+  }
+
+  @Test
+  void alternation_withMultipleLeadingChars_findsExactStart_orMinusOneWhenNeitherBranchMatches()
+      throws Exception {
+    // cat|dog: two disjoint leading characters, exercising the merge across more than one live
+    // NFA position at once (single-literal "abc" above only ever tracks one lineage).
+    Built b = build("cat|dog", 0);
+
+    assertEquals(3, b.cache.findLeftmostStart("xxxcatxxx", 0, b.step));
+    assertEquals(3, b.cache.findLeftmostStart("xxxdogxxx", 0, b.step));
+    assertEquals(-1, b.cache.findLeftmostStart("xxxxxxxxx", 0, b.step));
+    // "cad" shares a prefix with "cat" and a suffix with "dog" but is neither.
+    assertEquals(-1, b.cache.findLeftmostStart("xxxcadxxx", 0, b.step));
+  }
+
+  // --- (b) Adversarial unbounded-width case: localization across content wider than any fixed --
+  // --- window could handle, exercising the FALLBACK/frozen path once the cache hits DEFAULT_CAP --
+
+  @Test
+  void quotedString_unboundedWidthBody_findsExactOpeningQuote() throws Exception {
+    // '(?:''|[^'])*' : a SQL-style quoted string (simplified standalone version of SQL_ANSI's
+    // quoted-string branch) whose body is unbounded width. Once the opening quote at index 3 is
+    // consumed, the single surviving candidate's age grows by 1 on every subsequent 'a' — so
+    // after enough characters this genuinely defeats the "same (subset, age-vector) pair recurs"
+    // boundedness LaurikariNfaStep's class javadoc describes for typical bounded-loop patterns:
+    // here the interned state space *does* grow with input length, DEFAULT_CAP (4096) is hit
+    // partway through the run of 'a's, and LaurikariDFACache.findLeftmostStart must fall through
+    // to nfaFallbackFindLeftmostStart to finish the scan. This test's whole point is to prove that
+    // fallback path is exactly as correct as the cached path, not merely that the cached path
+    // works for short inputs.
+    Built b = build("'(?:''|[^'])*'", 0);
+
+    String input = "xxx'" + "a".repeat(5000) + "'yyy";
+    assertEquals(3, b.cache.findLeftmostStart(input, 0, b.step));
+  }
+
+  // --- (c) Genuine merge-tie case ------------------------------------------------------------
+
+  @Test
+  void repetition_selfAnchoringRestart_neverOverridesOlderSurvivingCandidate() throws Exception {
+    // a+b built by ThompsonBuilder (traced and verified, not assumed) has exactly these states:
+    //   0 --'a'--> 1 --eps--> {0, 2}
+    //   2 --'b'--> 3 --eps--> 4 (accept)
+    // i.e. state 1's epsilon fans out to BOTH state 0 (loop back for another 'a') and state 2
+    // (proceed to try 'b'), and state 0 is *also* the pattern's start state, so it is always
+    // re-seeded at age 0 by step 3's fresh self-anchoring closure(startId).
+    //
+    // Scanning "aaab" from position 0:
+    //   pos0 'a': dfa1 = {0,1,2}@{1,1,1}   (closure of consuming-target 1@1 reaches 0@1 and 2@1)
+    //   pos1 'a': dfa2 = {0,1,2}@{2,2,2}
+    //   pos2 'a': dfa3 = {0,1,2}@{3,3,3}
+    //   pos3 'b': dfa4 = {0,3,4}@{0,4,4}  -- accepting (state 4), winning age 4 -> start = 0
+    //
+    // At every one of those first three steps, state 0 is reached by TWO different-aged
+    // candidates in the same LaurikariNfaStep.apply call: the loop-back copy carried through
+    // closure of the consuming step (age k, k = pos+1: the original candidate that started
+    // consuming 'a' at position 0 and has survived k steps) AND the fresh self-anchoring
+    // re-injection of closure(startId) at age 0 (a brand-new candidate about to attempt starting
+    // its own match at the next position). This is the genuine collision: same target NFA state
+    // (id 0), reached via two different paths with two different ages in a single merge. The
+    // "keep the larger age" rule (k > 0 for k >= 1) means the fresh restart never overwrites the
+    // older, more-leftmost lineage's age at state 0 — which is exactly what preserves the correct
+    // start-position bookkeeping all the way to the eventual accept at position 3, where the
+    // winning age (4) recovers start = (3+1)-4 = 0, not some later restart's (wrong) start.
+    //
+    // Fresher restarts injected at positions 1, 2, or 3 are genuinely dead ends for reaching the
+    // 'b'-consuming state 2: they would need to consume an 'a' first (state0 --'a'--> state1), but
+    // by the time any of them could reach state1 and loop to state2, the input's only 'b' (at
+    // position 3) has already been consumed by the original, older lineage — so state 2/3/4 are
+    // never subject to the same double-arrival collision state 0 sees; only state 0 is contested,
+    // and only because it is simultaneously the loop-back epsilon target and the start state.
+    Built b = build("a+b", 0);
+
+    assertEquals(0, b.cache.findLeftmostStart("aaab", 0, b.step));
+  }
+
+  // --- (d) Genuine combinatorial stress: many candidates of different ages colliding under -----
+  // --- branchy input, as distinct from (b)'s single-lineage monotonic-age growth. Measured -----
+  // --- growth (via a throwaway sweep, not asserted here): stateCount ~= 2*cycleUnits - 1, i.e. ---
+  // --- LINEAR in input length, reaching DEFAULT_CAP (4096) at ~2050 cycle units -- confirming ---
+  // --- that Phase 0's age-based cache does NOT generally bound state growth by NFA structure ---
+  // --- alone; it only stays small on inputs like SQL_ANSI/LONG's benign filler because that ----
+  // --- filler keeps almost nothing alive. This test documents the real failure mode rather than -
+  // --- pretending it doesn't happen: FALLBACK is expected and exercised, and the assertion is ---
+  // --- that the fallback path still localizes correctly despite it, not that the cap is avoided.
+
+  @Test
+  void denseAlternation_manyOverlappingCandidateAges_hitsCapButFallbackStaysCorrect()
+      throws Exception {
+    // Six disjoint 3-char branches over a 2-letter alphabet, looped, requiring a trailing 'z' to
+    // accept. Every position in an a/b run is a fresh self-anchoring restart (step 3 of
+    // LaurikariNfaStep's merge), so scanning a long a/b string keeps many candidates that started
+    // at different offsets simultaneously alive at different ages as they race through the shared
+    // alternation -- unlike quotedString_unboundedWidthBody's test above, where only ONE lineage
+    // ever survives past the opening quote, here many *different* (subset, age-vector) combinations
+    // are live across the scan, and the growth is driven by that diversity, not one candidate's
+    // age.
+    Built b = build("(?:aab|aba|baa|abb|bab|bba)*z", 0);
+
+    // 3000 cycle units (well past the ~2050-unit point where the sweep above hits DEFAULT_CAP),
+    // then a single trailing 'z' so the only way to reach it is through
+    // nfaFallbackFindLeftmostStart
+    // once the cache has frozen.
+    StringBuilder sb = new StringBuilder();
+    String[] cycle = {"a", "b", "ab", "ba", "aab", "bba"};
+    for (int i = 0; i < 3000; i++) {
+      sb.append(cycle[i % cycle.length]);
+    }
+    sb.append('z');
+    String denseInput = sb.toString();
+
+    java.util.regex.Matcher oracle =
+        java.util.regex.Pattern.compile("(?:aab|aba|baa|abb|bab|bba)*z").matcher(denseInput);
+    assertTrue(oracle.find(), "JDK oracle must find a match (the trailing 'z' alone always does)");
+    int expectedStart = oracle.start();
+
+    assertEquals(expectedStart, b.cache.findLeftmostStart(denseInput, 0, b.step));
+
+    int stateCount = b.cache.stateCount();
+    assertEquals(
+        LaurikariDFACache.DEFAULT_CAP,
+        stateCount,
+        "expected this dense branchy input to hit DEFAULT_CAP (confirming real, input-length-driven"
+            + " growth, not a fixed NFA-structure bound) -- if this fails because stateCount is now"
+            + " LOWER, that's a genuine improvement worth re-deriving this test's sweep for; if"
+            + " it's HIGHER, the cache silently grew past its own advertised cap.");
+  }
+}

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariPhase05Test.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariPhase05Test.java
@@ -1,0 +1,406 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.datadoghq.reggie.codegen.ast.RegexNode;
+import com.datadoghq.reggie.codegen.automaton.NFA;
+import com.datadoghq.reggie.codegen.automaton.ThompsonBuilder;
+import com.datadoghq.reggie.codegen.parsing.RegexParser;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Phase 0.5 checkpoint (impl plan §2, doc/2026-07-10-tdfa-capture-engine-impl-plan.md): 2-3
+ * independent capture tags, exercising cross-tag merge conflicts that Phase 0's single
+ * total-ordered "age" tag ({@link LaurikariDFACacheTest}) cannot reach at all.
+ *
+ * <p><b>Tie-break discipline</b> (design §4, "whole-mapping priority discard"): unlike Phase 0's
+ * value-based "larger age wins," this driver tracks genuine priority order — a DFS through epsilon
+ * transitions in {@code curStates}' array order (index 0 = highest priority), first-visit wins,
+ * mirroring {@code PikeVMMatcher.addThread} exactly (see that method for the reference semantics
+ * this driver replicates). {@code curStates}' order is therefore load-bearing and never
+ * canonicalized/sorted, unlike Phase 0's driver.
+ *
+ * <p><b>Register encoding</b>: each of the {@code tagCount} registers stores an "age" (characters
+ * consumed since that tag was last set), exactly generalizing Phase 0's single age register to N
+ * independent ages instead of one — not "set to absolute position" (design/Task 1.2's eventual real
+ * mechanism, which needs runtime-substituted register *operations* to stay cache-friendly under an
+ * unbounded scan). Consuming a character ages every currently-set register by 1; closure resets a
+ * specific tag's age to 0 the moment it passes through that tag's {@code enterGroup}/ {@code
+ * exitGroup} marker state. The absolute tag position is recovered only once, at the end, as {@code
+ * consumed - age} — same formula Phase 0's {@code acceptAge} uses for its one tag. Choosing this
+ * encoding (over literal positions) is itself part of what Task 0.5.3 measures: if ages stay small
+ * in practice for these patterns, {@link LaurikariStateSetKey}'s value-based caching stays viable
+ * at this register shape; if they do not, that is precisely the state-space blowup signal this
+ * checkpoint exists to surface before Phase 1 commits to the real tag count.
+ *
+ * <p><b>Task 0.5.1a's hand-derivation</b> is confined to each pattern's small {@code tagSpecs}
+ * table below ({@code {groupNumber, isEnter}} pairs) — the closure/step driver itself is shared,
+ * generic machinery (not per-pattern hardcoded), reading {@link NFA.NFAState#enterGroup}/{@link
+ * NFA.NFAState#exitGroup} to resolve each spec to the concrete NFA state id(s) that carry it. This
+ * is legitimate: what's hand-picked is *which* 2-3 group boundaries matter for this checkpoint, not
+ * *how* a boundary maps to a state id (Phase 1's Task 1.1/1.2 generalizes this same lookup to
+ * literally every group instead of 2-3 hand-picked ones — the mechanism doesn't change, only the
+ * number of tags fed into it does).
+ *
+ * <p>Scope: this driver assumes an anchored whole-input match (mirrors {@code Matcher.matches()}
+ * semantics) — it accepts only if the NFA's accept state is live after consuming every input
+ * character, not the leftmost-find-localization semantics {@code LaurikariDFACacheTest} covers.
+ * That split (locate the match span, then extract its captures) matches how Phase 1's eventual
+ * capture engine is expected to compose with Phase 0's boolean/localization DFA (design §7) — this
+ * checkpoint only needs to validate the extraction half.
+ */
+class LaurikariPhase05Test {
+
+  // --- NFA plumbing, shared with LaurikariDFACacheTest's test-only driver -----------------------
+
+  private static NFA nfa(String pattern, int groupCount) throws Exception {
+    RegexNode ast = new RegexParser().parse(pattern);
+    return new ThompsonBuilder().build(ast, groupCount);
+  }
+
+  private static NFA.NFAState[] statesById(NFA nfa) {
+    NFA.NFAState[] arr = new NFA.NFAState[nfa.getStates().size()];
+    for (NFA.NFAState s : nfa.getStates()) {
+      arr[s.id] = s;
+    }
+    return arr;
+  }
+
+  /**
+   * Resolves each {@code tagSpecs[t] = {groupNumber, isEnter (1/0)}} entry to the NFA state id(s)
+   * that carry it: {@code tagOfState[id] = t} for every state matching tag {@code t}'s spec (see
+   * class javadoc's "Task 0.5.1a's hand-derivation" note — more than one state id can map to the
+   * same tag, e.g. {@code ((a)|())*}'s outer-close, reached via either alternation branch).
+   */
+  private static int[] tagOfState(NFA nfa, int stateCount, int[][] tagSpecs) {
+    int[] tagOfState = new int[stateCount];
+    Arrays.fill(tagOfState, -1);
+    for (NFA.NFAState s : nfa.getStates()) {
+      for (int t = 0; t < tagSpecs.length; t++) {
+        int group = tagSpecs[t][0];
+        boolean enter = tagSpecs[t][1] == 1;
+        if (enter
+            ? (s.enterGroup != null && s.enterGroup == group)
+            : (s.exitGroup != null && s.exitGroup == group)) {
+          tagOfState[s.id] = t;
+        }
+      }
+    }
+    return tagOfState;
+  }
+
+  private static int[] ageAll(int[] regs) {
+    int[] out = new int[regs.length];
+    for (int i = 0; i < regs.length; i++) {
+      out[i] = regs[i] < 0 ? -1 : regs[i] + 1;
+    }
+    return out;
+  }
+
+  /**
+   * Priority-ordered epsilon-closure DFS (first-visit wins per {@code visited}, mirroring {@code
+   * PikeVMMatcher.addThread}), resetting {@code tagOfState[id]}'s age to 0 at each tag boundary
+   * crossed and propagating every other tag's age unchanged.
+   */
+  private static void addClosure(
+      NFA.NFAState[] statesById,
+      boolean[] visited,
+      List<Integer> outIds,
+      List<int[]> outRegs,
+      int[] tagOfState,
+      int id,
+      int[] regs) {
+    if (visited[id]) return;
+    visited[id] = true;
+    int tag = tagOfState[id];
+    int[] r = regs;
+    if (tag >= 0) {
+      r = regs.clone();
+      r[tag] = 0;
+    }
+    outIds.add(id);
+    outRegs.add(r);
+    for (NFA.NFAState e : statesById[id].getEpsilonTransitions()) {
+      addClosure(statesById, visited, outIds, outRegs, tagOfState, e.id, r);
+    }
+  }
+
+  /** {@link LaurikariNfaStep} implementing the whole-mapping priority-discard rule (design §4). */
+  private static LaurikariNfaStep laurikariStep(NFA nfa, int[] tagOfState) {
+    NFA.NFAState[] statesById = statesById(nfa);
+    int stateCount = statesById.length;
+    return (curStates, curRegs, c) -> {
+      boolean[] seenTarget = new boolean[stateCount];
+      List<Integer> seedIds = new ArrayList<>();
+      List<int[]> seedRegs = new ArrayList<>();
+      for (int i = 0; i < curStates.length; i++) {
+        NFA.NFAState s = statesById[curStates[i]];
+        for (NFA.Transition t : s.getTransitions()) {
+          if (t.chars.contains((char) c)) {
+            int tid = t.target.id;
+            if (!seenTarget[tid]) {
+              seenTarget[tid] = true;
+              seedIds.add(tid);
+              seedRegs.add(ageAll(curRegs[i]));
+            }
+          }
+        }
+      }
+      boolean[] visited = new boolean[stateCount];
+      List<Integer> outIds = new ArrayList<>();
+      List<int[]> outRegs = new ArrayList<>();
+      for (int i = 0; i < seedIds.size(); i++) {
+        addClosure(
+            statesById, visited, outIds, outRegs, tagOfState, seedIds.get(i), seedRegs.get(i));
+      }
+      int[] states = new int[outIds.size()];
+      for (int i = 0; i < states.length; i++) states[i] = outIds.get(i);
+      int[][] regs = outRegs.toArray(new int[0][]);
+      return new LaurikariStepResult(states, regs);
+    };
+  }
+
+  private static final class Built {
+    final NFA nfa;
+    final int[] initStates;
+    final int[][] initRegs;
+    final LaurikariNfaStep step;
+    final int acceptId;
+    final int tagCount;
+
+    Built(
+        NFA nfa,
+        int[] initStates,
+        int[][] initRegs,
+        LaurikariNfaStep step,
+        int acceptId,
+        int tagCount) {
+      this.nfa = nfa;
+      this.initStates = initStates;
+      this.initRegs = initRegs;
+      this.step = step;
+      this.acceptId = acceptId;
+      this.tagCount = tagCount;
+    }
+  }
+
+  private static Built build(String pattern, int groupCount, int[][] tagSpecs) throws Exception {
+    NFA nfa = nfa(pattern, groupCount);
+    NFA.NFAState[] statesById = statesById(nfa);
+    int stateCount = statesById.length;
+    int startId = nfa.getStartState().id;
+    int tagCount = tagSpecs.length;
+    int[] tagOfState = tagOfState(nfa, stateCount, tagSpecs);
+
+    int[] allUnset = new int[tagCount];
+    Arrays.fill(allUnset, -1);
+    boolean[] visited = new boolean[stateCount];
+    List<Integer> outIds = new ArrayList<>();
+    List<int[]> outRegs = new ArrayList<>();
+    addClosure(statesById, visited, outIds, outRegs, tagOfState, startId, allUnset);
+    int[] initStates = new int[outIds.size()];
+    for (int i = 0; i < initStates.length; i++) initStates[i] = outIds.get(i);
+    int[][] initRegs = outRegs.toArray(new int[0][]);
+
+    int acceptId = nfa.getAcceptStates().iterator().next().id;
+    return new Built(nfa, initStates, initRegs, laurikariStep(nfa, tagOfState), acceptId, tagCount);
+  }
+
+  /**
+   * Runs the whole {@code input} through {@code built}'s step function (uncached — this is a
+   * correctness driver, not the growth-measurement one below) and returns the absolute tag
+   * positions at the accept state once every character is consumed, or {@code null} if the accept
+   * state isn't live at the end (no whole-input match).
+   */
+  private static int[] runToEnd(Built built, String input) {
+    int[] curStates = built.initStates;
+    int[][] curRegs = built.initRegs;
+    int consumed = 0;
+    for (int i = 0; i < input.length(); i++) {
+      if (curStates.length == 0) return null;
+      LaurikariStepResult r = built.step.apply(curStates, curRegs, input.charAt(i));
+      curStates = r.states;
+      curRegs = r.regs;
+      consumed++;
+    }
+    int idx = -1;
+    for (int i = 0; i < curStates.length; i++) {
+      if (curStates[i] == built.acceptId) {
+        idx = i;
+        break;
+      }
+    }
+    if (idx < 0) return null;
+    int[] ages = curRegs[idx];
+    int[] absolute = new int[built.tagCount];
+    for (int t = 0; t < built.tagCount; t++) {
+      absolute[t] = ages[t] < 0 ? -1 : consumed - ages[t];
+    }
+    return absolute;
+  }
+
+  private static PikeVMMatcher pikeVm(String pattern, int groupCount) throws Exception {
+    NFA nfa = nfa(pattern, groupCount);
+    return new PikeVMMatcher(nfa, pattern);
+  }
+
+  // --- (a) (a+)(b+): 2 tags, group1's close + group2's open --------------------------------------
+
+  @Test
+  void twoIndependentGroups_greedyBoundaries_matchPikeVM() throws Exception {
+    int[][] tagSpecs = {{1, 0}, {2, 1}}; // tag0 = group1 exit, tag1 = group2 enter
+    Built built = build("(a+)(b+)", 2, tagSpecs);
+    PikeVMMatcher oracle = pikeVm("(a+)(b+)", 2);
+
+    for (String input : new String[] {"ab", "aaabbb", "aaaaaaaabb", "ab" /* min case */}) {
+      MatchResult oracleResult = oracle.match(input);
+      assertNotNull(oracleResult, "PikeVMMatcher must match " + input);
+
+      int[] absolute = runToEnd(built, input);
+      assertNotNull(absolute, "Laurikari driver must also match " + input);
+
+      // tag0 = group1's exit = oracle.end(1); tag1 = group2's enter = oracle.start(2)
+      assertArrayEquals(
+          new int[] {oracleResult.end(1), oracleResult.start(2)},
+          absolute,
+          "capture boundaries diverged from PikeVMMatcher for input " + input);
+    }
+  }
+
+  // --- (b) (ab)+: 2 tags, single group's open+close, re-set every loop iteration
+  // ------------------
+
+  @Test
+  void loopBodyGroup_reSetOnEveryIteration_matchesPikeVM() throws Exception {
+    int[][] tagSpecs = {{1, 1}, {1, 0}}; // tag0 = group1 enter, tag1 = group1 exit
+    Built built = build("(ab)+", 1, tagSpecs);
+    PikeVMMatcher oracle = pikeVm("(ab)+", 1);
+
+    for (String input : new String[] {"ab", "abab", "ababab", "abababababab"}) {
+      MatchResult oracleResult = oracle.match(input);
+      assertNotNull(oracleResult, "PikeVMMatcher must match " + input);
+
+      int[] absolute = runToEnd(built, input);
+      assertNotNull(absolute, "Laurikari driver must also match " + input);
+
+      // Perl/greedy semantics: group 1's final captured span is its LAST iteration, i.e. the
+      // input's
+      // trailing "ab" — exactly what oracle.start(1)/end(1) already report.
+      assertArrayEquals(
+          new int[] {oracleResult.start(1), oracleResult.end(1)},
+          absolute,
+          "loop-back re-set boundaries diverged from PikeVMMatcher for input " + input);
+    }
+  }
+
+  // --- (c) ((a)|())*: 3 tags, outer open/close + inner group's open (nullable-branch case) -------
+
+  @Test
+  void nestedGroupsWithNullableBranch_matchesPikeVM() throws Exception {
+    // tag0 = outer group1 enter, tag1 = outer group1 exit, tag2 = inner group2 (the "(a)" branch)
+    // enter. Group3 (the "()" branch) and group2's exit are deliberately untracked (design's
+    // "3 tags" scope, see class/plan doc).
+    int[][] tagSpecs = {{1, 1}, {1, 0}, {2, 1}};
+    Built built = build("((a)|())*", 3, tagSpecs);
+    PikeVMMatcher oracle = pikeVm("((a)|())*", 3);
+
+    // "a" then "" then "a": last iteration is the empty branch, so tag2 (inner group2's open) must
+    // reflect the LAST time group2 participated (an earlier iteration), not this run's final
+    // iteration — the exact nullable-branch subtlety this pattern is chosen to exercise.
+    for (String input : new String[] {"", "a", "aa", "aaa"}) {
+      MatchResult oracleResult = oracle.match(input);
+      assertNotNull(oracleResult, "PikeVMMatcher must match " + input);
+
+      int[] absolute = runToEnd(built, input);
+      assertNotNull(absolute, "Laurikari driver must also match " + input);
+
+      int expectedGroup2Start = oracleResult.start(2); // -1 if group 2 never participated
+      assertArrayEquals(
+          new int[] {oracleResult.start(1), oracleResult.end(1), expectedGroup2Start},
+          absolute,
+          "nested/nullable-branch boundaries diverged from PikeVMMatcher for input " + input);
+    }
+  }
+
+  // --- Task 0.5.3: state-count growth from N=2 (two patterns) to N=3, via the generalized
+  // ---------
+  // --- LaurikariDFACache caching layer (Task 0.5.1's actual production interning path, not the ---
+  // --- uncached driver above) over an adversarial input designed to keep several live candidate --
+  // --- register-age vectors distinct at once, the same shape as LaurikariDFACacheTest's own
+  // -------
+  // --- denseAlternation stress case.
+  //
+  // Report (printed, not asserted — this is a measurement, not a pass/fail check per Task 0.5.3):
+  // distinct DFA states materialized for each of the three patterns, to compare against Phase 0's
+  // already-reported single-tag numbers and each other.
+
+  @Test
+  void stateCountGrowth_twoAndThreeTags_reportedForPhase05ExitCriteria() throws Exception {
+    // Scale sweep per pattern (not a single data point) so the growth *rate* — not just one
+    // sample — is visible for the exit-criteria report. (a+)(b+)'s tag0 (group1's close) never
+    // resets once set, so its age grows for as long as the b+ tail keeps consuming — the same
+    // already-accepted-and-mitigated growth mode Phase 0's own quotedString adversarial test
+    // exercises (cap-and-fallback, not a new failure class). (ab)+/((a)|())*'s tags reset every
+    // loop iteration, so their ages stay small regardless of scale — the interesting comparison
+    // for "does tag COUNT itself drive blowup" (2 tags vs 3, both loop-reset).
+    for (int n : new int[] {100, 400, 1600}) {
+      report("(a+)(b+)", 2, new int[][] {{1, 0}, {2, 1}}, "a".repeat(n) + "b".repeat(n));
+    }
+    for (int n : new int[] {100, 400, 1600}) {
+      report("(ab)+", 1, new int[][] {{1, 1}, {1, 0}}, "ab".repeat(n));
+    }
+    for (int n : new int[] {100, 400, 1600}) {
+      report("((a)|())*", 3, new int[][] {{1, 1}, {1, 0}, {2, 1}}, "a".repeat(n));
+    }
+  }
+
+  private static void report(String pattern, int groupCount, int[][] tagSpecs, String input)
+      throws Exception {
+    Built built = build(pattern, groupCount, tagSpecs);
+    int[] acceptIds = {built.acceptId};
+    LaurikariDFACache cache = new LaurikariDFACache(built.initStates, built.initRegs, acceptIds);
+
+    int dfaState = 0;
+    int[] curStates = built.initStates;
+    int[][] curRegs = built.initRegs;
+    boolean fellBack = false;
+    for (int i = 0; i < input.length() && !fellBack; i++) {
+      int next = cache.lookupOrCompute(dfaState, input.charAt(i), built.step);
+      if (next == LaurikariDFACache.DEAD) break;
+      if (next == LaurikariDFACache.FALLBACK) {
+        fellBack = true;
+        break;
+      }
+      dfaState = next;
+    }
+    System.out.println(
+        "=== Phase 0.5 growth report: "
+            + pattern
+            + " (tagCount="
+            + tagSpecs.length
+            + ", inputLen="
+            + input.length()
+            + ") ===");
+    System.out.println("    distinct DFA states materialized: " + cache.stateCount());
+    System.out.println("    hit cap/fell back to uncached stepping: " + fellBack);
+  }
+}

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariPhase0SpikeTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariPhase0SpikeTest.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datadoghq.reggie.codegen.automaton.NFA;
+import com.datadoghq.reggie.codegen.automaton.ThompsonBuilder;
+import com.datadoghq.reggie.codegen.parsing.RegexParser;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Phase-0 exit-criteria evidence (impl plan Task 0.3,
+ * doc/2026-07-10-tdfa-capture-engine-impl-plan.md §1): builds a {@link LaurikariDFACache} over the
+ * real {@code SQL_ANSI} tokenizer pattern (mirrored from {@code IastRegexpBenchmark.SQL_ANSI}) and
+ * runs it over that benchmark's LONG-scale scan-prefix inputs — the exact shape that exceeds {@code
+ * BitStateMatcher.BUDGET_CELLS} and today gets punted all the way to {@code PikeVMMatcher}'s full
+ * thread simulation.
+ *
+ * <p>This is a throwaway measurement harness, not a correctness/regression suite: it exists purely
+ * to produce the three numbers Task 0.3 asks for (exact localization, materialized state count,
+ * rough wall-clock signal vs. the JDK oracle) for the Phase 0 exit-criteria report. The
+ * closure/step-function driver duplicates {@code LaurikariDFACacheTest}'s test-only driver verbatim
+ * (same legitimate test-only duplication rationale documented there) rather than sharing code
+ * across test classes, since both are disposable Phase-0 scaffolding.
+ */
+class LaurikariPhase0SpikeTest {
+
+  // --- SQL_ANSI, mirrored from IastRegexpBenchmark.java:101-104 --------------------------------
+  private static final String SQL_ANSI =
+      "(?i)(?m)[-+]?(?:x'[0-9a-f]+'|0x[0-9a-f]+|b'[0-9a-f]+'|0b[0-9a-f]+"
+          + "|\\d*\\.\\d+(?:E[-+]?\\d+[fd]?)?|\\b\\d+(?:E[-+]?\\d+[fd]?)?)"
+          + "|'(?:''|[^'])*'|--.*$|/\\*[\\s\\S]*\\*/";
+
+  // --- LONG-scale sqlMatch/sqlNoMatch, mirrored from IastRegexpBenchmark.java:241-260 (the third
+  // --- `pick(scale, ...)` argument, since IastRegexpBenchmark.pick() returns longV by default for
+  // --- any scale other than SHORT/MEDIUM, i.e. LONG). "col_x = col_y AND ".repeat(2000) is benign
+  // --- scan-prefix filler (no digits/quotes/comment markers) that BitStateMatcher's bounded budget
+  // --- cannot get through without falling all the way to PikeVMMatcher.
+  private static final String SQL_MATCH_LONG =
+      "SELECT * FROM users WHERE "
+          + "col_x = col_y AND ".repeat(2000)
+          + "id = 42 AND name = 'Alice' AND balance = 1234.56";
+  private static final String SQL_NO_MATCH_LONG =
+      "SELECT id, name, email FROM users WHERE "
+          + "col_x = col_y AND ".repeat(2000)
+          + "id = id ORDER BY id";
+
+  // --- Test-only LaurikariNfaStep driver, duplicated verbatim from LaurikariDFACacheTest ---------
+
+  private static NFA nfa(String pattern, int groupCount) throws Exception {
+    return new ThompsonBuilder().build(new RegexParser().parse(pattern), groupCount);
+  }
+
+  private static NFA.NFAState[] statesById(NFA nfa) {
+    NFA.NFAState[] arr = new NFA.NFAState[nfa.getStates().size()];
+    for (NFA.NFAState s : nfa.getStates()) {
+      arr[s.id] = s;
+    }
+    return arr;
+  }
+
+  private static int[][] closureWithAges(
+      NFA.NFAState[] statesById, int stateCount, int[] seedStates, int[] seedAges) {
+    int[] ages = new int[stateCount];
+    Arrays.fill(ages, -1);
+    Deque<Integer> worklist = new ArrayDeque<>();
+    for (int i = 0; i < seedStates.length; i++) {
+      int id = seedStates[i];
+      if (seedAges[i] > ages[id]) {
+        ages[id] = seedAges[i];
+        worklist.push(id);
+      }
+    }
+    while (!worklist.isEmpty()) {
+      int id = worklist.pop();
+      int age = ages[id];
+      for (NFA.NFAState e : statesById[id].getEpsilonTransitions()) {
+        if (age > ages[e.id]) {
+          ages[e.id] = age;
+          worklist.push(e.id);
+        }
+      }
+    }
+    return denseToSeed(ages, stateCount);
+  }
+
+  private static int[][] denseToSeed(int[] denseAges, int stateCount) {
+    int count = 0;
+    for (int v : denseAges) {
+      if (v >= 0) count++;
+    }
+    int[] states = new int[count];
+    int[] ages = new int[count];
+    int oi = 0;
+    for (int id = 0; id < stateCount; id++) {
+      if (denseAges[id] >= 0) {
+        states[oi] = id;
+        ages[oi] = denseAges[id];
+        oi++;
+      }
+    }
+    return new int[][] {states, ages};
+  }
+
+  private static LaurikariNfaStep laurikariStep(NFA nfa) {
+    NFA.NFAState[] statesById = statesById(nfa);
+    int stateCount = statesById.length;
+    int startId = nfa.getStartState().id;
+    return (curStates, curRegs, c) -> {
+      int[] rawAges = new int[stateCount];
+      Arrays.fill(rawAges, -1);
+      for (int i = 0; i < curStates.length; i++) {
+        NFA.NFAState s = statesById[curStates[i]];
+        int age = curRegs[i][0];
+        for (NFA.Transition t : s.getTransitions()) {
+          if (t.chars.contains((char) c)) {
+            int cand = age + 1;
+            if (cand > rawAges[t.target.id]) rawAges[t.target.id] = cand;
+          }
+        }
+      }
+      int[][] consumedSeed = denseToSeed(rawAges, stateCount);
+      int[][] consumedClosed =
+          closureWithAges(statesById, stateCount, consumedSeed[0], consumedSeed[1]);
+      int[][] freshClosed =
+          closureWithAges(statesById, stateCount, new int[] {startId}, new int[] {0});
+
+      int[] merged = new int[stateCount];
+      Arrays.fill(merged, -1);
+      for (int i = 0; i < consumedClosed[0].length; i++) {
+        merged[consumedClosed[0][i]] = consumedClosed[1][i];
+      }
+      for (int i = 0; i < freshClosed[0].length; i++) {
+        int id = freshClosed[0][i];
+        int age = freshClosed[1][i];
+        if (age > merged[id]) merged[id] = age;
+      }
+      int[][] out = denseToSeed(merged, stateCount);
+      int[] outStates = out[0];
+      int[] outAges = out[1];
+      int[][] outRegs = new int[outStates.length][];
+      for (int i = 0; i < outStates.length; i++) {
+        outRegs[i] = new int[] {outAges[i]};
+      }
+      return new LaurikariStepResult(outStates, outRegs);
+    };
+  }
+
+  private static final class Built {
+    final LaurikariDFACache cache;
+    final LaurikariNfaStep step;
+
+    Built(LaurikariDFACache cache, LaurikariNfaStep step) {
+      this.cache = cache;
+      this.step = step;
+    }
+  }
+
+  private static Built build(String pattern, int groupCount) throws Exception {
+    NFA nfa = nfa(pattern, groupCount);
+    NFA.NFAState[] statesById = statesById(nfa);
+    int stateCount = statesById.length;
+    int startId = nfa.getStartState().id;
+
+    int[][] startClosure =
+        closureWithAges(statesById, stateCount, new int[] {startId}, new int[] {0});
+
+    int[] acceptIds = new int[nfa.getAcceptStates().size()];
+    int ai = 0;
+    for (NFA.NFAState s : nfa.getAcceptStates()) {
+      acceptIds[ai++] = s.id;
+    }
+
+    int[] startStates = startClosure[0];
+    int[] startAges = startClosure[1];
+    int[][] startRegs = new int[startStates.length][];
+    for (int i = 0; i < startStates.length; i++) {
+      startRegs[i] = new int[] {startAges[i]};
+    }
+
+    LaurikariDFACache cache = new LaurikariDFACache(startStates, startRegs, acceptIds);
+    return new Built(cache, laurikariStep(nfa));
+  }
+
+  // --- Timing harness: NOT JMH-rigorous, explicitly a throwaway directional signal per the plan --
+
+  private static final int WARMUP_ITERS = 5;
+  private static final int MEASURED_ITERS = 5;
+
+  private static long medianNanos(long[] samples) {
+    long[] sorted = samples.clone();
+    Arrays.sort(sorted);
+    return sorted[sorted.length / 2];
+  }
+
+  @Test
+  void sqlAnsiLongScale_exactLocalization_stateCount_andRoughTiming() throws Exception {
+    // SQL_ANSI has no capturing groups (every parenthesis in it is (?i)/(?m)/(?:...)), so
+    // groupCount = 0, same convention LaurikariDFACacheTest uses for its own group-less patterns.
+    Built built = build(SQL_ANSI, 0);
+
+    // --- (3) Correctness on sqlMatch, oracle-derived (java.util.regex.Pattern is the oracle; the
+    // --- expected start is computed here, not hardcoded) -----------------------------------------
+    Pattern oracle = Pattern.compile(SQL_ANSI);
+    Matcher oracleMatcher = oracle.matcher(SQL_MATCH_LONG);
+    assertTrue(oracleMatcher.find(), "JDK oracle must find a match in SQL_MATCH_LONG");
+    int expectedStart = oracleMatcher.start();
+
+    int laurikariStart = built.cache.findLeftmostStart(SQL_MATCH_LONG, 0, built.step);
+    boolean exactLocalization = laurikariStart == expectedStart;
+    assertEquals(
+        expectedStart,
+        laurikariStart,
+        "LaurikariDFACache localized start must exactly match the JDK oracle's match start");
+
+    // --- (4) sqlNoMatch must return -1
+    // -------------------------------------------------------------
+    Matcher noMatchOracle = Pattern.compile(SQL_ANSI).matcher(SQL_NO_MATCH_LONG);
+    assertTrue(
+        !noMatchOracle.find(), "JDK oracle must NOT find a match in SQL_NO_MATCH_LONG (sanity)");
+    int laurikariNoMatch = built.cache.findLeftmostStart(SQL_NO_MATCH_LONG, 0, built.step);
+    assertEquals(-1, laurikariNoMatch, "LaurikariDFACache must report -1 on SQL_NO_MATCH_LONG");
+
+    // --- (b) total distinct DFA states materialized (package-private test-only accessor already
+    // --- present on LaurikariDFACache: stateCount())
+    // ----------------------------------------------
+    int stateCount = built.cache.stateCount();
+
+    // --- (c) rough wall-clock: LaurikariDFACache.findLeftmostStart vs Pattern.matcher().find(),
+    // --- same input (SQL_MATCH_LONG), 5 warmup + 5 measured iterations each, report the median of
+    // --- the measured set. Both sides reuse an already-"warm" object (the cache and the compiled
+    // --- Pattern respectively) across iterations, matching how each would actually be used
+    // --- repeatedly in production (one-time build cost amortized away) -- this is explicitly NOT
+    // --- JMH-quality, just a directional signal per the plan's own framing.
+    Pattern timingPattern = Pattern.compile(SQL_ANSI);
+
+    for (int i = 0; i < WARMUP_ITERS; i++) {
+      built.cache.findLeftmostStart(SQL_MATCH_LONG, 0, built.step);
+      timingPattern.matcher(SQL_MATCH_LONG).find();
+    }
+
+    long[] laurikariNanos = new long[MEASURED_ITERS];
+    for (int i = 0; i < MEASURED_ITERS; i++) {
+      long t0 = System.nanoTime();
+      built.cache.findLeftmostStart(SQL_MATCH_LONG, 0, built.step);
+      laurikariNanos[i] = System.nanoTime() - t0;
+    }
+
+    long[] jdkNanos = new long[MEASURED_ITERS];
+    for (int i = 0; i < MEASURED_ITERS; i++) {
+      long t0 = System.nanoTime();
+      timingPattern.matcher(SQL_MATCH_LONG).find();
+      jdkNanos[i] = System.nanoTime() - t0;
+    }
+
+    long laurikariMedianNanos = medianNanos(laurikariNanos);
+    long jdkMedianNanos = medianNanos(jdkNanos);
+
+    System.out.println("=== LaurikariPhase0SpikeTest / Phase 0 Task 0.3 measurements ===");
+    System.out.println("(a) exact localization vs JDK oracle: " + exactLocalization);
+    System.out.println(
+        "    expectedStart(JDK oracle)=" + expectedStart + " laurikariStart=" + laurikariStart);
+    System.out.println("(b) distinct DFA states materialized: " + stateCount);
+    System.out.println(
+        "(c) LaurikariDFACache.findLeftmostStart median nanos ("
+            + MEASURED_ITERS
+            + " measured, "
+            + WARMUP_ITERS
+            + " warmup): "
+            + laurikariMedianNanos
+            + " ns, all samples="
+            + Arrays.toString(laurikariNanos));
+    System.out.println(
+        "    Pattern.matcher(...).find() median nanos ("
+            + MEASURED_ITERS
+            + " measured, "
+            + WARMUP_ITERS
+            + " warmup): "
+            + jdkMedianNanos
+            + " ns, all samples="
+            + Arrays.toString(jdkNanos));
+    System.out.println(
+        "    ratio (JDK / Laurikari): "
+            + (jdkMedianNanos == 0 ? "n/a" : (double) jdkMedianNanos / laurikariMedianNanos));
+    System.out.println("==================================================================");
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Adds a Laurikari-style tagged-DFA spike for capture-group extraction: Phase 0 validates a scalar-age register against JDK/PikeVM baselines; Phase 0.5 generalizes the register to a per-tag `int[]` vector with whole-mapping priority discard and checks state-space growth with 2-3 independent tags.

### Motivation

Per `doc/2026-07-10-tdfa-capture-engine-design.md` and its impl plan: evaluate whether a tagged-DFA can eventually replace the PikeVM-thread-simulation fallback for capture-heavy patterns without combinatorial state blowup, before committing to Phase 1's full `2*(groupCount+1)`-tag machinery.

### Related Issue(s)



### Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [x] Test improvement
- [ ] Build/CI change

### Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] All existing tests pass (`./gradlew build`)
- [x] I have added tests for my changes
- [x] I have updated documentation (if applicable)
- [ ] My commits are signed

### Performance Impact

Not production-wired yet (Phase 0/0.5 spike only, package-private classes with no entry point). State-space growth measured across 3 adversarial patterns at 3 input scales each; see `LaurikariPhase05Test` — loop-reset patterns stay flat (5/3 states) regardless of tag count or scale, `(a+)(b+)` grows linearly with input length (~n/2), the same mitigated mode Phase 0's `quotedString` test already validates.

### Additional Notes

Stacked on top of #104 (`perf/bitstate-localize-before-fallback`) — this PR's diff is TDFA-only; merge #104 first.