### PR TITLE
TDFA Laurikari capture engine (Phase 0-2) + \b/\B fixed-sequence fast path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,9 @@
 plugins {
     id 'jacoco'
+    // Pinned below 8.3.0: 8.4.0's googleJavaFormat worker throws
+    // NoClassDefFoundError on com.sun.tools.javac.tree.JCTree$JCAnyPattern
+    // when formatting any file that needs reformatting (JDK 11/17/21 tested).
+    // Bump only after confirming spotlessApply works on a real file again.
     id 'com.diffplug.spotless' version '8.2.1'
     id 'com.vanniktech.maven.publish' version '0.36.0' apply false
     id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'jacoco'
-    id 'com.diffplug.spotless' version '8.4.0'
+    id 'com.diffplug.spotless' version '8.2.1'
     id 'com.vanniktech.maven.publish' version '0.36.0' apply false
     id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 }

--- a/doc/2026-07-10-tdfa-capture-engine-design.md
+++ b/doc/2026-07-10-tdfa-capture-engine-design.md
@@ -1,0 +1,345 @@
+# TDFA (tagged-DFA) capture engine — design
+
+Status: **draft / not started**. This is a forward design for a multi-week investment, written
+to support a go/no-go decision. No code changes are proposed alongside this document.
+
+## 1. Problem
+
+`BitStateMatcher` (the bounded-backtracking DFS capture engine) falls back to `PikeVMMatcher`
+(plain PikeVM thread simulation) whenever `stateCount * (spanLen + 1) > BUDGET_CELLS`
+(`BitStateMatcher.BUDGET_CELLS = 1 << 18`). For `SQL_ANSI` (97 NFA states) this threshold is
+~2700 input characters; the LONG-scale case of the `IastRegexpBenchmark` `SqlAnsiFind`/
+`SqlMysqlFind`/`SqlPostgresqlFind` benchmarks (`@Param("scale")`, added in
+`reggie-benchmark/.../IastRegexpBenchmark.java` on this branch, `perf/bitstate-hot-loop-flattening`
+commit `a5287c7` — the scale parameter does not exist on `main`) exceeds it, so every `find()` at
+that scale is served entirely by `PikeVMMatcher`'s full thread simulation.
+
+Measured effect (full SHORT→MEDIUM→LONG run, 53 methods × 3 scales, all 42 scaled inputs
+independently verified to match/not-match as intended before trusting the throughput numbers):
+LONG-scale input for these three benchmarks is `"col_x = col_y AND ".repeat(2000)` plus a fixed
+~75-char match/no-match suffix, ≈37KB. reggie/RE2J on `find()` drops from ~1.6x ahead at
+SHORT/MEDIUM to a genuine loss at LONG:
+
+| benchmark | reggie/jdk SHORT→MED→LONG | reggie/re2j SHORT→MED→LONG |
+|---|---|---|
+| `SqlAnsiFind` | 0.63x → 0.62x → 0.33x | 1.63x → 1.64x → **0.86x** |
+| `SqlMysqlFind` | 0.66x → 0.60x → 0.31x | 1.75x → 1.67x → **0.84x** |
+| `SqlPostgresqlFind` | 0.51x → 0.45x → 0.23x | 1.73x → 1.68x → **0.86x** |
+
+The MEDIUM→LONG degradation is real but ~2x, not the ~2000x an earlier draft of this section
+claimed — that figure had no benchmark backing it (caught by adversarial review; struck here,
+no replacement source exists) and is retracted. The correct, evidence-backed claim is narrower:
+these three patterns cross from *winning* against RE2J to *losing* against it specifically between
+MEDIUM and LONG scale, consistent with LONG being the only scale that crosses the `BUDGET_CELLS`
+threshold above.
+
+**Open, unattributed observation from the same run** (not folded into the analysis below, no
+root cause established yet): `LdapFind`, `UrlAuthFind`, and `UrlAuthCapture` degrade far worse
+over the same SHORT→LONG range — down to 0.02x–0.09x vs JDK at LONG (a 10–50x loss, not SQL's
+~3x), and `UrlQueryFind` drops to 0.93x vs RE2J at LONG (SQL's `Find` cases don't cross 1.0x until
+LONG either). Whether this is the same `BUDGET_CELLS` mechanism or a different bottleneck — LDAP's
+`LITERAL` group and the URL `AUTHORITY` branch are both "matched-region growth" inputs, unlike
+SQL's "scan-prefix growth" — is unconfirmed and out of scope for this document; flagged here so it
+isn't lost.
+
+Async-profiler confirmed the cost is real interpreter tax inside `PikeVMMatcher`'s own
+thread-simulation loop (per-character subset advance + capture-array bookkeeping across all live
+threads), not allocation or GC. Two cheaper mitigations were spiked and rejected before this
+document:
+
+- **Fixed-size windowed `BitStateMatcher` scan** (sequential windows sized to fit `BUDGET_CELLS`,
+  each an independent `search()` call). 2.9–3.4x real speedup, but **unsound**: `search()`'s
+  consuming-leaf bound hard-caps consumption at the window boundary, so a match whose content
+  (e.g. `SQL_ANSI`'s unbounded-width `'...'` literal or `/*...*/` comment) spans wider than one
+  window is silently missed. Rejected per the "only proceed if valid" gate.
+- **Dynamic window** (extend the window only while some thread is provably still alive). Requires
+  knowing *which* start position is responsible for keeping the DFA state alive at the boundary —
+  but `RejectDfaFactory`'s (and `PikeVMMatcher.findStep`'s) shared self-anchoring design discards
+  that attribution by construction: `RejectDfaFactory.build()`'s step function unions a fresh
+  `startAll` closure into *every* step's result unconditionally (`RejectDfaFactory.java`, the
+  `union(tc, startAll)` line), not only on death. This is why `LazyDFACache.findFrom`/`findEnd`
+  degrade to non-localizing behavior on patterns like `SQL_ANSI` whose broad alternation (7+
+  branches covering common characters) keeps some thread alive almost everywhere in prose-like
+  filler — the merged DFA state essentially never reaches a genuine `DEAD` transition. Recovering
+  per-candidate attribution to make the window boundary decision soundly is exactly tag/priority
+  tracking — i.e. the same investment as a TDFA, not a smaller one.
+- **A non-self-anchoring find-DFA for the anchored case**, extending `PikeVMMatcher.findDfaEligible`
+  (currently restricted to patterns whose only anchors are `START`/`STRING_START`/
+  `START_MULTILINE`, handled via the mid-line/after-newline reinject-closure split in the
+  constructor around `PikeVMMatcher.java:255-282`) to end anchors and `\b`. Analysis: naively
+  dropping the every-step reinject and relying only on `LazyDFACache.findFrom`'s restart-on-`DEAD`
+  is **incorrect** — restart-on-`DEAD` only tries a new start at wherever the *previous* attempt
+  died, silently skipping intermediate candidate starts that could independently match. A
+  single-scalar "leftmost live start" tag fixes that correctness gap but reintroduces the same
+  state-space/cache-reuse tension the tag machinery below has to solve anyway, for none of the
+  capture payoff. Not pursued as a separate, smaller project — folded into this design instead.
+
+Net: there is no cheap fix left on the table. The next tier is a genuinely tagged automaton.
+
+## 2. Goals / non-goals
+
+**Goals**
+- Eliminate the fallback-cliff class of regression: give `find()`/`findFrom()`/`match()` an O(n)
+  (or near-O(n), budget-bounded) path with real capture-group boundaries, for the pattern class
+  BitState/PikeVM already serve natively (no backrefs, no lookaround assertions, no atomic
+  groups — the existing `noAssertionsOrBackrefs`/`findDfaEligible`-style eligibility boundary).
+- Preserve today's leftmost-first (Perl/PCRE greedy) priority semantics exactly, for the patterns
+  TDFA is eligible for — this is the same semantics `PikeVMMatcher`'s thread ordering already
+  implements and that `CorrectnessTest` already asserts against JDK `Pattern`. This is explicitly
+  the *wrong* semantics for `usePosixLastMatch` patterns (see §5's eligibility note) — those must
+  stay excluded, not be given leftmost-first tags.
+- Keep the existing fallback architecture pattern: eligible-but-too-large inputs degrade
+  gracefully to `PikeVMMatcher`, exactly as `BitStateMatcher` degrades today. No correctness
+  regression is acceptable; performance regression on ineligible/oversized inputs is acceptable
+  (status quo).
+
+**Non-goals**
+- Do not attempt backreferences, lookaround assertions, or atomic groups in the TDFA itself —
+  those stay on `PikeVMMatcher`/`BackrefBacktrackMatcher` exactly as today.
+- Do not change public API, `Reggie.compile()` semantics, or bytecode generation strategy
+  selection in this phase. This is a `reggie-runtime` matcher-internal change, mirroring how
+  `BitStateMatcher` itself was introduced as an additional native strategy alongside PikeVM.
+
+## 3. Background: the two existing self-anchoring DFA builders
+
+Both `RejectDfaFactory.build()` and `PikeVMMatcher`'s boolean `findDfa`/`matchesDfa` construction
+share the same shape: subset-construct over the NFA via `LazyDFACache`, with a step function that
+unions in a fresh start-closure at every character (the "self-anchoring" trick that makes one scan
+implicitly try every start position at once, in O(n) instead of the O(n²) that trying each start
+independently would cost). This buys correctness and speed for the *boolean* question ("does a
+match exist from here"), but the union at merge time is exactly what erases which candidate start
+produced which surviving thread — there is no way to ask a self-anchoring DFA "which start is
+still alive" without also tracking that as part of the state, which is the core idea below.
+
+`PikeVMMatcher.findDfaEligible` already demonstrates the one case where *no* tag tracking is
+needed: `START`/`STRING_START`/`START_MULTILINE` anchors are **past-context-only** — whether they
+fire at a position depends only on whether the previous character was `\n` (or it's position 0),
+which the step function already knows locally without threading any extra state. That's why they
+can be handled by splitting the reinject closure into "mid-line" vs "after-newline" variants
+(`reinjectClosureIds` / `reinjectAfterNlClosureIds`) instead of needing per-position tags. End
+anchors (`$`, `\Z`, `\z`, `END_MULTILINE`) and `\b` don't have this property in general — `\b`
+needs one character of lookahead (feasible, symmetric to lookbehind), but "is this the true end of
+string" is a property of `regionEnd`, which the *caller* (`search()`/`findPosFrom()`) already
+threads separately from the scan bound (see `BitStateMatcher.search`'s `regionEnd` parameter,
+added specifically so a narrowed scan bound never corrupts `$`/`\z`/`\b`/`END_MULTILINE` checks).
+The TDFA should keep that same separation: anchor *evaluation* stays a per-step/per-accept check
+against the true end of input, not something baked into subset-construction identity.
+
+## 4. What a TDFA adds: tags and registers
+
+Standard reference: Ville Laurikari, *NFAs with Tagged Transitions, their Conversion to Deterministic
+Automata and Application to Regular Expression Recognition* (2000) — the algorithm RE2/RE2J's
+authors describe but did not implement (confirmed via RE2J 1.8 source inspection this session:
+RE2J has no BitState/OnePass/TDFA tier, only a plain per-thread PikeVM `Machine.java`). This is new
+ground *relative to RE2J*, but **not relative to this codebase**: `PatternAnalyzer` already has an
+unrelated "Tagged DFA" mechanism — `MatchingStrategyResult.useTaggedDFA`
+(`PatternAnalyzer.java:3420`) drives `DFAUnrolledBytecodeGenerator.generateTaggedDFAMatching`
+(`DFAUnrolledBytecodeGenerator.java:1557`) for the `DFA_UNROLLED_WITH_GROUPS` strategy
+(`PatternAnalyzer.java:3376`, "<20 states — unrolled with inline group tracking"), and is hashed
+into `StructuralHash.java:85/135`. That mechanism solves a narrower, different problem:
+compile-time-unrolled bytecode with inline group tracking and priority-cut semantics, bounded to
+small (<20-state) explicit DFAs — it does not do Laurikari-style register-based determinization
+over arbitrarily large NFAs at runtime, which is what this design proposes. The two are
+architecturally distinct, but the shared "Tagged DFA" vocabulary is a real collision risk during
+implementation and code review — this is why the classes proposed below are named `Laurikari*`
+rather than `Tagged*`, to keep them unambiguously distinct from `useTaggedDFA`/
+`DFA_UNROLLED_WITH_GROUPS` in searches and reviews.
+
+**Tags.** Each capture-group boundary (`NFA.NFAState.enterGroup`/`exitGroup`, nullable `Integer`
+group-number fields already present in the Thompson construction) becomes a *tag*: a marker that
+must record the current input position whenever the NFA transitions through it. `groupCount`
+explicit capture groups → `2 * (groupCount + 1)` tags (open + close per group, plus the implicit
+whole-match group 0) — the same slot count `PikeVMMatcher.java:192`'s
+`int slotCount = 2 * (groupCount + 1)` already uses for `clistCaptures`/`nlistCaptures`.
+
+**Registers.** A tagged DFA state doesn't just carry an NFA-state subset (like `StateSetKey`
+today); it carries, per NFA state in the subset, a mapping from tag id → *register* (an integer
+naming a memory cell that holds a recorded position or "unset"). Transitions carry register
+*operations*: `copy(r_dst, r_src)`, `set-to-current-pos(r_dst)`, or `set-unset(r_dst)`. Concretely
+this generalizes what `PikeVMMatcher.clistCaptures[stateId]` already does at runtime (an
+`int[stateCount][slotCount]` capture array copied thread-to-thread on every step) into something
+computed and cached **once per (DFA-state, char) transition**, ahead of time, instead of being
+recomputed by walking live threads on every character of every search.
+
+**Priority/conflict resolution.** When two NFA states carrying *different* register mappings merge
+into the same subset during determinization (i.e., two "threads" reach the same NFA state), the
+existing `PikeVMMatcher` thread-list ordering already defines which one wins: earlier-added threads
+have priority (this is exactly the leftmost-first / greedy-first semantics `clistIds`/`nlistIds`
+maintain today by appending in priority order and never re-adding a state already in the list —
+see `inClist`/`inNlist` guards). The TDFA's determinization must replicate that same ordering rule
+at *build* time: when constructing the subset for a given (state, char) transition, process
+predecessor NFA states in the same priority order PikeVM's `addThread` does, and when a target NFA
+state is already in the new subset, discard the lower-priority arrival's register mapping instead
+of merging it. This is the same rule, moved from run time to build time — not a new semantics
+decision.
+
+## 5. Architecture sketch
+
+New sibling classes to the existing DFA machinery, following the same shape `LazyDFACache` /
+`RejectDfaFactory` already establish:
+
+- `LaurikariDFACache` (sibling to `LazyDFACache`): lazily-materialized, subset-constructed DFA whose
+  states are `(NFA-subset, register-mapping)` pairs, keyed for interning the same way
+  `StateSetKey` interns plain subsets today. Bounded at a cap (mirroring
+  `LazyDFACache.DEFAULT_CAP`/`BitStateMatcher.BUDGET_CELLS`); on overflow, **freeze and fall back**
+  — exactly the existing `FALLBACK` sentinel / `frozen` field pattern in `LazyDFACache`, just handed
+  off to `PikeVMMatcher` instead of to raw NFA stepping.
+- `LaurikariNfaStep`: like `NfaStep`, but returns both the next state-id set and the register
+  operations to apply, so the caller can update its own register-file array.
+- A new matcher, e.g. `LaurikariDfaMatcher extends ReggieMatcher`, or an extension of
+  `BitStateMatcher`'s existing "NATIVE" role — parallel to how `BitStateMatcher` today decides
+  per-call whether it's within budget and only asks `PikeVMMatcher` for oversized/ineligible
+  inputs. Eligibility gate: reuse `noAssertionsOrBackrefs`-style checks (no backrefs, no lookaround,
+  no atomic groups) — the same class of pattern `RejectDfaFactory`/`findDfaEligible` already carve
+  out, extended (per §3) to cover end anchors and `\b` via per-step/accept-time checks against the
+  true `regionEnd`, not via subset-identity fracturing — **and additionally excluding
+  `usePosixLastMatch` patterns** (see the eligibility note at the end of this list).
+
+**Relationship to `HybridMatcher`.** `RuntimeCompiler.shouldUseHybrid`/`compileHybrid`
+(`RuntimeCompiler.java:763-841`) already builds a "DFA for fast matching, NFA for group extraction"
+matcher today, for `MatchingStrategy.OPTIMIZED_NFA`-eligible patterns and for
+`usePosixLastMatch` patterns specifically. That is the same top-level shape TDFA's value
+proposition in §4 is pitched on (replacing per-thread capture-array copying with a cheaper,
+precomputed mechanism) — but `HybridMatcher`'s NFA extraction pass only runs over the *already
+DFA-bounded matched substring*, so its cost is independent of haystack size; it is not exposed to
+the `BUDGET_CELLS` fallback-cliff this design exists to fix. `PatternAnalyzer` already routes
+capture-ambiguous/`usePosixLastMatch` patterns to `HybridMatcher` specifically *because* the
+DFA-then-JDK-NFA extraction path gives correct POSIX-last-match group spans where leftmost-first
+NFA priority (what TDFA replicates, per §4) does not — so TDFA must not compete for that pattern
+class; see the eligibility exclusion above. For the general capturing patterns `HybridMatcher`
+already serves cheaply, TDFA offers no motivating win (Hybrid's cost model is already
+haystack-size-independent) — TDFA's target is specifically the fallback-cliff class in §1, which is
+disjoint from what `HybridMatcher` handles today. Phase 2 (§7) should confirm this stays disjoint
+in `PatternAnalyzer`'s eventual strategy table rather than assume it.
+
+**Eligibility gate must also exclude `usePosixLastMatch` patterns.** `PatternAnalyzer` sets
+`usePosixLastMatch` (`PatternAnalyzer.java:3426`, `needsPosixSemantics` driven purely by AST shape —
+capturing groups inside a repeating quantifier, e.g. `(a|a)+`) independently of the
+backref/lookaround/atomic-group checks `findDfaEligible`/`noAssertionsOrBackrefs` perform; grep
+confirms neither method references it. A capture-ambiguous pattern like `(a|a)+` would pass the
+gate as literally described above and get routed through leftmost-first tagged determinization,
+reproducing the exact wrong-group-span bug `usePosixLastMatch`/`HybridMatcher` routing exists to
+avoid — and critically, §6's proposed oracle (`PikeVMMatcher`) is *also* leftmost-first, so
+differential fuzzing against it would not catch this specific divergence either. The eligibility
+gate must check `usePosixLastMatch` explicitly, not rely on the backref/lookaround/atomic-group
+checks to cover it, and any fuzz corpus for this pattern class needs `java.util.regex` (not
+`PikeVMMatcher`) as the oracle.
+
+**Register-file management at runtime.** Once a `LaurikariDFACache` transition is resolved, applying
+its register ops to a small `int[]` register file per active scan is O(registers-touched-this-step),
+not O(live-threads) — this is the actual performance win: it replaces PikeVM's per-character,
+per-thread capture-array copy with a per-character, precomputed, DFA-transition-indexed op list.
+
+**State-space bounding.** Register mappings are structurally bounded the same way plain subsets
+are (finitely many NFA states × finitely many distinct "which predecessor thread's mapping won"
+outcomes per merge), so in principle the reachable `(subset, mapping)` space is still finite, but
+it can be much larger than the plain-subset space `LazyDFACache` already builds for the same
+pattern — this is the paper's well-known practical risk, and needs the same lazy-materialize +
+cap + freeze-to-fallback discipline `LazyDFACache` already uses, not upfront full determinization.
+
+**Explicit guardrail: no post-hoc minimization by subset-equivalence.** The interning described
+above (hash-consing exact `(subset, mapping)` state identity during determinization) is safe —
+it is what determinization already is. Do **not** additionally minimize the resulting automaton by
+classical Hopcroft/Moore-style equivalence (merging two states whose *future* NFA-subset behavior
+is identical): this is a well-known Laurikari-family correctness pitfall — two states can agree on
+every future transition while holding different live register mappings, and merging them silently
+corrupts which register produced which capture. If state-space size ever needs a second lever
+beyond cap-and-fallback, the correct technique is *operation-aware* minimization/register
+allocation (already named, without being resolved, in `doc/2026-07-05-reggie-vs-re2j-algorithm-research.md`
+item 2) — not naive subset-equivalence. This is called out explicitly here because nothing in the
+existing `LazyDFACache`/`RejectDfaFactory` code this design models itself on performs any
+minimization at all (they intern by exact subset identity only), so there is no established local
+precedent to lean on if a future implementer reaches for it as a blowup mitigation.
+
+## 6. Correctness strategy
+
+- **Ground truth**: `PikeVMMatcher`'s existing thread simulation (already checked against JDK
+  `Pattern` via `CorrectnessTest`) is the oracle. Every `LaurikariDFACache`-served `find`/`match`/
+  `findFrom` call must be differentially fuzzed against the same call on `PikeVMMatcher` over the
+  existing fuzz corpus infrastructure — this work must introduce zero *net-new* divergences on top
+  of whatever `AlgorithmicFuzzTest.KNOWN_FINDINGS_BUDGET` currently is (re-check the live constant;
+  as of this writing it is 28, not 0 — the `project_reggie_prod_readiness` memory note's "zero known
+  divergences" claim is stale relative to the current fuzz window) before any pattern class is
+  allowed to route to the new engine.
+- **Priority/merge correctness is the highest-risk correctness surface**, not the plain-subset
+  transitions (those are already proven by `LazyDFACache`/`RejectDfaFactory`'s existing tests).
+  Needs dedicated adversarial cases: nested groups with empty-body iterations (the same class
+  `groupBodyNullable`/trailing-empty-iteration rebind logic in `PikeVMMatcher` exists to handle
+  correctly today), unrolled-quantifier multi-anchor paths (`clistViaMultipleAnchors`'s reason for
+  existing), and alternation branches with shared prefixes but different capture groups.
+- **Anchor correctness**: end-anchor/`\b` checks must be verified identical to
+  `PikeVMMatcher.checkAnchor`'s existing switch-case semantics, using the same `regionEnd`-vs-scan-
+  bound separation already fixed once for `BitStateMatcher.search` this session — do not
+  re-introduce that class of bug in the new engine.
+
+## 7. Phased rollout (de-risking the most uncertain parts first)
+
+**Phase 0 — spike, boolean/localization-only tag.** Build a `LaurikariDFACache` variant with exactly
+*one* tag: "leftmost live start position" (no per-group captures). This is the "single min-start
+tag" middle ground identified during the dynamic-window analysis — a strict, much smaller subset
+of the full design (trivial conflict resolution: smaller start always wins, no group-ambiguity
+logic) that directly fixes the motivating fallback-cliff problem (real localization for `find()`
+on `SQL_ANSI`-shaped patterns) even if full capture tags are never built. Success criteria: (a)
+correct localization on the exact adversarial case that broke the windowed-scan prototype
+(unbounded-width literal/comment spanning what would have been a window boundary), (b) state count
+for `SQL_ANSI`-class patterns stays within a cache budget comparable to `LazyDFACache.DEFAULT_CAP`,
+(c) measurable win over the current full-`PikeVMMatcher`-punt on the LONG-scale IAST benchmarks.
+
+**Phase 0 passing is necessary but NOT sufficient evidence for Phase 1's feasibility.** With one
+tag under a total order (smaller start always wins), every register-merge has exactly one possible
+outcome — the state-space dimension §5 names as the actual risk driver ("finitely many... outcomes
+per merge") is pinned at 1 in this spike. Phase 1's real risk comes from `2 * (groupCount + 1)`
+*independent* open/close tags whose winning predecessor can differ tag-by-tag across nesting,
+alternation, and quantifier unrolling — a thread can be "ahead" on one group's tag and "behind" on
+another simultaneously, which does not collapse via a total order the way a single scalar does.
+Phase 0 cannot exercise that combinatorial mechanism at all, so its success measures only the
+cap-and-fallback plumbing, not the actual multi-tag blowup risk.
+
+**Phase 0.5 — intermediate checkpoint, 2-3 independent tags.** Before committing to the full
+`2 * (groupCount + 1)`-tag Phase 1, spike a small, fixed number of independent tags (e.g. two
+nested groups, or one group inside a quantifier) specifically to exercise cross-tag merge conflicts
+— the mechanism Phase 0 cannot. This is the cheapest available signal on whether the real
+multi-tag state-space blowup is tractable before the multi-week Phase 1 investment. Only proceed to
+Phase 1 if this checkpoint's state-space growth is still within a workable budget.
+
+**Phase 1 — full capture tags**, only if Phase 0 *and* Phase 0.5 succeed: extend to
+`2 * (groupCount + 1)` tags per the full design in §4, gated on the eligibility boundary in §5
+(including the `usePosixLastMatch` exclusion), differentially fuzzed per §6.
+
+**Phase 2 — integration**: wire into `BitStateMatcher`'s existing decision point (budget check →
+fallback selection) as a new, preferred-when-eligible tier, or as a new strategy in
+`PatternAnalyzer`'s strategy selection — decide based on Phase 1 findings about how cleanly it
+composes with the existing bytecode-generation dual-path rule (`RuntimeCompiler.java` /
+`ReggieMatcherBytecodeGenerator.java`) if compile-time codegen support is later desired. Runtime-
+only integration (skip bytecode generation) is the lower-risk default for this phase.
+
+## 8. Effort and risk
+
+This is a multi-week R&D effort, not a spike-sized change — comparable in scope to the original
+`BitStateMatcher` capture-engine build (shipped in PR #94, 2026-07-07) but with a genuinely novel
+determinization algorithm (subset construction is well-understood in this codebase; tagged subset
+construction with priority-ordered register-merge is not) rather than an adaptation of an existing
+technique. Key risks:
+
+| Risk | Mitigation |
+|---|---|
+| Tagged state-space blowup makes the cache unusable for real patterns | Phase 0.5's multi-tag checkpoint measures this — Phase 0 alone does NOT, since its single total-ordered tag can't exercise cross-tag merge conflicts (§7) |
+| Priority/merge conflict resolution subtly diverges from PikeVM's leftmost-first semantics on some AST shape | Differential fuzzing against `PikeVMMatcher` as oracle before any pattern class routes to the new engine (§6) |
+| Anchor handling (end anchors, `\b`) reintroduces the `regionEnd`-vs-scan-bound bug class already found and fixed once this session | Explicit test mirroring `BitStateMatcher.search`'s `regionEnd` separation; do not bake anchor satisfaction into subset identity |
+| `usePosixLastMatch` capture-ambiguous patterns (e.g. `(a|a)+`) silently get leftmost-first tags, reproducing the wrong-group-span bug `HybridMatcher` exists to avoid | Eligibility gate explicitly excludes `usePosixLastMatch` (§5); fuzz that pattern class against `java.util.regex`, not `PikeVMMatcher`, since PikeVMMatcher shares the same blind spot |
+| Effort doesn't pay off if the fallback-cliff pattern class is rare in practice | Phase 0's success criteria are tied directly to the measured IAST LONG-scale regression, not a hypothetical |
+
+## 9. Alternatives if this is not greenlit
+
+Two cheaper mitigations remain available independent of this design, already identified this
+session and not requiring any of the above:
+
+1. **Raise `BUDGET_CELLS`** (`BitStateMatcher.java:61`) to push the fallback-cliff threshold
+   further out. Cheap, does not eliminate the cliff, just documents/moves it — reasonable as an
+   interim step regardless of whether TDFA is pursued.
+2. **Accept and document the residual cliff** as a known, structural, PikeVM-simulation-overhead
+   limitation (consistent with how `doc/agents-fallback-and-limitations.md` already documents
+   other performance-only gaps).
+
+Both are non-exclusive with pursuing this design later; neither requires reverting if TDFA work
+starts.

--- a/doc/2026-07-10-tdfa-capture-engine-impl-plan.md
+++ b/doc/2026-07-10-tdfa-capture-engine-impl-plan.md
@@ -1,0 +1,479 @@
+# TDFA (tagged-DFA) capture engine — Implementation Plan
+
+**Date:** 2026-07-10
+**Design:** [doc/2026-07-10-tdfa-capture-engine-design.md](2026-07-10-tdfa-capture-engine-design.md)
+**Status:** not started — this plan is for a go/no-go decision, same as the design doc. Phase 0 is
+the only phase authorized to start without a further checkpoint; every later phase is gated on the
+previous one's exit criteria (see design §7).
+
+---
+
+## 0. Prerequisites and conventions
+
+- Build/test: `./gradlew :reggie-runtime:test :reggie-integration-tests:test`
+- Spotless: `./gradlew spotlessApply` before every push
+- Debug tool: `./gradlew :reggie-runtime:debugPattern -Ppattern="..."` to inspect strategy/bytecode
+  routing for any pattern touched by this work
+- New runtime classes go in `reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/`; new tests
+  in the sibling `src/test` tree, mirroring `RejectDfaFactoryTest`'s reflection-based access pattern
+  for package-private classes
+- **Naming: this is `Laurikari*`, not `Tagged*`, on purpose.** The codebase already has an
+  unrelated "Tagged DFA" mechanism — `PatternAnalyzer.MatchingStrategyResult.useTaggedDFA`
+  (`PatternAnalyzer.java:3420`) drives `DFAUnrolledBytecodeGenerator.generateTaggedDFAMatching`
+  for the `DFA_UNROLLED_WITH_GROUPS` strategy (compile-time-unrolled bytecode, inline group
+  tracking, bounded to <20-state explicit DFAs — a different technique for a different, smaller
+  problem than what this plan builds). Every new class here (`LaurikariNfaStep`,
+  `LaurikariDFACache`, `LaurikariDfaMatcher`, `LaurikariEligibility`, ...) is named after the
+  algorithm (design §4) specifically to stay unambiguous from `useTaggedDFA`/
+  `DFA_UNROLLED_WITH_GROUPS` in grep/search and code review. Do not rename these back to
+  `Tagged*` even if it reads more naturally — that's the collision this naming avoids.
+- **Two distinct correctness oracles are in play, not one** — the design doc's §6 says
+  "`PikeVMMatcher` is the oracle," which is correct for isolating this-engine-specific bugs
+  quickly, but the project's actual system-of-record fuzz harness
+  (`reggie-integration-tests/.../AlgorithmicFuzzTest.java` +
+  `.../fuzz/RegexFuzzOracle.java`) uses **JDK `Pattern` as the oracle**, per
+  `RegexFuzzOracle.java:30`'s class doc ("The JDK is the oracle; any divergence is reported...").
+  This plan uses both, at different stages:
+  - **Fast, engine-isolating checks** (Phases 0–1, run constantly during development): new engine
+    vs `PikeVMMatcher`, same call, same input — cheap, in-process, no fuzz-harness plumbing needed.
+  - **System-of-record validation** (Phase 1 exit, Phase 2): once the new engine is wired to
+    actually receive real patterns, extend `AlgorithmicFuzzTest`'s existing pattern-generation
+    window to include its eligible shapes and let the existing JDK-oracle harness catch anything
+    the PikeVMMatcher-only comparison missed (this also protects against the class of bug where
+    the new engine and `PikeVMMatcher` agree with each other but both diverge from JDK — unlikely
+    given `PikeVMMatcher`'s current fuzz baseline (see below), but not provably impossible).
+  - `usePosixLastMatch` patterns are explicitly excluded from eligibility (design §5) — their
+    correctness is unaffected by this work and continues to be covered by whatever already exercises
+    `HybridMatcher`.
+- **Current fuzz baseline is NOT zero** — `AlgorithmicFuzzTest.java:64` declares
+  `KNOWN_FINDINGS_BUDGET = 28` for the currently-active 25k–50k pattern window (two tracked bugs,
+  B-CGG-1/B-SQG-1, per that file's own class-doc history). The `project_reggie_prod_readiness`
+  memory note this plan and its design doc both cited ("fuzzer currently at zero known
+  divergences") is stale relative to that constant — **re-check the live value of
+  `KNOWN_FINDINGS_BUDGET` before treating any number in this plan as current**; every "must not
+  regress the baseline" criterion below means "must not increase whatever that constant is at
+  the time," not literally zero.
+- No commits without being asked; this plan produces code across several PRs, one per phase at
+  minimum (see §5 below) — do not batch phases into a single PR.
+
+---
+
+## 1. Phase 0 — boolean/localization-only single-tag spike
+
+**Goal** (design §7): prove a `LaurikariDFACache` with exactly one tag ("leftmost live start
+position") gives sound, tight localization for `find()` on `SQL_ANSI`-shaped patterns, without
+committing to full capture semantics yet.
+
+**Explicitly NOT this phase's job** (see design §7's "necessary but not sufficient" caveat):
+proving the multi-tag state-space is tractable. That's Phase 0.5. Do not read a Phase 0 pass as
+evidence for Phase 1's feasibility.
+
+### Task 0.1 — `LaurikariNfaStep` interface
+
+**File (new):** `reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariNfaStep.java`
+
+```java
+/**
+ * One tagged-NFA step: given active (state, register-mapping) pairs and a character, returns the
+ * next active state ids together with the register operations each transition carries.
+ *
+ * <p>Phase 0 uses exactly one tag (register slot 0 = "candidate start position"); later phases
+ * generalize {@code registerCount}. Kept as a separate interface from {@link NfaStep} rather than
+ * changing NfaStep's shape, matching how {@link RejectDfaFactory}/{@link PikeVMMatcher} already
+ * keep multiple independent NfaStep-shaped lambdas per purpose.
+ */
+@FunctionalInterface
+interface LaurikariNfaStep {
+  /**
+   * @param curStates active NFA state ids (subset)
+   * @param curRegs curStates[i]'s register file, i.e. curRegs[i] is state curStates[i]'s tag-0
+   *     value (the candidate start position that reached it, or -1 if none has)
+   * @param c the character being consumed
+   * @return next active state ids and their per-state register files, merged/deduped per the
+   *     priority rule in design §4 (earlier-priority arrival's register wins on merge)
+   */
+  LaurikariStepResult apply(int[] curStates, int[] curRegs, int c);
+}
+```
+
+**New small value type**, same file or `LaurikariStepResult.java`:
+```java
+final class LaurikariStepResult {
+  final int[] states;
+  final int[] regs; // regs[i] corresponds to states[i]
+  LaurikariStepResult(int[] states, int[] regs) { this.states = states; this.regs = regs; }
+}
+```
+
+**Completion criterion:** compiles; no behavior yet.
+
+### Task 0.2 — `LaurikariDFACache` (single-register specialization)
+
+**File (new):** `reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDFACache.java`
+
+Model directly on `LazyDFACache` (read that class in full before starting — this task is a
+close structural port, not a fresh design):
+- State key changes from `StateSetKey` (subset only) to a new `LaurikariStateSetKey` that hashes/equals
+  on `(sortedStates, perStateRegisterValue)` pairs — two states with the same subset but different
+  register values are different DFA states (design §5's "State-space bounding" paragraph).
+- Keep `DEFAULT_CAP`, `UNCACHED`/`DEAD`/`FALLBACK` sentinels, and the `frozen` freeze-on-cap-hit
+  behavior verbatim — same lazy-materialize discipline, same fallback contract.
+- `findFrom`/`findEnd` equivalents don't apply in the same shape here — Phase 0's actual entry
+  point is closer to a direct replacement for `RejectDfaFactory`'s self-anchoring find, but instead
+  of unioning a fresh `startAll` closure every step (which erases attribution, design §1/§3), each
+  merge keeps the **smaller** register value in a genuine tie (that's the whole point: this DFA can
+  answer "which start is this" because ties resolve by an explicit rule instead of by an
+  unconditional union).
+- Do **not** implement the general `N`-tag register-merge machinery here — hardcode single-register
+  (`int`, not `int[]`) for this phase; Task 0.5.x is where it generalizes. Keeping Phase 0's
+  implementation deliberately narrow is what makes it fast to build and easy to reason about; don't
+  let scope creep from "this will need to generalize eventually" pull Phase 1's machinery in early.
+
+**Completion criterion:** unit tests (new `LaurikariDFACacheTest`, modeled on
+`RejectDfaFactoryTest`'s reflection-based access pattern) covering:
+- Simple literal, alternation with multiple leading chars (same base cases as
+  `RejectDfaFactoryTest` — confirms the plain-subset side of this still works).
+- **The adversarial case that killed the windowed-scan prototype** (design §1): a pattern with an
+  unbounded-width literal/comment construct (reuse `SQL_ANSI`'s `'...'`/`/*...*/` shape, or a
+  minimal standalone repro) over an input where the real match's content spans wider than
+  `BUDGET_CELLS`'s implied window — must correctly report the true leftmost start, not silently
+  narrow past it.
+- A case exercising genuine merge ties (two distinct start positions both reaching the same NFA
+  state at the same position) — confirms the "smaller register wins" rule, not just the trivial
+  single-candidate path.
+
+### Task 0.3 — Spike harness / measurement
+
+Not a shippable matcher yet — a throwaway (but committed, since it's the evidence this phase exists
+to produce) test or small `main()` that:
+1. Builds `LaurikariDFACache` over `SQL_ANSI`'s NFA (reuse `IastRegexpBenchmark.SQL_ANSI`'s pattern
+   string, or the compiled NFA if more convenient).
+2. Runs it over the LONG-scale input from `IastRegexpBenchmark` (confirm branch has the rescale —
+   it does now, this branch is rebased onto `perf/bitstate-hot-loop-flattening`).
+3. Reports: (a) the localized start/end bounds returned vs. the real match's actual bounds (must be
+   exact for a single-tag scheme — there's no ambiguity to approximate away), (b) total distinct
+   DFA states materialized, (c) wall-clock vs. the current full-`PikeVMMatcher`-punt path.
+
+**Exit criteria for Phase 0** (verbatim from design §7 — do not relax these):
+- (a) correct localization on the adversarial unbounded-width-literal case.
+- (b) state count for `SQL_ANSI`-class patterns stays within a budget comparable to
+  `LazyDFACache.DEFAULT_CAP` (4096).
+- (c) measurable win over the current full-`PikeVMMatcher`-punt on the LONG-scale IAST benchmarks
+  (re-run `IastRegexpBenchmark`'s `SqlAnsiFind`/`SqlMysqlFind`/`SqlPostgresqlFind` at LONG scale;
+  compare against the numbers already recorded in the design doc's §1 table).
+
+**If Phase 0 fails (b) specifically** (state count blows up even for one tag): stop here. That's a
+worse signal than anything Phase 0.5 could add — if a single scalar tag already blows up the state
+space for `SQL_ANSI`-class patterns, multi-tag will not do better. Fall back to design §9's cheaper
+mitigations (raise `BUDGET_CELLS`, or document the cliff) instead of proceeding.
+
+---
+
+## 2. Phase 0.5 — intermediate checkpoint: 2–3 independent tags
+
+**Goal** (design §7): the cheapest available signal on whether real multi-tag state-space blowup is
+tractable, before committing to Phase 1's full `2 * (groupCount + 1)`-tag machinery. This phase
+exists specifically because Phase 0's single total-ordered tag cannot exercise cross-tag merge
+conflicts at all (design §7's "necessary but not sufficient" analysis) — don't skip it under
+schedule pressure; skipping it converts this plan back into the un-derisked version the adversarial
+review flagged.
+
+### Task 0.5.1 — Generalize register file to `int[]` (small, fixed N)
+
+Extend `LaurikariDFACache`/`LaurikariNfaStep` in place (or throw away Phase 0's implementation and
+rebuild this specific class if the single-register specialization doesn't generalize cleanly —
+acceptable either way, since that code's job was to be a fast, disposable spike, not a foundation)
+to carry a small fixed-size `int[]` register file per state instead of one scalar. Conflict
+resolution: **whole-mapping priority discard**, exactly as design §4 specifies — when two arrivals
+reach the same target NFA state, the lower-priority arrival's entire register mapping is dropped,
+not merged tag-by-tag. This is the same rule as Phase 1; Phase 0.5's job is to validate it doesn't
+explode the state space at small N, not to invent a different rule.
+
+### Task 0.5.1a — Hand-derive tags for exactly the three Task 0.5.2 patterns
+
+**This task exists to break a circularity**: Task 0.5.2's patterns are real capturing-group
+patterns, but the *general* mechanism for deriving a tag id from an arbitrary `NFA.NFAState
+.enterGroup`/`exitGroup` and emitting the matching register op is Phase 1's Task 1.1/1.2 —
+which is gated on Phase 0.5 passing. Do not pull that general mechanism forward. Instead, for
+each of the three fixed patterns below, hand-pick which NFA transitions carry which of the 2-3
+tags, hardcoded per pattern (a short `switch`/`if` on the pattern string, or three separate
+tiny test-only builder methods — throwaway code, not shipped past this phase):
+- `(a+)(b+)`: 2 tags, one pair (open/close) *per group is overkill for this checkpoint's purpose* —
+  use exactly 2 tags total, one for group 1's close position and one for group 2's open position
+  (the two boundaries that actually move independently under backtracking); that's enough to
+  exercise cross-tag merge conflicts without needing a full 4-tag (2-group × open/close) model yet.
+- `(ab)+`: 2 tags — the loop body's single group's open and close, re-set on every iteration
+  (tests the loop-back re-set semantics directly, Laurikari's flagged subtlety).
+- `((a)|())*`: 3 tags — outer group open/close plus inner group open (the inner group's close is
+  the interesting nullable case: does it get correctly left unset when the empty alternative wins).
+
+Task 1.1/1.2 in Phase 1 **generalize this hand-rolled, pattern-specific derivation into an
+automatic, pattern-independent mechanism** driven by `enterGroup`/`exitGroup` directly — this task
+is intentionally the narrow, disposable version of that work, scoped to exactly three known
+patterns, not a preview of the general case.
+
+### Task 0.5.2 — Adversarial multi-tag test patterns
+
+Specifically chosen to exercise cross-tag divergence (design §7's "ahead on one tag, behind on
+another" scenario):
+- Two independent, non-nested capturing groups: `(a+)(b+)` over inputs where greedy backtracking
+  forces re-evaluation of both groups' boundaries.
+- One group inside a quantifier: `(ab)+` — tests the loop-back register semantics Laurikari's paper
+  flags as the classic subtlety (design §4's algorithmic-soundness review flagged this as the
+  highest-risk correctness surface for exactly this reason).
+- Nested groups with an empty-body iteration option: `((a)|())*` — exercises the same
+  `groupBodyNullable`-class scenario `PikeVMMatcher`'s trailing-empty-iteration rebind logic exists
+  to handle correctly today (design §6).
+
+### Task 0.5.3 — Measure and report
+
+Same three metrics as Phase 0 (state count, correctness vs. `PikeVMMatcher` on the adversarial set,
+wall-clock), but the state-count number is the one that actually matters here — compare its growth
+rate from 1→2→3 tags. Roughly linear-in-practice growth is a green light for Phase 1; anything that
+looks combinatorial already at N=3 is a stop signal (extrapolate, don't wait to hit the wall at
+N=`2*(groupCount+1)` for a real multi-group pattern).
+
+**Exit criteria for Phase 0.5:**
+- State-space growth from Phase 0 (N=1) through this checkpoint (N=2-3) stays within a workable
+  budget (no fixed number given in the design — this is a judgment call informed by the actual
+  measured curve, not a threshold to hit).
+- All three adversarial patterns in Task 0.5.2 produce capture output identical to `PikeVMMatcher`.
+- If either fails: stop here, same fallback as Phase 0's failure path (design §9). Do not proceed to
+  Phase 1 on the strength of Phase 0 alone (that's precisely the mistake the adversarial review
+  caught).
+
+---
+
+## 3. Phase 1 — full capture tags
+
+**Precondition:** Phase 0 **and** Phase 0.5 both passed their exit criteria.
+
+### Task 1.1 — Tag numbering
+
+Derive `2 * (groupCount + 1)` tags from `NFA.NFAState.enterGroup`/`exitGroup` (nullable `Integer`
+group-number fields — not `GroupEntry`/`GroupExit`, which don't exist; see design §4's corrected
+wording). Tag `2*g` = group `g`'s open, `2*g+1` = group `g`'s close, matching
+`PikeVMMatcher.java:192`'s existing `slotCount = 2 * (groupCount + 1)` layout exactly, so the
+eventual `MatchResult` construction can reuse `PikeVMMatcher`'s/`BitStateMatcher`'s existing
+`buildCaptureResult`-shaped helpers without a slot-numbering translation layer.
+
+### Task 1.2 — Full priority-ordered register-merge determinization
+
+Generalize Phase 0.5's `int[]`-register machinery to the real tag count. Determinization loop
+structure (design §4):
+1. For each `(DFA-state, char)` pair not yet cached, compute consuming transitions from every NFA
+   state in the current subset, in the same priority order `PikeVMMatcher.addThread` already
+   walks epsilon closures — grep `PikeVMMatcher.java` for `addThread` and replicate its traversal
+   order exactly, don't re-derive priority ordering from scratch.
+2. For each NFA transition consumed, compute the register ops it carries: `copy` for pass-through
+   tags, `set-to-current-pos` for the tag(s) matching this transition's `enterGroup`/`exitGroup`
+   (if any), `set-unset` where applicable (e.g. re-entering a group after a prior non-participating
+   alternation branch).
+3. When two arrivals target the same NFA state in the new subset, keep only the higher-priority
+   arrival's full register mapping (whole-mapping discard, not per-tag merge — design §4).
+4. Intern the resulting `(subset, register-mapping)` pair via `LaurikariStateSetKey`, exactly as
+   Phase 0.5 already does.
+
+**Do not add a minimization pass** (design §5's explicit guardrail) — if this task's state-space
+growth needs a second lever beyond cap-and-fallback, that's a separate, later investigation
+(operation-aware minimization, not classical subset-equivalence), not something to reach for here
+under time pressure.
+
+### Task 1.3 — Eligibility gate
+
+**New function**, e.g. `LaurikariEligibility.isEligible(NFA nfa)` (or a static method alongside the
+new matcher class) implementing design §5's gate exactly:
+- No assertions, no backrefs (same check as `RejectDfaFactory.build`'s guard / `PikeVMMatcher
+  .noAssertionsOrBackrefs`).
+- No atomic groups (same check as `findDfaEligible`).
+- Anchors: `START`/`STRING_START`/`START_MULTILINE` handled via the reinject-closure split
+  (port `PikeVMMatcher`'s `reinjectClosureIds`/`reinjectAfterNlClosureIds` construction); end
+  anchors (`$`/`\Z`/`\z`/`END_MULTILINE`) and `\b` handled as per-step/per-accept checks against the
+  caller-supplied `regionEnd`, **not** folded into subset/register identity (design §3) — reuse
+  `PikeVMMatcher.checkAnchor`'s exact switch-case semantics rather than reimplementing anchor logic.
+- **`usePosixLastMatch` explicitly excluded** — this is a separate check from the above (grep
+  confirms `findDfaEligible`/`noAssertionsOrBackrefs` never reference it; do not assume the
+  backref/lookaround/atomic-group checks cover it). Wire this from
+  `PatternAnalyzer.MatchingStrategyResult.usePosixLastMatch` (`PatternAnalyzer.java:3426`) if the
+  eligibility check runs at the `PatternAnalyzer` layer, or thread the flag through to wherever the
+  NFA-level gate runs otherwise.
+
+**Test:** a dedicated `LaurikariEligibilityTest` with one case per exclusion reason (lookahead,
+backref, atomic group, `\b`/end-anchor inside a loop — mirroring `findDfaEligible`'s own
+loop-reachability check — and `(a|a)+`-shaped `usePosixLastMatch` patterns), confirming each is
+correctly rejected, plus positive cases confirming ordinary capturing patterns pass.
+
+### Task 1.4 — `LaurikariDfaMatcher`
+
+**New file:** `reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcher.java`,
+implementing `ReggieMatcher` (mirror `BitStateMatcher`'s shape: constructor takes `(NFA nfa, String
+pattern)`, lazily-constructed `PikeVMMatcher fallback`, `fallbackCount()` observability method for
+test pinning, same as `BitStateMatcher.fallbackCount()`). At this phase, **do not wire it into
+`PatternAnalyzer`/`RuntimeCompiler` routing yet** — that's Phase 2. Build and test it standalone,
+constructed directly in tests the way `RejectDfaFactoryTest`/a hypothetical `LaurikariDFACacheTest`
+already do.
+
+### Task 1.5 — Fast correctness checks (dev-loop oracle: `PikeVMMatcher`)
+
+Property-based/parameterized test comparing `LaurikariDfaMatcher` against `PikeVMMatcher` directly,
+same pattern + input, across:
+- `find`/`findFrom`/`match`/`matches`/`findMatch`/`findMatchFrom` — every `ReggieMatcher` method
+  `LaurikariDfaMatcher` implements.
+- The Phase 0.5 adversarial set (Task 0.5.2) plus new cases: alternation branches with shared
+  prefixes but different capture groups (design §6), unrolled-quantifier multi-anchor paths
+  (mirroring what `PikeVMMatcher.clistViaMultipleAnchors` exists to handle).
+- Anchor-boundary cases specifically re-testing the `regionEnd`-vs-scan-bound separation (design
+  §6's "do not re-introduce that class of bug" — this is the same bug class fixed once already this
+  session in `BitStateMatcher.search`; write the equivalent test here proactively rather than
+  waiting to rediscover it).
+
+### Task 1.6 — System-of-record validation (oracle: JDK, via existing fuzz harness)
+
+**Task 1.6a — build the matcher-injectable oracle variant first.** `RegexFuzzOracle.check(String
+pattern, String input)` (`RegexFuzzOracle.java:97`) hard-codes
+`Reggie.compile(pattern, ReggieOptions.builder().allowJdkFallback().build())` to produce the
+`ReggieMatcher` it exercises — there is no parameter or seam to inject a caller-supplied matcher
+instance, and since Phase 2 hasn't wired `LaurikariDfaMatcher` into strategy selection,
+`compile()` can never route to it yet. Task 1.6 cannot proceed without first adding an overload (or
+sibling class, e.g. `RegexFuzzOracle.checkAgainst(String pattern, String input, ReggieMatcher
+candidate)`) that runs the same JDK-oracle comparison logic against an explicitly-supplied matcher
+instead of one obtained via `compile()`. This is new, unscoped-elsewhere plumbing — treat it as its
+own small task, not an assumed detail of Task 1.6b below.
+
+**Task 1.6b — extend the fuzz window.** Using Task 1.6a's new oracle entry point, extend
+`AlgorithmicFuzzTest`'s pattern-generation window (see that file's `BASE_SEED`/window-advance
+convention, already documented in its own class doc) to include `LaurikariEligibility`-eligible
+shapes, exercised directly against `LaurikariDfaMatcher` instances built by hand in the test (not
+through the full compile pipeline, since Phase 2 hasn't wired routing). This is the check that
+would catch a bug where the new engine and `PikeVMMatcher` happen to agree with each other but both
+diverge from JDK.
+
+**Exit criteria for Phase 1:**
+- Task 1.5 and Task 1.6b both introduce zero *net-new* divergences on top of whatever
+  `KNOWN_FINDINGS_BUDGET` currently is in `AlgorithmicFuzzTest.java` at the time this phase runs
+  (re-check the live constant — see §0's note; do not assume it is still 28, and do not assume it is
+  zero).
+- `LaurikariEligibilityTest`'s full exclusion matrix passes, including the `usePosixLastMatch` case.
+
+---
+
+## 4. Phase 2 — integration
+
+**Precondition:** Phase 1 passed.
+
+### Task 2.1 — Choose and wire the integration point
+
+Design §7 defers this decision to Phase 1 findings; this task is where that decision gets made and
+executed. Two concrete options, both already scoped in the design:
+- **Option A**: wire into `BitStateMatcher`'s existing decision point — when a call would exceed
+  `BUDGET_CELLS` (`BitStateMatcher.java:61`) and the pattern is `LaurikariEligibility`-eligible, try
+  `LaurikariDfaMatcher` before falling all the way through to `PikeVMMatcher`. Smallest-blast-radius
+  option: only changes behavior for calls that were already hitting the fallback cliff.
+- **Option B**: a new `MatchingStrategy` value (mirror the `COUNTING_GLUSHKOV` enum-addition
+  pattern used for a prior new strategy: `PatternAnalyzer.java`'s `MatchingStrategy` enum at line
+  3335, plus the exhaustive switches in `RuntimeCompiler.isNfaBacked()`/`generateBytecode()` and
+  `PatternDebugger.main()` — see `BITSTATE_CAPTURE`'s existing switch arms, e.g.
+  `PatternDebugger.java:103`, as the concrete template). Larger blast radius, but makes the new
+  engine a first-class, directly-selectable strategy rather than a fallback-of-a-fallback.
+  **This option also triggers AGENTS.md's dual-path rule** ("bytecode-generation changes must
+  update both `RuntimeCompiler.java` and `ReggieMatcherBytecodeGenerator.java`") —
+  `reggie-processor/src/main/java/com/datadoghq/reggie/processor/ReggieMatcherBytecodeGenerator.java`
+  has a `default: throw new IllegalStateException("Unknown strategy: " + strategy)` catch-all
+  (around line 741) that would fire the first time `PatternAnalyzer` recommends the new strategy
+  for an `@RegexPattern`-annotated (compile-time) pattern, unless this file gets an explicit carve-out
+  — follow `BITSTATE_CAPTURE`'s existing precedent there (folds into the `PIKEVM_CAPTURE` branch,
+  `ReggieMatcherBytecodeGenerator.java:108-115`: "v1 intentionally does not add a [...]-backed
+  codegen path for the annotation-processor pipeline") rather than building full compile-time
+  codegen support in this phase.
+
+Recommendation if no strong signal emerges from Phase 1: start with **Option A** — it composes
+trivially with the existing fallback architecture (design §2's goal of "keep the existing fallback
+pattern" is satisfied for free), requires no `PatternAnalyzer`/enum/bytecode-dual-path changes, and
+directly targets the motivating problem (design §1's fallback cliff) without opening the larger
+question of where TDFA ranks against every other native strategy. Option B can be revisited later
+as a separate, smaller follow-up once Option A is shipped and validated in practice.
+
+### Task 2.1a — Confirm `HybridMatcher` disjointness against the real strategy table
+
+Design §5 explicitly requires this, not an assumption: "Phase 2 ... should confirm this stays
+disjoint in `PatternAnalyzer`'s eventual strategy table rather than assume it." Task 1.3's
+`usePosixLastMatch` exclusion is necessary but was decided in Phase 1, before real routing
+existed — it is not sufficient on its own to call this confirmed. Concretely: once Task 2.1's
+integration point is wired, take every pattern already routed to `HybridMatcher` today via
+`RuntimeCompiler.shouldUseHybrid` (patterns where `PatternAnalyzer.hasGroupsInRepeatingQuantifiers`
+sets `usePosixLastMatch = true` — e.g. `(fo|foo)`, `(a|ab)`, `(.1[1])+`, `(.c)+`; existing coverage
+in `PikeVMRoutingTest`/`DfaUnrolledGroupAndFindRegressionTest`, which assert routing to
+`DFA_UNROLLED_WITH_GROUPS`/`usePosixLastMatch`, not literally to a `shouldUseHybrid` string — grep
+for `usePosixLastMatch`/`DFA_UNROLLED_WITH_GROUPS` in those files, not `shouldUseHybrid`) through
+the new integration point and confirm none of them get redirected to `LaurikariDfaMatcher` instead
+of `HybridMatcher`. This is a real test to write and run, not a design-review checkbox.
+
+### Task 2.2 — Observability
+
+`fallbackCount()`-equivalent (already present on `LaurikariDfaMatcher` per Task 1.4) plus, if Option A
+is chosen, a way to distinguish "served by TDFA" from "served by BitState's own bounded DFS" from
+"punted all the way to PikeVMMatcher" for the same kind of reflection-based test verification used
+throughout this investigation (e.g. `BitStateMatcher.fallbackCount()`'s existing test-only accessor
+pattern).
+
+### Task 2.3 — Re-run the motivating benchmark
+
+Re-run `IastRegexpBenchmark`'s `SqlAnsiFind`/`SqlMysqlFind`/`SqlPostgresqlFind` at all three scales
+and confirm the LONG-scale loss documented in the design doc's §1 table is closed (reggie/RE2J back
+above 1.0x at LONG, not just improved). If the open, unattributed `LdapFind`/`UrlAuthFind`/
+`UrlQueryFind` degradation from the same benchmark run (design §1) turns out to share this
+mechanism, re-run those too and note it — but do not assume it does; that's still an open question
+this plan does not resolve.
+
+**Exit criteria for Phase 2 / overall project:**
+- Chosen integration point wired, tested, `spotlessApply`-clean.
+- Task 2.1a's `HybridMatcher` disjointness check passes with zero pattern reassigned away from it.
+- Benchmark re-run confirms the win is real end-to-end, not just at the isolated matcher level.
+- Zero *net-new* divergences on top of `AlgorithmicFuzzTest`'s `KNOWN_FINDINGS_BUDGET` at the time
+  (re-check the live constant, same caveat as Phase 1's exit criteria).
+
+---
+
+## 5. Sequencing and PR boundaries
+
+One PR per phase minimum, each independently reviewable and each leaving the tree in a shippable
+state (even if the shipped state is "new dead code behind an eligibility gate that nothing routes
+to yet," for Phases 0/0.5/1):
+1. Phase 0 PR: `LaurikariNfaStep`, `LaurikariDFACache` (single-register), spike harness/test, measured
+   results reported in the PR description (not just "looks fine" — the actual numbers against the
+   exit criteria).
+2. Phase 0.5 PR: register-file generalization to small fixed N, the hand-derived per-pattern tag
+   assignments (Task 0.5.1a), adversarial tests, growth-curve measurement reported in the PR
+   description.
+3. Phase 1 PR: full tag count, eligibility gate, `LaurikariDfaMatcher`, the fuzz-oracle
+   matcher-injection seam (Task 1.6a), and both correctness passes (Task 1.5 fast dev-loop + Task
+   1.6b fuzz-harness).
+4. Phase 2 PR: integration wiring, the `HybridMatcher` disjointness check (Task 2.1a), and
+   benchmark re-run results in the PR description.
+
+Do not open Phase N+1's PR before Phase N's exit criteria are confirmed and reported — that
+ordering is the entire point of the phased design (design §7's core fix for the "Phase 0 doesn't
+de-risk Phase 1" gap).
+
+---
+
+## 6. Kill criteria (any phase)
+
+Stop and fall back to design §9's cheaper mitigations (raise `BUDGET_CELLS`, or document the
+residual cliff) if, at any phase boundary:
+- State-space growth is combinatorial rather than roughly linear in tag count (Phase 0.5's core
+  question, but re-check at Phase 1 with the real tag count too — Phase 0.5 extrapolates from N≤3,
+  it doesn't prove N=`2*(groupCount+1)` behaves the same).
+- Correctness divergences against either oracle (`PikeVMMatcher` or JDK) can't be driven to zero
+  **within 2 engineer-weeks of focused debugging on a single divergence, or after 3 independent
+  root-cause attempts on it, whichever comes first** — priority/merge correctness was flagged
+  (design §6) as the highest-risk correctness surface, and Laurikari-family tag semantics are
+  genuinely subtle; a persistent, unexplained divergence is a stronger stop signal here than in
+  most of this codebase's other native-strategy work, precisely because there's no existing local
+  implementation to diff against when something goes wrong. (These numbers are a starting default,
+  not derived from any historical data point in this codebase — whoever runs this phase should
+  adjust them explicitly, in writing, rather than silently drifting past an unstated threshold.)
+- The measured end-to-end win (Phase 2, Task 2.3) doesn't materialize even after Phase 1 passed in
+  isolation — possible if the integration point chosen in Task 2.1 doesn't actually intercept the
+  calls that were hitting the cliff (verify Task 2.2's observability confirms real routing before
+  concluding a lack of speedup is the engine's fault, not the wiring's).

--- a/doc/2026-07-14-laurikari-anchor-caching-fix-design.md
+++ b/doc/2026-07-14-laurikari-anchor-caching-fix-design.md
@@ -1,0 +1,169 @@
+# Laurikari anchor-caching fix: recovering the `find()` regression from TDFA Phase 2
+
+## Context
+
+Commit `274488d` ("feat: TDFA Phase 2 — end-anchor/\b eligibility for Laurikari DFA (KNOWN
+PERF REGRESSION)") extended `LaurikariEligibility` to allow `END`, `STRING_END`,
+`STRING_END_ABSOLUTE`, `END_MULTILINE`, and `WORD_BOUNDARY` anchors into the Laurikari
+tagged-DFA (TDFA) capture engine. It gated this via a per-DFA-state `anchorSensitive` flag:
+any interned state whose NFA-subset touches one of these 5 anchor types never populates
+`LaurikariDFACache.asciiTables` — it always falls through to a live NFA-closure recomputation
+(`LaurikariCaptureNfaStep.addClosure`, which calls `PikeVMMatcher.checkAnchor` per candidate
+state).
+
+This was expected to be low-risk: anchor-free states stay byte-identical, and only a small
+anchor-adjacent slice of states would lose caching. **That assumption is false for `find()`-mode
+scanning.** Measured via `IastRegexpBenchmark`'s SQL-tokenizer patterns (`\b\d+`,
+`(?m)...--.*$`) at LONG scale:
+
+| Benchmark | pre-Phase-2 (PikeVM fallback) | post-274488d |
+|---|---|---|
+| SqlAnsiFind | ~0.83–0.86x RE2J | 0.22x RE2J (0.0477 vs 0.2150 ops/ms) |
+| SqlMysqlFind | ~0.83–0.86x RE2J | 0.22x RE2J (0.0436 vs 0.2017 ops/ms) |
+| SqlPostgresqlFind | ~0.83–0.86x RE2J | 0.22x RE2J (0.0439 vs 0.1999 ops/ms) |
+
+~4x worse, for exactly the pattern class this extension was meant to help.
+
+## Root cause (verified against current code)
+
+`LaurikariCaptureNfaStep.addClosure` adds an anchor-bearing NFA state to the closure's output
+subset **unconditionally** — the `checkAnchor` gate only prunes that state's *onward* epsilon
+edges when it fails. So a DFA state's `anchorSensitive` classification depends only on
+epsilon-reachability of an anchor-bearing state, not on whether the anchor actually fires at
+that position.
+
+`find()`'s driving loop (`LaurikariCaptureNfaStep.applyFind`) re-injects a fresh
+self-anchoring closure from `startStateId` at *every* character (this is how "restart the match
+attempt at every position" leftmost-longest semantics work here). Since `\b` sits directly on
+the `\d+` branch reachable by epsilon from `startStateId`, nearly every state interned in
+`findCache` ends up `anchorSensitive = true` — measured 13/19 (68%) for `SQL_ANSI`. That defeats
+`asciiTables` caching for most of the automaton; live per-character closure recomputation
+(including a `checkAnchor` call) is far more expensive than even the `PikeVMMatcher` fallback
+this was meant to beat.
+
+Crucially, `matches()`/`match()` use a **separate** cache instance (`anchoredCache`), driven by
+plain `apply` with no reinject — so it doesn't suffer this explosion, and `matches()`-only usage
+of these patterns does not regress. The two code paths are already architecturally separable,
+which the recommended fix (Angle 4 below) exploits directly.
+
+`PikeVMMatcher.checkAnchor`'s actual information dependency for the 5 new types is small and
+local, not a general function of absolute position:
+- `WORD_BOUNDARY`: `isLetterOrDigit(charAt(pos-1)) != isLetterOrDigit(charAt(pos))` — the
+  "prev word-class" bit is already known (it's the just-consumed transition char), the "next
+  word-class" bit depends on the *next*, not-yet-consumed character.
+- `END`/`STRING_END`/`END_MULTILINE`/`STRING_END_ABSOLUTE`: depend only on `pos == regionEnd`
+  and, within 2 characters of `regionEnd`, the literal next 1–2 characters (`\r`, `\n`,
+  NEL/LS/PS).
+
+This collapses to a small, enumerable "lookahead class" over the next character(s) — not a
+general position signature.
+
+## Angles considered
+
+1. **Narrower eligibility** (exclude anchors epsilon-reachable from start). Rejected — the SQL
+   tokenizer's `\b` sits exactly at the leading position of its branch, i.e. precisely the shape
+   this extension exists to help. Excluding it defeats the extension's purpose.
+
+2. **Smarter caching key** — fold anchor context into the `asciiTables` transition-cache lookup
+   only (not into `LaurikariStateSetKey`/state identity). The plan's original rejection of "bake
+   an anchor signature into the cache key" was about baking it into *state identity*, which risks
+   state-space blowup (new interned states per context). Widening only the per-transition cache
+   dimension for the minority of anchor-sensitive states carries none of that risk.
+
+3. **Two-tier caching** — cache the anchor-blind transition and only recompute near the boundary.
+   Not literally sound standalone (the anchor outcome changes which onward epsilon edges are
+   followed, so one fixed cached target is wrong), but its refined form — cache **one small table
+   per lookahead-class bucket** instead of one table or none — is the same fix as angle 2, just
+   arrived at from the other direction. Treat 2+3 as one fix.
+
+4. **Route `find()` for new-anchor-bearing patterns to `PikeVMMatcher`, keep `matches()` on the
+   new path.** Cheap and low-risk: `LaurikariDfaMatcher` already keeps `anchoredCache` (used by
+   `matches`/`match`) and `findCache` (used by the `find` family) as separate paths, and
+   `BitStateMatcher` already has a fallback branch point per call. Pure routing change, no new
+   closure logic — near-zero correctness risk. Restores the pre-Phase-2 `find()` baseline
+   immediately but forgoes the `find()`-side win for exactly the SQL benchmark class.
+
+5. **Drop anchor-bearing states from the reinject closure.** Not viable — the anchor-bearing
+   state's epsilon-reachability from the reinject seed is exactly the pattern's real downstream
+   content (`\d+`); it can't be omitted from the subset. Only the caching *decision* around it
+   can be made smarter — i.e. angle 2+3.
+
+## Recommendation
+
+Ship angle 2+3 (the lookahead-class fan-out) directly — it supersedes angle 4, so there's no
+need for a separate safety-net step: the fan-out attacks the actual caching defeat rather than
+routing around it, and its own fast proxy check (test-plan item 1, below) is exactly the gate
+that should have caught `274488d`'s regression before a JMH run was needed. Angle 4
+(`findEligible` routing `find()` to `PikeVMMatcher` for these patterns) is noted only as a
+rollback lever: if the proxy check ever shows a *different* anchor shape blowing up
+`anchorSensitiveCount` even with the fan-out in place, add `findEligible` then, as a targeted
+kill switch for that shape — don't build it speculatively now.
+
+**The fix: lookahead-class fan-out (angle 2+3).**
+Define a bounded `AnchorLookahead` classification computed from `(input, pos, regionEnd)`,
+sufficient to make `checkAnchor`'s result for all 5 new types a pure function of
+`(anchorType, class)`:
+- `END_OF_INPUT` (`pos == regionEnd`)
+- `WORD_CHAR` (`charAt(pos)` is letter-or-digit)
+- `CR`, `LF`, `NEL_LS_PS`, `OTHER_NONWORD`
+
+For `END`/`STRING_END`'s 2-character-ahead `\r\n` check, restrict the fan-out to interior
+positions (`regionEnd - pos > 2`) and force live recomputation for the last 2 characters before
+`regionEnd` — O(1) per scan, and removes the only case needing more than 1-character lookahead
+from the fast path.
+
+Cache table shape for anchor-sensitive states changes from `int[128]` (indexed by consumed char)
+to `int[128][]` (second dimension = lookahead class, allocated lazily, size ≤ 6). Anchor-*free*
+states are unaffected — no second dimension allocated, same `asciiTables` code path as today.
+
+### File-by-file sketch
+
+- **`LaurikariDFACache.java`**: add `anchorLookaheadTables[state]` (`int[128][]`, lazily
+  allocated) alongside `asciiTables`. `step(state, c, ..., input, pos, regionEnd)` for
+  `anchorSensitive[state]` computes the lookahead class first, looks up
+  `anchorLookaheadTables[state][c][class]` before falling through to `lookupOrCompute`.
+  `cacheEntry` gains an overload keyed by `(state, c, class, value)`. Positions within 2 of
+  `regionEnd` always call `lookupOrCompute` directly (never cached).
+- **New small helper** (`PikeVMMatcher` or a new package-private `AnchorLookahead` utility):
+  `static int lookaheadClass(String input, int pos, int regionEnd)`. The equivalence
+  `checkAnchor(anchor, input, pos, 0, regionEnd) == f(anchor, lookaheadClass(input, pos,
+  regionEnd))` for all 5 new types is the correctness linchpin and needs its own exhaustive unit
+  test.
+- **`LaurikariCaptureNfaStep.java`**: no change to closure/register logic — `addClosure`'s
+  existing per-occurrence `checkAnchor` call remains the ground truth the cache must reproduce.
+- **`LaurikariDfaMatcher.java`**: no routing change — `find`/`findFrom`/`findMatch`/
+  `findMatchFrom` keep using `findCache` as today; the fan-out lives entirely inside
+  `LaurikariDFACache`'s transition-cache lookup.
+- **`LaurikariEligibility.java`**: no change — eligibility stays as extended in `274488d`.
+
+### Test plan
+
+1. **Fast proxy check before any JMH run** (this is the check `274488d`'s postmortem says was
+   missing): assert `anchorSensitiveCount` for `findCache` built from `SQL_ANSI`/`SQL_MYSQL`/
+   `SQL_POSTGRESQL` drops from ~68% back to near the `anchoredCache` baseline once this fix lands,
+   and that `stateCount()` stays the same order of magnitude (the fan-out doesn't touch state
+   identity, so no state-space blowup). Assert `anchorLookaheadTables` allocation count is
+   bounded by the number of distinct anchor-bearing states × their outgoing anchor edges, not
+   proportional to input length. Run this check before any JMH benchmark re-run, per the
+   `274488d` postmortem.
+2. **Correctness**: exhaustive test proving `lookaheadClass` + cached lookup agrees with live
+   `checkAnchor`/`addClosure` for every `(anchorType, class)` combination, including the
+   interior/tail-of-input boundary (`regionEnd-1`, `regionEnd-2`, `regionEnd`). Re-run
+   `LaurikariHybridDisjointnessTest`, the Task 1.5 anchor-boundary tests (`ce24f15`), and the
+   full differential-fuzz suite against `PikeVMMatcher` — zero net-new divergences.
+3. **Byte-identical regression guard**: anchor-free patterns must produce identical
+   `asciiTables`/`anchorSensitive` state and identical cache hit/miss counts before and after —
+   no `int[128][]` allocated at all when `hasNewAnchor == false`.
+4. **Performance regression pin**: re-add a benchmark-backed (or cheaper op-count/hit-rate CI
+   proxy) assertion that `SqlAnsiFind`/`SqlMysqlFind`/`SqlPostgresqlFind` are at or above the
+   ~0.83–0.86x pre-Phase-2 baseline at LONG scale — gate the merge on this explicitly. If this
+   still fails after the fan-out lands, that is the signal to reconsider a `findEligible`-style
+   rollback lever for the specific shape that still blows up, rather than adding it preemptively.
+
+## Critical files
+
+- `reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDFACache.java`
+- `reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariCaptureNfaStep.java`
+- `reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcher.java`
+- `reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java`
+- `reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDFACacheTest.java`

--- a/docs/sphinx/specs/2026-07-15-b-and-b-semantics-here-use-characteri.md
+++ b/docs/sphinx/specs/2026-07-15-b-and-b-semantics-here-use-characteri.md
@@ -1,0 +1,109 @@
+# Spec: b-and-b-semantics-here-use-characteri
+
+## Problem
+The runtime `\b`/`\B` (`WORD_BOUNDARY`/`NON_WORD_BOUNDARY`) anchor checks in `PikeVMMatcher`,
+`BackrefBacktrackMatcher`, and the Laurikari transition-cache classifier in `LaurikariDFACache`
+classify "word" characters with `Character.isLetterOrDigit`, which admits Unicode
+letters/digits and excludes `_`. This diverges from the ASCII `[A-Za-z0-9_]` word-char definition
+used everywhere else in Reggie (`CharSet.WORD`, the generated `isWordChar` helpers) and from Java's
+own `\b` semantics for `_`.
+
+Separately, the annotation-processor code-generation path
+(`ReggieMatcherBytecodeGenerator`'s `SPECIALIZED_FIXED_SEQUENCE` case) never calls
+`FixedSequenceBytecodeGenerator.generateBoundaryHelperMethods`, unlike the runtime-compiler path
+(`RuntimeCompiler`), so compile-time-generated matchers for patterns like
+`@RegexPattern("\\bfoo")` reference a private static `isBoundary` helper that is never emitted,
+which will fail at class verification/load time.
+
+Finally, two test files embed literal U+2028/U+2029/U+0085 characters directly in Java string
+literals instead of using `\uXXXX` escapes.
+
+## Correct behaviour
+- `\b`/`\B` classify a character as a "word" character iff it is ASCII `[A-Za-z0-9_]`
+  (`Character.isLetterOrDigit` matches on Unicode letters/digits, and it excludes `_` — neither is
+  correct here). This must hold identically in every place that evaluates or pre-classifies
+  `WORD_BOUNDARY`/`NON_WORD_BOUNDARY`:
+  - `PikeVMMatcher.checkAnchor` (used directly by `BitStateMatcher` and `LaurikariCaptureNfaStep`,
+    not duplicated by them).
+  - `BackrefBacktrackMatcher.checkAnchor` (its own duplicated mirror of `PikeVMMatcher`'s anchor
+    semantics).
+  - `LaurikariDFACache.lookaheadClass`, which pre-buckets the not-yet-consumed character into
+    `LOOKAHEAD_WORD`/`LOOKAHEAD_NEWLINE`/`LOOKAHEAD_OTHER` for a cache keyed on
+    `PikeVMMatcher.checkAnchor`'s outcome — it must bucket exactly the same set of characters as
+    `LOOKAHEAD_WORD` that `checkAnchor` treats as word characters, or the cache serves a stale
+    result for one class after computing it for the other.
+  - For example, `/\B\w+/` on `"_a"` must find a match starting at position 0 (no boundary between
+    `_` and `a`), consistently across `PikeVMMatcher`, `BackrefBacktrackMatcher`, `BitStateMatcher`,
+    and `LaurikariDfaMatcher`.
+- Compile-time-generated matchers (annotation processor) for `SPECIALIZED_FIXED_SEQUENCE` patterns
+  with a leading and/or trailing `\b`/`\B` must emit the `isWordChar`/`isBoundary` helper methods,
+  exactly like the runtime-compiler path already does, so `matches()`/`find()`/`findFrom()` resolve
+  correctly for patterns such as `@RegexPattern("\\bfoo")`, `@RegexPattern("foo\\b")`, and
+  `@RegexPattern("\\bfoo\\b")` (and their `\B` variants).
+- The affected test files must use Unicode escapes (`\u2028`, `\u2029`, `\u0085`) instead of literal
+  non-ASCII characters, with the same characters being tested and existing descriptive comments
+  preserved.
+
+## Constraints
+- `PikeVMMatcher.checkAnchor`'s signature and its direct callers (`BitStateMatcher`,
+  `LaurikariCaptureNfaStep`) must not change.
+- `BackrefBacktrackMatcher.checkAnchor` keeps its private, class-local mirror of the anchor logic
+  (existing project convention noted in its own Javadoc: "Mirrors `PikeVMMatcher`'s anchor
+  semantics") — only its word-char classification changes.
+- `LaurikariDFACache`'s ASCII fast-path split (values `0-127` cached directly, `c >= 128` always
+  falls back) is unchanged; only which of the 128 ASCII values classify as `LOOKAHEAD_WORD` changes.
+- No behavior change to any anchor type other than `WORD_BOUNDARY`/`NON_WORD_BOUNDARY`.
+- `RuntimeCompiler`'s existing `needsBoundaryHelpers()`-guarded call to
+  `generateBoundaryHelperMethods` is the reference implementation the annotation-processor path
+  must mirror — do not change `RuntimeCompiler` itself.
+- Test-string literal changes are source-representation-only; the runtime `String` contents tested
+  must be byte-for-byte identical to before.
+
+## Scope
+
+### Primary fixes
+- `reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java:1339-1350` —
+  inconsistent word-char predicate — add an ASCII `[A-Za-z0-9_]` `isWordChar` helper and use it in
+  `WORD_BOUNDARY`/`NON_WORD_BOUNDARY`.
+- `reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BackrefBacktrackMatcher.java:266-277`
+  — same defect class in the mirrored `checkAnchor` copy — add the same ASCII predicate locally and
+  use it.
+- `reggie-processor/src/main/java/com/datadoghq/reggie/processor/ReggieMatcherBytecodeGenerator.java`
+  (`SPECIALIZED_FIXED_SEQUENCE` case, ~line 360-374) — dual-path codegen divergence — call
+  `fixedGen.generateBoundaryHelperMethods(cw, getJavaClassName())` under the same
+  `needsBoundaryHelpers()` guard `RuntimeCompiler` uses.
+- `reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariAnchorLookaheadFuzzTest.java:369-371`
+  — literal Unicode line/paragraph separator/NEL characters — replace with `\u2028`/`\u2029`/`\u0085`
+  escapes.
+
+### Auto-expanded sibling fixes
+- `reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDFACache.java:382-385`
+  (`lookaheadClass`) — same word-char-predicate defect class — evidence: this method's Javadoc
+  (lines 373-376) explicitly documents that its `LOOKAHEAD_WORD` classification must match
+  `PikeVMMatcher.checkAnchor`'s `WORD_BOUNDARY` operand for the not-yet-consumed character, and its
+  body still calls `Character.isLetterOrDigit`. FLOW: `LaurikariDfaMatcher`/`LaurikariCaptureNfaStep`
+  drive `LaurikariDFACache.step`, which for `anchorSensitive` states calls `lookaheadClass` to pick
+  a cache bucket before delegating to `PikeVMMatcher.checkAnchor` via `lookupOrCompute`.
+  PRECONDITION: a `\b`/`\B`-anchored pattern reaches an `anchorSensitive` DFA state away from
+  `regionEnd`. REACHABLE: yes — this is the exact code path exercised by
+  `LaurikariAnchorLookaheadFuzzTest`. CONCLUSION: must be fixed in the same pass as
+  `PikeVMMatcher.checkAnchor`, or the cache silently serves wrong transitions for `_`-adjacent
+  input once `checkAnchor` itself is corrected.
+- `reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcherTest.java:366` —
+  same defect class as the primary literal-Unicode-characters item — evidence: the line contains
+  literal U+2028 and U+0085 characters in a `String[]` literal, in the same PR's added test code.
+  FLOW: N/A (test data literal, not an execution path). PRECONDITION: none — the literal characters
+  are present in the file regardless of any runtime path. REACHABLE: yes — the file compiles and
+  runs as part of the existing test suite today. CONCLUSION: same fix (escape the characters)
+  applies for the same readability/encoding-robustness reason.
+
+## Assumptions
+- Resolved at ≥90% confidence: `LaurikariDFACache.lookaheadClass` should call a shared,
+  package-private `PikeVMMatcher.isWordChar` rather than duplicating the ASCII predicate a third
+  time, since `LaurikariDFACache` is in the same package (`com.datadoghq.reggie.runtime`) and its
+  sole purpose for this method is to pre-compute `PikeVMMatcher.checkAnchor`'s outcome.
+- Resolved at ≥90% confidence: `BackrefBacktrackMatcher.checkAnchor` keeps its own private
+  duplicate helper (rather than calling `PikeVMMatcher`), consistent with its existing "mirrors"
+  convention and its already fully-duplicated `checkAnchor` method body.
+- Resolved at ≥90% confidence: the trailing descriptive comments (`// LINE SEPARATOR`, etc.) in the
+  two test files are preserved verbatim; only the character literal changes to its escape.

--- a/reggie-benchmark/build.gradle
+++ b/reggie-benchmark/build.gradle
@@ -9,6 +9,10 @@ repositories {
 
 dependencies {
     implementation project(':reggie-runtime')
+
+    // NFA/ThompsonBuilder/RegexParser for LaurikariPhase0Benchmark's test-only driver.
+    // reggie-runtime declares this as 'implementation' (not 'api'), so it is not exposed
+    // transitively and must be declared explicitly here.
     implementation project(':reggie-codegen')
     annotationProcessor project(':reggie-processor')
 

--- a/reggie-benchmark/build.gradle
+++ b/reggie-benchmark/build.gradle
@@ -9,6 +9,7 @@ repositories {
 
 dependencies {
     implementation project(':reggie-runtime')
+    implementation project(':reggie-codegen')
     annotationProcessor project(':reggie-processor')
 
     // Integration tests for benchmark patterns

--- a/reggie-benchmark/src/main/java/com/datadoghq/reggie/benchmark/IastRegexpBenchmark.java
+++ b/reggie-benchmark/src/main/java/com/datadoghq/reggie/benchmark/IastRegexpBenchmark.java
@@ -106,6 +106,11 @@ public class IastRegexpBenchmark {
   // Original flags: MULTILINE | DOTALL — expressed as inline (?s)(?m) for Reggie.
   private static final String COMMAND = "(?s)(?m)^(?:\\s*(?:sudo|doas)\\s+)?\\b\\S+\\b\\s*(.*)";
 
+  // Bare word-boundary anchor, isolated from any surrounding tokenizer pattern — measures \b's
+  // own cost rather than a larger pattern's. Scan-prefix growth: filler text (no "foo" substring)
+  // is prepended before the matching "foo", stressing find()'s scan cost.
+  private static final String BARE_WORD_BOUNDARY = "\\bfoo";
+
   // UrlRegexpTokenizer: matches credentials in the authority component, or sensitive query params.
   // Named groups: JDK/Reggie use (?<name>), re2j uses (?P<name>).
   private static final String URL_JDK =
@@ -154,6 +159,7 @@ public class IastRegexpBenchmark {
 
   // --- Reggie matchers ---
   private ReggieMatcher reggieCommand;
+  private ReggieMatcher reggieBareWordBoundary;
   private ReggieMatcher reggieUrl;
   private ReggieMatcher reggieSqlAnsi;
   private ReggieMatcher reggieSqlMysql;
@@ -163,6 +169,7 @@ public class IastRegexpBenchmark {
 
   // --- JDK patterns ---
   private Pattern jdkCommand;
+  private Pattern jdkBareWordBoundary;
   private Pattern jdkUrl;
   private Pattern jdkSqlAnsi;
   private Pattern jdkSqlMysql;
@@ -172,6 +179,7 @@ public class IastRegexpBenchmark {
 
   // --- RE2J patterns ---
   private com.google.re2j.Pattern re2jCommand;
+  private com.google.re2j.Pattern re2jBareWordBoundary;
   private com.google.re2j.Pattern re2jUrl;
   private com.google.re2j.Pattern re2jSqlAnsi;
   private com.google.re2j.Pattern re2jSqlMysql;
@@ -185,6 +193,9 @@ public class IastRegexpBenchmark {
   // Command: a sudo invocation with arguments (find() always matches — tests match-path cost).
   // Matched-region growth: the trailing (.*) capture widens.
   private String commandInput;
+
+  // Bare word-boundary: scan-prefix growth — filler (no "foo" substring) grows before the match.
+  private String bareWordBoundaryInput;
 
   // URL: authority credentials match vs query-param match vs no match.
   // AUTHORITY branch is matched-region growth (^-anchored, so scan-prefix filler isn't possible
@@ -224,6 +235,16 @@ public class IastRegexpBenchmark {
     reggieCommand = RuntimeCompiler.compile(COMMAND);
     jdkCommand = Pattern.compile(COMMAND);
     re2jCommand = com.google.re2j.Pattern.compile(COMMAND);
+
+    bareWordBoundaryInput =
+        pick(
+            scale,
+            "lorem ipsum dolor sit amet foo",
+            "lorem ipsum dolor sit amet ".repeat(20) + "foo",
+            "lorem ipsum dolor sit amet ".repeat(2000) + "foo");
+    reggieBareWordBoundary = RuntimeCompiler.compile(BARE_WORD_BOUNDARY);
+    jdkBareWordBoundary = Pattern.compile(BARE_WORD_BOUNDARY);
+    re2jBareWordBoundary = com.google.re2j.Pattern.compile(BARE_WORD_BOUNDARY);
 
     urlAuthMatch =
         pick(
@@ -395,6 +416,23 @@ public class IastRegexpBenchmark {
       return -1L;
     }
     return (long) m.start(1) + m.end(1);
+  }
+
+  // ===== Bare word boundary =====
+
+  @Benchmark
+  public boolean reggieBareWordBoundaryFind() {
+    return reggieBareWordBoundary.find(bareWordBoundaryInput);
+  }
+
+  @Benchmark
+  public boolean jdkBareWordBoundaryFind() {
+    return jdkBareWordBoundary.matcher(bareWordBoundaryInput).find();
+  }
+
+  @Benchmark
+  public boolean re2jBareWordBoundaryFind() {
+    return re2jBareWordBoundary.matcher(bareWordBoundaryInput).find();
   }
 
   // ===== URL =====

--- a/reggie-benchmark/src/main/java/com/datadoghq/reggie/runtime/LaurikariPhase0Benchmark.java
+++ b/reggie-benchmark/src/main/java/com/datadoghq/reggie/runtime/LaurikariPhase0Benchmark.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import com.datadoghq.reggie.codegen.automaton.NFA;
+import com.datadoghq.reggie.codegen.automaton.ThompsonBuilder;
+import com.datadoghq.reggie.codegen.parsing.RegexParser;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Real-JMH counterpart to {@code LaurikariPhase0SpikeTest}'s ad-hoc {@code nanoTime} measurement,
+ * closing the Phase 0 exit-criterion-(c) gap flagged by adversarial verification (impl plan Task
+ * 0.3): {@code findLeftmostStart} measured under the same JMH harness (warmup/fork/measurement
+ * discipline) as {@code IastRegexpBenchmark}'s {@code reggieSqlAnsiFind}/{@code
+ * reggieSqlMysqlFind}/{@code reggieSqlPostgresqlFind} (the "current full-{@code
+ * PikeVMMatcher}-punt" baseline this design targets, since at LONG scale those calls already exceed
+ * {@code BitStateMatcher.BUDGET_CELLS} and fall through to {@code PikeVMMatcher}'s thread
+ * simulation), against the exact same LONG-scale inputs (mirrored verbatim from {@code
+ * IastRegexpBenchmark.java}'s {@code setup()}).
+ *
+ * <p>Package placement note: this class lives in {@code com.datadoghq.reggie.runtime} (matching the
+ * package it benchmarks) even though it is physically under {@code reggie-benchmark}'s source tree,
+ * to reach {@link LaurikariDFACache}/{@link LaurikariNfaStep}/{@link LaurikariStepResult}, which
+ * are package-private with no production entry point yet (Phase 0 has none — see those classes'
+ * javadoc). The project has no {@code module-info.java} anywhere, so this split package is plain
+ * classpath-mode Java, not a module violation.
+ *
+ * <p>The step-function driver (closure + consuming-transition + merge) duplicates {@code
+ * LaurikariDFACacheTest}'s and {@code LaurikariPhase0SpikeTest}'s test-only driver verbatim, for
+ * the same legitimate reason those two duplicate each other: Phase 0 has no shared production
+ * wiring point, and this is disposable spike-measurement scaffolding, not a place to introduce a
+ * shared abstraction ahead of Phase 1's actual generalization.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class LaurikariPhase0Benchmark {
+
+  // --- SQL_ANSI/MYSQL/POSTGRESQL, mirrored verbatim from IastRegexpBenchmark.java:101-116 -------
+  private static final String SQL_ANSI =
+      "(?i)(?m)[-+]?(?:x'[0-9a-f]+'|0x[0-9a-f]+|b'[0-9a-f]+'|0b[0-9a-f]+"
+          + "|\\d*\\.\\d+(?:E[-+]?\\d+[fd]?)?|\\b\\d+(?:E[-+]?\\d+[fd]?)?)"
+          + "|'(?:''|[^'])*'|--.*$|/\\*[\\s\\S]*\\*/";
+  private static final String SQL_MYSQL =
+      "(?i)(?m)[-+]?(?:x'[0-9a-f]+'|0x[0-9a-f]+|b'[0-9a-f]+'|0b[0-9a-f]+"
+          + "|\\d*\\.\\d+(?:E[-+]?\\d+[fd]?)?|\\b\\d+(?:E[-+]?\\d+[fd]?)?)"
+          + "|\"(?:\\\\\"|[^\"])*\"|'(?:\\\\'|[^'])*'|--.*$|/\\*[\\s\\S]*\\*/";
+  private static final String SQL_POSTGRESQL =
+      "(?i)(?m)[-+]?(?:x'[0-9a-f]+'|0x[0-9a-f]+|b'[0-9a-f]+'|0b[0-9a-f]+"
+          + "|\\d*\\.\\d+(?:E[-+]?\\d+[fd]?)?|\\b\\d+(?:E[-+]?\\d+[fd]?)?)"
+          + "|\\$(?:[a-zA-Z_]\\w*)?\\$|'(?:''|[^'])*'|--.*$|/\\*[\\s\\S]*\\*/";
+
+  // --- LONG-scale sqlMatch/mysqlMatch/postgresqlMatch, mirrored verbatim from
+  // --- IastRegexpBenchmark.java's setup() (the third pick(scale, ...) argument = LONG).
+  // -----------
+  private static final String SQL_MATCH_LONG =
+      "SELECT * FROM users WHERE "
+          + "col_x = col_y AND ".repeat(2000)
+          + "id = 42 AND name = 'Alice' AND balance = 1234.56";
+  private static final String MYSQL_MATCH_LONG =
+      "SELECT id, `name` FROM users WHERE "
+          + "col_x = col_y AND ".repeat(2000)
+          + "id = 1 AND email = 'user@example.com' AND active = 1";
+  private static final String POSTGRESQL_MATCH_LONG =
+      "SELECT * FROM docs WHERE "
+          + "col_x = col_y AND ".repeat(2000)
+          + "body = $$hello world$$ AND revision = 3";
+
+  // --- Test-only LaurikariNfaStep driver, duplicated verbatim from LaurikariDFACacheTest ---------
+
+  private static NFA nfa(String pattern, int groupCount) throws Exception {
+    return new ThompsonBuilder().build(new RegexParser().parse(pattern), groupCount);
+  }
+
+  private static NFA.NFAState[] statesById(NFA nfa) {
+    NFA.NFAState[] arr = new NFA.NFAState[nfa.getStates().size()];
+    for (NFA.NFAState s : nfa.getStates()) {
+      arr[s.id] = s;
+    }
+    return arr;
+  }
+
+  private static int[][] closureWithAges(
+      NFA.NFAState[] statesById, int stateCount, int[] seedStates, int[] seedAges) {
+    int[] ages = new int[stateCount];
+    Arrays.fill(ages, -1);
+    Deque<Integer> worklist = new ArrayDeque<>();
+    for (int i = 0; i < seedStates.length; i++) {
+      int id = seedStates[i];
+      if (seedAges[i] > ages[id]) {
+        ages[id] = seedAges[i];
+        worklist.push(id);
+      }
+    }
+    while (!worklist.isEmpty()) {
+      int id = worklist.pop();
+      int age = ages[id];
+      for (NFA.NFAState e : statesById[id].getEpsilonTransitions()) {
+        if (age > ages[e.id]) {
+          ages[e.id] = age;
+          worklist.push(e.id);
+        }
+      }
+    }
+    return denseToSeed(ages, stateCount);
+  }
+
+  private static int[][] denseToSeed(int[] denseAges, int stateCount) {
+    int count = 0;
+    for (int v : denseAges) {
+      if (v >= 0) count++;
+    }
+    int[] states = new int[count];
+    int[] ages = new int[count];
+    int oi = 0;
+    for (int id = 0; id < stateCount; id++) {
+      if (denseAges[id] >= 0) {
+        states[oi] = id;
+        ages[oi] = denseAges[id];
+        oi++;
+      }
+    }
+    return new int[][] {states, ages};
+  }
+
+  private static LaurikariNfaStep laurikariStep(NFA nfa) {
+    NFA.NFAState[] statesById = statesById(nfa);
+    int stateCount = statesById.length;
+    int startId = nfa.getStartState().id;
+    return (curStates, curRegs, c) -> {
+      int[] rawAges = new int[stateCount];
+      Arrays.fill(rawAges, -1);
+      for (int i = 0; i < curStates.length; i++) {
+        NFA.NFAState s = statesById[curStates[i]];
+        int age = curRegs[i][0];
+        for (NFA.Transition t : s.getTransitions()) {
+          if (t.chars.contains((char) c)) {
+            int cand = age + 1;
+            if (cand > rawAges[t.target.id]) rawAges[t.target.id] = cand;
+          }
+        }
+      }
+      int[][] consumedSeed = denseToSeed(rawAges, stateCount);
+      int[][] consumedClosed =
+          closureWithAges(statesById, stateCount, consumedSeed[0], consumedSeed[1]);
+      int[][] freshClosed =
+          closureWithAges(statesById, stateCount, new int[] {startId}, new int[] {0});
+
+      int[] merged = new int[stateCount];
+      Arrays.fill(merged, -1);
+      for (int i = 0; i < consumedClosed[0].length; i++) {
+        merged[consumedClosed[0][i]] = consumedClosed[1][i];
+      }
+      for (int i = 0; i < freshClosed[0].length; i++) {
+        int id = freshClosed[0][i];
+        int age = freshClosed[1][i];
+        if (age > merged[id]) merged[id] = age;
+      }
+      int[][] out = denseToSeed(merged, stateCount);
+      int[] outStates = out[0];
+      int[] outAges = out[1];
+      int[][] outRegs = new int[outStates.length][];
+      for (int i = 0; i < outStates.length; i++) {
+        outRegs[i] = new int[] {outAges[i]};
+      }
+      return new LaurikariStepResult(outStates, outRegs);
+    };
+  }
+
+  private static final class Built {
+    final LaurikariDFACache cache;
+    final LaurikariNfaStep step;
+
+    Built(LaurikariDFACache cache, LaurikariNfaStep step) {
+      this.cache = cache;
+      this.step = step;
+    }
+  }
+
+  private static Built build(String pattern) throws Exception {
+    NFA nfa = nfa(pattern, 0);
+    NFA.NFAState[] statesById = statesById(nfa);
+    int stateCount = statesById.length;
+    int startId = nfa.getStartState().id;
+
+    int[][] startClosure =
+        closureWithAges(statesById, stateCount, new int[] {startId}, new int[] {0});
+
+    int[] acceptIds = new int[nfa.getAcceptStates().size()];
+    int ai = 0;
+    for (NFA.NFAState s : nfa.getAcceptStates()) {
+      acceptIds[ai++] = s.id;
+    }
+
+    int[] startStates = startClosure[0];
+    int[] startAges = startClosure[1];
+    int[][] startRegs = new int[startStates.length][];
+    for (int i = 0; i < startStates.length; i++) {
+      startRegs[i] = new int[] {startAges[i]};
+    }
+
+    LaurikariDFACache cache = new LaurikariDFACache(startStates, startRegs, acceptIds);
+    return new Built(cache, laurikariStep(nfa));
+  }
+
+  private Built sqlAnsi;
+  private Built sqlMysql;
+  private Built sqlPostgresql;
+
+  @Setup(Level.Trial)
+  public void setup() throws Exception {
+    sqlAnsi = build(SQL_ANSI);
+    sqlMysql = build(SQL_MYSQL);
+    sqlPostgresql = build(SQL_POSTGRESQL);
+  }
+
+  @Benchmark
+  public int laurikariSqlAnsiFindLong() {
+    return sqlAnsi.cache.findLeftmostStart(SQL_MATCH_LONG, 0, sqlAnsi.step);
+  }
+
+  @Benchmark
+  public int laurikariSqlMysqlFindLong() {
+    return sqlMysql.cache.findLeftmostStart(MYSQL_MATCH_LONG, 0, sqlMysql.step);
+  }
+
+  @Benchmark
+  public int laurikariSqlPostgresqlFindLong() {
+    return sqlPostgresql.cache.findLeftmostStart(POSTGRESQL_MATCH_LONG, 0, sqlPostgresql.step);
+  }
+}

--- a/reggie-benchmark/src/main/java/com/datadoghq/reggie/runtime/LaurikariPhase0Benchmark.java
+++ b/reggie-benchmark/src/main/java/com/datadoghq/reggie/runtime/LaurikariPhase0Benchmark.java
@@ -157,7 +157,7 @@ public class LaurikariPhase0Benchmark {
     NFA.NFAState[] statesById = statesById(nfa);
     int stateCount = statesById.length;
     int startId = nfa.getStartState().id;
-    return (curStates, curRegs, c) -> {
+    return (curStates, curRegs, c, input, pos, regionEnd) -> {
       int[] rawAges = new int[stateCount];
       Arrays.fill(rawAges, -1);
       for (int i = 0; i < curStates.length; i++) {

--- a/reggie-benchmark/src/main/java/com/datadoghq/reggie/runtime/LaurikariPhase0Benchmark.java
+++ b/reggie-benchmark/src/main/java/com/datadoghq/reggie/runtime/LaurikariPhase0Benchmark.java
@@ -66,7 +66,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Fork(1)
 public class LaurikariPhase0Benchmark {
 
-  // --- SQL_ANSI/MYSQL/POSTGRESQL, mirrored verbatim from IastRegexpBenchmark.java:101-116 -------
+  // --- SQL_ANSI/MYSQL/POSTGRESQL, mirrored verbatim from IastRegexpBenchmark.java:118-133 -------
   private static final String SQL_ANSI =
       "(?i)(?m)[-+]?(?:x'[0-9a-f]+'|0x[0-9a-f]+|b'[0-9a-f]+'|0b[0-9a-f]+"
           + "|\\d*\\.\\d+(?:E[-+]?\\d+[fd]?)?|\\b\\d+(?:E[-+]?\\d+[fd]?)?)"
@@ -85,15 +85,15 @@ public class LaurikariPhase0Benchmark {
   // -----------
   private static final String SQL_MATCH_LONG =
       "SELECT * FROM users WHERE "
-          + "col_x = col_y AND ".repeat(2000)
+          + "col_x = col_y AND ".repeat(100)
           + "id = 42 AND name = 'Alice' AND balance = 1234.56";
   private static final String MYSQL_MATCH_LONG =
       "SELECT id, `name` FROM users WHERE "
-          + "col_x = col_y AND ".repeat(2000)
+          + "col_x = col_y AND ".repeat(100)
           + "id = 1 AND email = 'user@example.com' AND active = 1";
   private static final String POSTGRESQL_MATCH_LONG =
       "SELECT * FROM docs WHERE "
-          + "col_x = col_y AND ".repeat(2000)
+          + "col_x = col_y AND ".repeat(100)
           + "body = $$hello world$$ AND revision = 3";
 
   // --- Test-only LaurikariNfaStep driver, duplicated verbatim from LaurikariDFACacheTest ---------

--- a/reggie-benchmark/src/main/java/com/datadoghq/reggie/runtime/LaurikariVsPikeVMCaptureBenchmark.java
+++ b/reggie-benchmark/src/main/java/com/datadoghq/reggie/runtime/LaurikariVsPikeVMCaptureBenchmark.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import com.datadoghq.reggie.codegen.ast.RegexNode;
+import com.datadoghq.reggie.codegen.automaton.NFA;
+import com.datadoghq.reggie.codegen.automaton.ThompsonBuilder;
+import com.datadoghq.reggie.codegen.parsing.RegexParser;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Direct-construction throughput comparison of {@link LaurikariDfaMatcher} against {@link
+ * PikeVMMatcher} over the exact five patterns whose capture correctness was verified against the
+ * PikeVMMatcher oracle in {@code LaurikariDfaMatcherTest}'s Phase 0.5 adversarial set: two
+ * independent greedy groups, a loop-body group, nested nullable groups, shared-prefix alternation,
+ * and quantified alternation.
+ *
+ * <p>Package placement note: this class lives in {@code com.datadoghq.reggie.runtime} (matching the
+ * package it benchmarks) even though it is physically under {@code reggie-benchmark}'s source tree,
+ * to reach {@link LaurikariDfaMatcher}, which is package-private with no production entry point yet
+ * (not wired into {@code PatternAnalyzer}/{@code RuntimeCompiler}). The project has no {@code
+ * module-info.java} anywhere, so this split package is plain classpath-mode Java, not a module
+ * violation — same approach already used by {@code LaurikariPhase0Benchmark}.
+ *
+ * <p>Both matchers are constructed once per trial in {@link #setup()} over the same {@link NFA}
+ * instance per pattern (mirroring {@code LaurikariDfaMatcherTest}'s {@code laurikari(...)}/{@code
+ * pikeVm(...)} helpers), so NFA-build cost is excluded from the measured {@code match}/{@code
+ * findMatch} calls themselves — except that each matcher's DFA cache is lazily populated on first
+ * use, so the very first measured call per state pays one-time subset-construction cost; this is
+ * intentional (mirrors real steady-state reuse) and warmup iterations absorb it.
+ *
+ * <p>Two scaling strategies, chosen per-pattern to match what actually varies, mirroring {@code
+ * AllStrategyVsJdkBenchmark}'s convention:
+ *
+ * <ul>
+ *   <li><b>Matched-region growth</b> (patterns 1-3: {@code (a+)(b+)}, {@code (ab)+}, {@code
+ *       ((a)|())*} — all have an unbounded loop/quantifier): LONG grows the matched span itself
+ *       (~1000 chars), for both {@code match()} and {@code findMatch()}, so the DFA's per-character
+ *       advantage (no capture-array copy) actually gets exercised over a long run.
+ *   <li><b>Scan-prefix growth for find, fixed width for match</b> (patterns 4-5: {@code
+ *       (foobar)|(foobaz)}, {@code (a|b){2,4}(c)} — both are fixed-width once matched, so an
+ *       anchored {@code match()} call cannot grow its own input without breaking the anchor).
+ *       {@code match()} uses the same fixed-width input at both scales (SHORT == LONG is
+ *       deliberate, not a bug); {@code findMatch()} instead prepends non-matching filler before the
+ *       match at LONG, stressing the self-anchoring scan cost rather than the match width (which
+ *       cannot grow).
+ * </ul>
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class LaurikariVsPikeVMCaptureBenchmark {
+
+  @Param({"SHORT", "LONG"})
+  public String scale;
+
+  private static NFA nfa(String pattern, int groupCount) throws Exception {
+    RegexNode ast = new RegexParser().parse(pattern);
+    return new ThompsonBuilder().build(ast, groupCount);
+  }
+
+  private static String pick(String scale, String shortV, String longV) {
+    return "SHORT".equals(scale) ? shortV : longV;
+  }
+
+  // ── Pattern 1: (a+)(b+) — two independent greedy groups (matched-region growth) ──
+  private static final String TWO_GROUPS_PAT = "(a+)(b+)";
+  private static final int TWO_GROUPS_GC = 2;
+
+  private String twoGroupsIn;
+  private LaurikariDfaMatcher twoGroupsLaurikari;
+  private PikeVMMatcher twoGroupsPikeVm;
+
+  // ── Pattern 2: (ab)+ — loop-body group (matched-region growth) ───────────────────
+  private static final String LOOP_BODY_PAT = "(ab)+";
+  private static final int LOOP_BODY_GC = 1;
+
+  private String loopBodyIn;
+  private LaurikariDfaMatcher loopBodyLaurikari;
+  private PikeVMMatcher loopBodyPikeVm;
+
+  // ── Pattern 3: ((a)|())* — nested nullable groups (matched-region growth) ────────
+  private static final String NESTED_NULLABLE_PAT = "((a)|())*";
+  private static final int NESTED_NULLABLE_GC = 3;
+
+  private String nestedNullableIn;
+  private LaurikariDfaMatcher nestedNullableLaurikari;
+  private PikeVMMatcher nestedNullablePikeVm;
+
+  // ── Pattern 4: (foobar)|(foobaz) — shared-prefix alternation (fixed width; scan-
+  // prefix growth for find only) ────────────────────────────────────────────────────
+  private static final String SHARED_PREFIX_PAT = "(foobar)|(foobaz)";
+  private static final int SHARED_PREFIX_GC = 2;
+  private static final String SHARED_PREFIX_MATCH_IN = "foobaz";
+
+  private String sharedPrefixFindIn;
+  private LaurikariDfaMatcher sharedPrefixLaurikari;
+  private PikeVMMatcher sharedPrefixPikeVm;
+
+  // ── Pattern 5: (a|b){2,4}(c) — quantified alternation (fixed width; scan-prefix
+  // growth for find only) ────────────────────────────────────────────────────────────
+  private static final String QUANTIFIED_ALT_PAT = "(a|b){2,4}(c)";
+  private static final int QUANTIFIED_ALT_GC = 2;
+  private static final String QUANTIFIED_ALT_MATCH_IN = "abbac";
+
+  private String quantifiedAltFindIn;
+  private LaurikariDfaMatcher quantifiedAltLaurikari;
+  private PikeVMMatcher quantifiedAltPikeVm;
+
+  @Setup(Level.Trial)
+  public void setup() throws Exception {
+    twoGroupsIn = pick(scale, "aaabbb", "a".repeat(500) + "b".repeat(500));
+    twoGroupsLaurikari =
+        new LaurikariDfaMatcher(nfa(TWO_GROUPS_PAT, TWO_GROUPS_GC), TWO_GROUPS_PAT, TWO_GROUPS_GC);
+    twoGroupsPikeVm = new PikeVMMatcher(nfa(TWO_GROUPS_PAT, TWO_GROUPS_GC), TWO_GROUPS_PAT);
+
+    loopBodyIn = pick(scale, "ababab", "ab".repeat(500));
+    loopBodyLaurikari =
+        new LaurikariDfaMatcher(nfa(LOOP_BODY_PAT, LOOP_BODY_GC), LOOP_BODY_PAT, LOOP_BODY_GC);
+    loopBodyPikeVm = new PikeVMMatcher(nfa(LOOP_BODY_PAT, LOOP_BODY_GC), LOOP_BODY_PAT);
+
+    nestedNullableIn = pick(scale, "aaaaaaaaaa", "a".repeat(1000));
+    nestedNullableLaurikari =
+        new LaurikariDfaMatcher(
+            nfa(NESTED_NULLABLE_PAT, NESTED_NULLABLE_GC), NESTED_NULLABLE_PAT, NESTED_NULLABLE_GC);
+    nestedNullablePikeVm =
+        new PikeVMMatcher(nfa(NESTED_NULLABLE_PAT, NESTED_NULLABLE_GC), NESTED_NULLABLE_PAT);
+
+    sharedPrefixFindIn = pick(scale, "xfoobazy", "z".repeat(1000) + "foobaz");
+    sharedPrefixLaurikari =
+        new LaurikariDfaMatcher(
+            nfa(SHARED_PREFIX_PAT, SHARED_PREFIX_GC), SHARED_PREFIX_PAT, SHARED_PREFIX_GC);
+    sharedPrefixPikeVm =
+        new PikeVMMatcher(nfa(SHARED_PREFIX_PAT, SHARED_PREFIX_GC), SHARED_PREFIX_PAT);
+
+    quantifiedAltFindIn = pick(scale, "xabbacy", "z".repeat(1000) + "abbac");
+    quantifiedAltLaurikari =
+        new LaurikariDfaMatcher(
+            nfa(QUANTIFIED_ALT_PAT, QUANTIFIED_ALT_GC), QUANTIFIED_ALT_PAT, QUANTIFIED_ALT_GC);
+    quantifiedAltPikeVm =
+        new PikeVMMatcher(nfa(QUANTIFIED_ALT_PAT, QUANTIFIED_ALT_GC), QUANTIFIED_ALT_PAT);
+  }
+
+  // ── (a+)(b+) benchmarks ────────────────────────────────────────────────────────
+
+  @Benchmark
+  public MatchResult twoGroups_match_laurikari() {
+    return twoGroupsLaurikari.match(twoGroupsIn);
+  }
+
+  @Benchmark
+  public MatchResult twoGroups_match_pikevm() {
+    return twoGroupsPikeVm.match(twoGroupsIn);
+  }
+
+  @Benchmark
+  public MatchResult twoGroups_findMatch_laurikari() {
+    return twoGroupsLaurikari.findMatch(twoGroupsIn);
+  }
+
+  @Benchmark
+  public MatchResult twoGroups_findMatch_pikevm() {
+    return twoGroupsPikeVm.findMatch(twoGroupsIn);
+  }
+
+  // ── (ab)+ benchmarks ────────────────────────────────────────────────────────────
+
+  @Benchmark
+  public MatchResult loopBody_match_laurikari() {
+    return loopBodyLaurikari.match(loopBodyIn);
+  }
+
+  @Benchmark
+  public MatchResult loopBody_match_pikevm() {
+    return loopBodyPikeVm.match(loopBodyIn);
+  }
+
+  @Benchmark
+  public MatchResult loopBody_findMatch_laurikari() {
+    return loopBodyLaurikari.findMatch(loopBodyIn);
+  }
+
+  @Benchmark
+  public MatchResult loopBody_findMatch_pikevm() {
+    return loopBodyPikeVm.findMatch(loopBodyIn);
+  }
+
+  // ── ((a)|())* benchmarks ─────────────────────────────────────────────────────────
+
+  @Benchmark
+  public MatchResult nestedNullable_match_laurikari() {
+    return nestedNullableLaurikari.match(nestedNullableIn);
+  }
+
+  @Benchmark
+  public MatchResult nestedNullable_match_pikevm() {
+    return nestedNullablePikeVm.match(nestedNullableIn);
+  }
+
+  @Benchmark
+  public MatchResult nestedNullable_findMatch_laurikari() {
+    return nestedNullableLaurikari.findMatch(nestedNullableIn);
+  }
+
+  @Benchmark
+  public MatchResult nestedNullable_findMatch_pikevm() {
+    return nestedNullablePikeVm.findMatch(nestedNullableIn);
+  }
+
+  // ── (foobar)|(foobaz) benchmarks ─────────────────────────────────────────────────
+
+  @Benchmark
+  public MatchResult sharedPrefix_match_laurikari() {
+    return sharedPrefixLaurikari.match(SHARED_PREFIX_MATCH_IN);
+  }
+
+  @Benchmark
+  public MatchResult sharedPrefix_match_pikevm() {
+    return sharedPrefixPikeVm.match(SHARED_PREFIX_MATCH_IN);
+  }
+
+  @Benchmark
+  public MatchResult sharedPrefix_findMatch_laurikari() {
+    return sharedPrefixLaurikari.findMatch(sharedPrefixFindIn);
+  }
+
+  @Benchmark
+  public MatchResult sharedPrefix_findMatch_pikevm() {
+    return sharedPrefixPikeVm.findMatch(sharedPrefixFindIn);
+  }
+
+  // ── (a|b){2,4}(c) benchmarks ─────────────────────────────────────────────────────
+
+  @Benchmark
+  public MatchResult quantifiedAlt_match_laurikari() {
+    return quantifiedAltLaurikari.match(QUANTIFIED_ALT_MATCH_IN);
+  }
+
+  @Benchmark
+  public MatchResult quantifiedAlt_match_pikevm() {
+    return quantifiedAltPikeVm.match(QUANTIFIED_ALT_MATCH_IN);
+  }
+
+  @Benchmark
+  public MatchResult quantifiedAlt_findMatch_laurikari() {
+    return quantifiedAltLaurikari.findMatch(quantifiedAltFindIn);
+  }
+
+  @Benchmark
+  public MatchResult quantifiedAlt_findMatch_pikevm() {
+    return quantifiedAltPikeVm.findMatch(quantifiedAltFindIn);
+  }
+}

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/LinearPatternAnalyzer.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/LinearPatternAnalyzer.java
@@ -148,11 +148,18 @@ public class LinearPatternAnalyzer implements RegexVisitor<Void> {
 
     // Handle word boundaries separately from line anchors
     if (node.type == AnchorNode.Type.WORD_BOUNDARY) {
-      // Word boundary check: \b (always positive, \B not yet supported)
       operations.add(
           new LinearPatternInfo.LinearOperation(
               LinearPatternInfo.LinearOperation.Type.CHECK_WORD_BOUNDARY,
               true // true = \b (positive word boundary)
+              ));
+      return null;
+    }
+    if (node.type == AnchorNode.Type.NON_WORD_BOUNDARY) {
+      operations.add(
+          new LinearPatternInfo.LinearOperation(
+              LinearPatternInfo.LinearOperation.Type.CHECK_WORD_BOUNDARY,
+              false // false = \B (negative word boundary)
               ));
       return null;
     }

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
@@ -98,6 +98,12 @@ public class PatternAnalyzer {
       return false;
     }
 
+    // \b/\B: OnePassBytecodeGenerator has no word-boundary check at all (silently a no-op);
+    // PIKEVM_CAPTURE evaluates checkAnchor correctly at each position instead.
+    if (nfa.hasWordBoundaryAnchor()) {
+      return false;
+    }
+
     // Check each state for ambiguity
     for (NFA.NFAState state : nfa.getStates()) {
       // Check for overlapping character transitions
@@ -1257,6 +1263,19 @@ public class PatternAnalyzer {
                   null,
                   needsPosixSemantics);
             }
+            // \b/\B: DFA subset construction silently drops per-position boundary context
+            // (SubsetConstructor.isPositionAnchor excludes WORD_BOUNDARY/NON_WORD_BOUNDARY);
+            // PIKEVM_CAPTURE evaluates checkAnchor correctly at each position instead.
+            if (nfa.hasWordBoundaryAnchor()) {
+              return new MatchingStrategyResult(
+                  MatchingStrategy.PIKEVM_CAPTURE,
+                  null,
+                  null,
+                  false,
+                  requiredLiterals,
+                  null,
+                  needsPosixSemantics);
+            }
             // Pure-regular, anchor-free: C2 priority-ordered TDFA gives correct spans.
             int stateCount = dfa.getStateCount();
             addTrace(
@@ -1389,6 +1408,20 @@ public class PatternAnalyzer {
               null,
               needsPosixSemantics);
         }
+        // \b/\B: DFA subset construction silently drops per-position boundary context
+        // (SubsetConstructor.isPositionAnchor excludes WORD_BOUNDARY/NON_WORD_BOUNDARY);
+        // PIKEVM_CAPTURE evaluates checkAnchor correctly at each position instead. OPTIMIZED_NFA
+        // (the state-count fallback below) has the same latent bug, so it must be excluded too.
+        if (nfa.hasWordBoundaryAnchor()) {
+          return new MatchingStrategyResult(
+              MatchingStrategy.PIKEVM_CAPTURE,
+              null,
+              null,
+              false,
+              requiredLiterals,
+              null,
+              needsPosixSemantics);
+        }
         int stateCount = dfa.getStateCount();
         if (stateCount < DFA_UNROLLED_STATE_LIMIT) {
           return new MatchingStrategyResult(
@@ -1498,6 +1531,15 @@ public class PatternAnalyzer {
 
       if (FallbackPatternDetector.hasCapturingGroupInQuantifiedSection(ast)) {
         // DFA cannot track per-iteration spans; PIKEVM_CAPTURE handles capturing groups correctly.
+        return new MatchingStrategyResult(
+            MatchingStrategy.PIKEVM_CAPTURE, null, null, false, requiredLiterals);
+      }
+      // \b/\B: DFA subset construction silently drops per-position boundary context
+      // (SubsetConstructor.isPositionAnchor excludes WORD_BOUNDARY/NON_WORD_BOUNDARY);
+      // PIKEVM_CAPTURE evaluates checkAnchor correctly at each position instead. OPTIMIZED_NFA/
+      // BITPARALLEL_GLUSHKOV/DFA_TABLE (the state-count fallbacks below) share the same latent
+      // bug, so this must precede the whole state-count branch, not just DFA_UNROLLED/DFA_SWITCH.
+      if (nfa.hasWordBoundaryAnchor()) {
         return new MatchingStrategyResult(
             MatchingStrategy.PIKEVM_CAPTURE, null, null, false, requiredLiterals);
       }

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternAnalyzer.java
@@ -6785,10 +6785,24 @@ public class PatternAnalyzer {
     public final int minLength; // Minimum length (with optional parts excluded)
     public final int maxLength; // Maximum length (with optional parts included)
     public final int groupCount; // Number of capturing groups
+    // Non-null if the sequence is preceded/followed by \b or \B (WORD_BOUNDARY /
+    // NON_WORD_BOUNDARY only); null otherwise.
+    public final AnchorNode.Type leadingBoundary;
+    public final AnchorNode.Type trailingBoundary;
 
     public FixedSequenceInfo(List<SequenceElement> elements, int groupCount) {
+      this(elements, groupCount, null, null);
+    }
+
+    public FixedSequenceInfo(
+        List<SequenceElement> elements,
+        int groupCount,
+        AnchorNode.Type leadingBoundary,
+        AnchorNode.Type trailingBoundary) {
       this.elements = elements;
       this.groupCount = groupCount;
+      this.leadingBoundary = leadingBoundary;
+      this.trailingBoundary = trailingBoundary;
       int min = 0;
       int max = 0;
       for (SequenceElement elem : elements) {
@@ -6807,6 +6821,8 @@ public class PatternAnalyzer {
       hash = 31 * hash + minLength;
       hash = 31 * hash + maxLength;
       hash = 31 * hash + groupCount;
+      hash = 31 * hash + (leadingBoundary == null ? 0 : leadingBoundary.hashCode());
+      hash = 31 * hash + (trailingBoundary == null ? 0 : trailingBoundary.hashCode());
       return hash;
     }
   }
@@ -7393,10 +7409,35 @@ public class PatternAnalyzer {
     }
 
     ConcatNode concat = (ConcatNode) ast;
+    List<RegexNode> children = concat.children;
 
-    // Analyze each child element, using flattenElement to handle multi-char literal groups
-    // like (foo)(bar) which analyzeElement alone cannot decompose.
-    for (RegexNode child : concat.children) {
+    // Strip a single leading and/or trailing \b / \B anchor (bare word-boundary literal, e.g.
+    // \bfoo, foo\b, \bfoo\b) - these are otherwise rejected outright below since analyzeElement
+    // has no AnchorNode case. The stripped anchor type(s) are recorded and checked at match time
+    // by the bytecode generator instead.
+    int startIdx = 0;
+    int endIdx = children.size();
+    AnchorNode.Type leadingBoundary = null;
+    AnchorNode.Type trailingBoundary = null;
+    if (startIdx < endIdx && children.get(startIdx) instanceof AnchorNode) {
+      AnchorNode.Type type = ((AnchorNode) children.get(startIdx)).type;
+      if (type == AnchorNode.Type.WORD_BOUNDARY || type == AnchorNode.Type.NON_WORD_BOUNDARY) {
+        leadingBoundary = type;
+        startIdx++;
+      }
+    }
+    if (endIdx > startIdx && children.get(endIdx - 1) instanceof AnchorNode) {
+      AnchorNode.Type type = ((AnchorNode) children.get(endIdx - 1)).type;
+      if (type == AnchorNode.Type.WORD_BOUNDARY || type == AnchorNode.Type.NON_WORD_BOUNDARY) {
+        trailingBoundary = type;
+        endIdx--;
+      }
+    }
+
+    // Analyze each remaining child element, using flattenElement to handle multi-char literal
+    // groups like (foo)(bar) which analyzeElement alone cannot decompose.
+    for (int idx = startIdx; idx < endIdx; idx++) {
+      RegexNode child = children.get(idx);
       int prevSize = elements.size();
       if (!flattenElement(child, -1, groupCounter, elements)) {
         return null; // Contains unsupported element
@@ -7415,7 +7456,8 @@ public class PatternAnalyzer {
     }
 
     // Check if it's actually fixed-length or has reasonable bounds
-    FixedSequenceInfo info = new FixedSequenceInfo(elements, groupCounter[0]);
+    FixedSequenceInfo info =
+        new FixedSequenceInfo(elements, groupCounter[0], leadingBoundary, trailingBoundary);
 
     // Only optimize if length is reasonable
     if (info.maxLength > 100) {

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/ast/AnchorNode.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/ast/AnchorNode.java
@@ -22,6 +22,7 @@ public final class AnchorNode implements RegexNode {
     START, // ^ (affected by multiline mode)
     END, // $ (affected by multiline mode)
     WORD_BOUNDARY, // \b
+    NON_WORD_BOUNDARY, // \B
     STRING_START, // \A (start of string, not affected by multiline)
     STRING_END, // \Z (end of string or before final newline)
     STRING_END_ABSOLUTE, // \z (absolute end of string)

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/automaton/NFA.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/automaton/NFA.java
@@ -150,6 +150,21 @@ public final class NFA {
   }
 
   /**
+   * Check if this NFA contains a word-boundary anchor ({@code \b} or {@code \B}).
+   *
+   * @return true if any state has WORD_BOUNDARY or NON_WORD_BOUNDARY anchor
+   */
+  public boolean hasWordBoundaryAnchor() {
+    for (NFAState state : states) {
+      if (state.anchor == AnchorType.WORD_BOUNDARY
+          || state.anchor == AnchorType.NON_WORD_BOUNDARY) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Check if a start anchor is REQUIRED to match this pattern. Unlike hasStartAnchor(), this
    * returns true only if ALL paths to character transitions go through a START or STRING_START
    * anchor.
@@ -461,6 +476,7 @@ public final class NFA {
     START_MULTILINE, // ^ (multiline mode - matches at start or after \n)
     END_MULTILINE, // $ (multiline mode - matches at end or before \n)
     WORD_BOUNDARY, // \b
+    NON_WORD_BOUNDARY, // \B
     STRING_START, // \A (start of string, not affected by multiline)
     STRING_END, // \Z (end of string or before final newline)
     STRING_END_ABSOLUTE, // \z (absolute end of string)

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/automaton/ThompsonBuilder.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/automaton/ThompsonBuilder.java
@@ -418,6 +418,9 @@ public class ThompsonBuilder implements RegexVisitor<ThompsonBuilder.NFAFragment
       case WORD_BOUNDARY:
         state.anchor = NFA.AnchorType.WORD_BOUNDARY;
         break;
+      case NON_WORD_BOUNDARY:
+        state.anchor = NFA.AnchorType.NON_WORD_BOUNDARY;
+        break;
       case STRING_START:
         state.anchor = NFA.AnchorType.STRING_START;
         break;

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/FixedSequenceBytecodeGenerator.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/codegen/FixedSequenceBytecodeGenerator.java
@@ -23,6 +23,7 @@ import com.datadoghq.reggie.codegen.analysis.PatternAnalyzer.LiteralElement;
 import com.datadoghq.reggie.codegen.analysis.PatternAnalyzer.OptionalLiteralElement;
 import com.datadoghq.reggie.codegen.analysis.PatternAnalyzer.RepetitionElement;
 import com.datadoghq.reggie.codegen.analysis.PatternAnalyzer.SequenceElement;
+import com.datadoghq.reggie.codegen.ast.AnchorNode;
 import com.datadoghq.reggie.codegen.automaton.CharSet;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Label;
@@ -127,8 +128,20 @@ public class FixedSequenceBytecodeGenerator {
       mv.visitLabel(maxOk);
     }
 
-    // Generate checks for each element
     Label returnFalse = new Label();
+
+    // Leading/trailing \b or \B check (info.totalLength is always fixed when a boundary is
+    // present - boundary-bearing patterns never carry OptionalLiteralElements, see
+    // PatternAnalyzer.detectFixedSequence).
+    if (info.leadingBoundary != null) {
+      generateBoundaryCheckConstPos(mv, 1, 0, info.leadingBoundary, returnFalse, className);
+    }
+    if (info.trailingBoundary != null) {
+      generateBoundaryCheckConstPos(
+          mv, 1, info.totalLength, info.trailingBoundary, returnFalse, className);
+    }
+
+    // Generate checks for each element
     int pos = 0;
     for (SequenceElement elem : info.elements) {
       pos = generateElementCheck(mv, elem, pos, 1, returnFalse, allocator);
@@ -149,6 +162,174 @@ public class FixedSequenceBytecodeGenerator {
 
     mv.visitMaxs(0, 0);
     mv.visitEnd();
+  }
+
+  /** True if this pattern has a leading/trailing \b or \B requiring the isBoundary helper. */
+  public boolean needsBoundaryHelpers() {
+    return info.leadingBoundary != null || info.trailingBoundary != null;
+  }
+
+  /**
+   * Generates the {@code isWordChar}/{@code isBoundary} private static helpers used by {@code
+   * matches()}/{@code findFrom()} to check a leading/trailing \b or \B. Mirrors {@code
+   * BitStateBytecodeGenerator}'s implementation exactly (this codebase duplicates such helpers per
+   * generator class rather than sharing them). Call at most once per generated class, only when
+   * {@link #needsBoundaryHelpers()} is true.
+   */
+  public void generateBoundaryHelperMethods(ClassWriter cw, String className) {
+    generateIsWordCharMethod(cw);
+    generateIsBoundaryMethod(cw, className);
+  }
+
+  /** {@code private static boolean isWordChar(char c)} - the fixed PCRE/Java \b word-char set. */
+  private void generateIsWordCharMethod(ClassWriter cw) {
+    MethodVisitor mv = cw.visitMethod(ACC_PRIVATE | ACC_STATIC, "isWordChar", "(C)Z", null, null);
+    mv.visitCode();
+    int cVar = 0;
+    Label checkUpper = new Label();
+    Label checkDigit = new Label();
+    Label checkUnderscore = new Label();
+    Label yes = new Label();
+    Label no = new Label();
+
+    mv.visitVarInsn(ILOAD, cVar);
+    pushInt(mv, 'a');
+    mv.visitJumpInsn(IF_ICMPLT, checkUpper);
+    mv.visitVarInsn(ILOAD, cVar);
+    pushInt(mv, 'z');
+    mv.visitJumpInsn(IF_ICMPLE, yes);
+
+    mv.visitLabel(checkUpper);
+    mv.visitVarInsn(ILOAD, cVar);
+    pushInt(mv, 'A');
+    mv.visitJumpInsn(IF_ICMPLT, checkDigit);
+    mv.visitVarInsn(ILOAD, cVar);
+    pushInt(mv, 'Z');
+    mv.visitJumpInsn(IF_ICMPLE, yes);
+
+    mv.visitLabel(checkDigit);
+    mv.visitVarInsn(ILOAD, cVar);
+    pushInt(mv, '0');
+    mv.visitJumpInsn(IF_ICMPLT, checkUnderscore);
+    mv.visitVarInsn(ILOAD, cVar);
+    pushInt(mv, '9');
+    mv.visitJumpInsn(IF_ICMPLE, yes);
+
+    mv.visitLabel(checkUnderscore);
+    mv.visitVarInsn(ILOAD, cVar);
+    pushInt(mv, '_');
+    mv.visitJumpInsn(IF_ICMPEQ, yes);
+    mv.visitJumpInsn(GOTO, no);
+
+    mv.visitLabel(yes);
+    mv.visitInsn(ICONST_1);
+    mv.visitInsn(IRETURN);
+    mv.visitLabel(no);
+    mv.visitInsn(ICONST_0);
+    mv.visitInsn(IRETURN);
+
+    mv.visitMaxs(0, 0);
+    mv.visitEnd();
+  }
+
+  /**
+   * {@code private static boolean isBoundary(String input, int p, int n)} - true iff exactly one of
+   * {@code (p>0 && isWordChar(input.charAt(p-1)))} / {@code (p<n && isWordChar(input.charAt(p)))}
+   * holds.
+   */
+  private void generateIsBoundaryMethod(ClassWriter cw, String className) {
+    MethodVisitor mv =
+        cw.visitMethod(
+            ACC_PRIVATE | ACC_STATIC, "isBoundary", "(Ljava/lang/String;II)Z", null, null);
+    mv.visitCode();
+    int inputVar = 0;
+    int pVar = 1;
+    int nVar = 2;
+    LocalVarAllocator allocator = new LocalVarAllocator(3);
+    int beforeVar = allocator.allocate();
+    int afterVar = allocator.allocate();
+
+    // before = p > 0 && isWordChar(input.charAt(p - 1));
+    mv.visitInsn(ICONST_0);
+    mv.visitVarInsn(ISTORE, beforeVar);
+    Label skipBefore = new Label();
+    mv.visitVarInsn(ILOAD, pVar);
+    mv.visitJumpInsn(IFLE, skipBefore);
+    mv.visitVarInsn(ALOAD, inputVar);
+    mv.visitVarInsn(ILOAD, pVar);
+    pushInt(mv, 1);
+    mv.visitInsn(ISUB);
+    mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "charAt", "(I)C", false);
+    mv.visitMethodInsn(INVOKESTATIC, className.replace('.', '/'), "isWordChar", "(C)Z", false);
+    mv.visitVarInsn(ISTORE, beforeVar);
+    mv.visitLabel(skipBefore);
+
+    // after = p < n && isWordChar(input.charAt(p));
+    mv.visitInsn(ICONST_0);
+    mv.visitVarInsn(ISTORE, afterVar);
+    Label skipAfter = new Label();
+    mv.visitVarInsn(ILOAD, pVar);
+    mv.visitVarInsn(ILOAD, nVar);
+    mv.visitJumpInsn(IF_ICMPGE, skipAfter);
+    mv.visitVarInsn(ALOAD, inputVar);
+    mv.visitVarInsn(ILOAD, pVar);
+    mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "charAt", "(I)C", false);
+    mv.visitMethodInsn(INVOKESTATIC, className.replace('.', '/'), "isWordChar", "(C)Z", false);
+    mv.visitVarInsn(ISTORE, afterVar);
+    mv.visitLabel(skipAfter);
+
+    // return before != after;
+    Label returnTrue = new Label();
+    mv.visitVarInsn(ILOAD, beforeVar);
+    mv.visitVarInsn(ILOAD, afterVar);
+    mv.visitJumpInsn(IF_ICMPNE, returnTrue);
+    mv.visitInsn(ICONST_0);
+    mv.visitInsn(IRETURN);
+    mv.visitLabel(returnTrue);
+    mv.visitInsn(ICONST_1);
+    mv.visitInsn(IRETURN);
+
+    mv.visitMaxs(0, 0);
+    mv.visitEnd();
+  }
+
+  /** isBoundary(input, posConst, input.length()); jumps to failLabel if the anchor doesn't hold. */
+  private void generateBoundaryCheckConstPos(
+      MethodVisitor mv,
+      int inputVar,
+      int posConst,
+      AnchorNode.Type anchorType,
+      Label failLabel,
+      String className) {
+    mv.visitVarInsn(ALOAD, inputVar);
+    pushInt(mv, posConst);
+    mv.visitVarInsn(ALOAD, inputVar);
+    mv.visitMethodInsn(INVOKEVIRTUAL, "java/lang/String", "length", "()I", false);
+    mv.visitMethodInsn(
+        INVOKESTATIC, className.replace('.', '/'), "isBoundary", "(Ljava/lang/String;II)Z", false);
+    mv.visitJumpInsn(anchorType == AnchorNode.Type.WORD_BOUNDARY ? IFEQ : IFNE, failLabel);
+  }
+
+  /** isBoundary(input, posVar + offset, lenVar); jumps to failLabel if the anchor doesn't hold. */
+  private void generateBoundaryCheckVarPos(
+      MethodVisitor mv,
+      int inputVar,
+      int posVar,
+      int offset,
+      int lenVar,
+      AnchorNode.Type anchorType,
+      Label failLabel,
+      String className) {
+    mv.visitVarInsn(ALOAD, inputVar);
+    mv.visitVarInsn(ILOAD, posVar);
+    if (offset != 0) {
+      pushInt(mv, offset);
+      mv.visitInsn(IADD);
+    }
+    mv.visitVarInsn(ILOAD, lenVar);
+    mv.visitMethodInsn(
+        INVOKESTATIC, className.replace('.', '/'), "isBoundary", "(Ljava/lang/String;II)Z", false);
+    mv.visitJumpInsn(anchorType == AnchorNode.Type.WORD_BOUNDARY ? IFEQ : IFNE, failLabel);
   }
 
   /**
@@ -449,6 +630,17 @@ public class FixedSequenceBytecodeGenerator {
 
     // Generate inline matching checks for all elements at offset i
     Label tryNext = new Label();
+
+    // Leading/trailing \b or \B check at this candidate position (info.totalLength is always
+    // fixed when a boundary is present, see PatternAnalyzer.detectFixedSequence).
+    if (info.leadingBoundary != null) {
+      generateBoundaryCheckVarPos(mv, 1, iVar, 0, lenVar, info.leadingBoundary, tryNext, className);
+    }
+    if (info.trailingBoundary != null) {
+      generateBoundaryCheckVarPos(
+          mv, 1, iVar, info.totalLength, lenVar, info.trailingBoundary, tryNext, className);
+    }
+
     int pos = 0;
     for (SequenceElement elem : info.elements) {
       if (elem instanceof LiteralElement) {

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
@@ -572,6 +572,8 @@ public class RegexParser {
         return new CharClassNode(CharSet.WHITESPACE, true);
       case 'b':
         return new AnchorNode(AnchorNode.Type.WORD_BOUNDARY);
+      case 'B':
+        return new AnchorNode(AnchorNode.Type.NON_WORD_BOUNDARY);
       case 'A':
         return new AnchorNode(AnchorNode.Type.STRING_START);
       case 'Z':

--- a/reggie-integration-tests/build.gradle
+++ b/reggie-integration-tests/build.gradle
@@ -19,6 +19,11 @@ dependencies {
     // JSON parsing for test data
     implementation 'com.google.code.gson:gson:2.14.0'
 
+    // RegexParser/ThompsonBuilder/NFA/PatternAnalyzer for LaurikariAlgorithmicFuzzTest's
+    // direct-construction driver. reggie-runtime declares this as 'implementation' (not 'api'),
+    // so it is not exposed transitively and must be declared explicitly here.
+    testImplementation project(':reggie-codegen')
+
     // JUnit for integration testing
     testImplementation 'org.junit.jupiter:junit-jupiter:6.0.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/reggie-integration-tests/src/main/java/com/datadoghq/reggie/integration/fuzz/RegexFuzzOracle.java
+++ b/reggie-integration-tests/src/main/java/com/datadoghq/reggie/integration/fuzz/RegexFuzzOracle.java
@@ -99,6 +99,27 @@ public final class RegexFuzzOracle {
       return Result.skipped(
           "Reggie rejected pattern: " + t.getClass().getSimpleName() + ": " + t.getMessage());
     }
+    return compareAgainstJdk(jdk, pattern, input, reggie);
+  }
+
+  /**
+   * Task 1.6a (doc/2026-07-10-tdfa-capture-engine-impl-plan.md §3): same JDK comparison as {@link
+   * #check}, but against a caller-supplied {@code candidate} matcher instead of one obtained via
+   * {@link Reggie#compile}. Lets callers exercise a matcher built outside the normal compile
+   * pipeline (e.g. a hand-constructed {@code LaurikariDfaMatcher}) against the JDK oracle.
+   */
+  public Result checkAgainst(String pattern, String input, ReggieMatcher candidate) {
+    Pattern jdk;
+    try {
+      jdk = Pattern.compile(pattern);
+    } catch (PatternSyntaxException e) {
+      return Result.skipped("JDK rejected pattern: " + e.getDescription());
+    }
+    return compareAgainstJdk(jdk, pattern, input, candidate);
+  }
+
+  private Result compareAgainstJdk(
+      Pattern jdk, String pattern, String input, ReggieMatcher reggie) {
     List<Finding> findings = new ArrayList<>();
 
     // matches() — anchored full-input match

--- a/reggie-integration-tests/src/test/java/com/datadoghq/reggie/integration/LaurikariAlgorithmicFuzzTest.java
+++ b/reggie-integration-tests/src/test/java/com/datadoghq/reggie/integration/LaurikariAlgorithmicFuzzTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.integration;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datadoghq.reggie.codegen.analysis.PatternAnalyzer;
+import com.datadoghq.reggie.codegen.ast.RegexNode;
+import com.datadoghq.reggie.codegen.automaton.NFA;
+import com.datadoghq.reggie.codegen.automaton.ThompsonBuilder;
+import com.datadoghq.reggie.codegen.parsing.RegexParser;
+import com.datadoghq.reggie.integration.fuzz.RandomInputGenerator;
+import com.datadoghq.reggie.integration.fuzz.RandomRegexGenerator;
+import com.datadoghq.reggie.integration.fuzz.RegexFuzzOracle;
+import com.datadoghq.reggie.integration.fuzz.RegexFuzzOracle.Finding;
+import com.datadoghq.reggie.integration.fuzz.RegexFuzzOracle.Result;
+import com.datadoghq.reggie.runtime.LaurikariDfaSupport;
+import com.datadoghq.reggie.runtime.ReggieMatcher;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Task 1.6b (doc/2026-07-10-tdfa-capture-engine-impl-plan.md §3): JDK-oracle fuzz coverage for
+ * {@code LaurikariDfaMatcher}, exercised directly via {@link LaurikariDfaSupport#tryCreate}
+ * (bypassing the compile pipeline — Phase 2's routing wire-up hasn't landed yet).
+ *
+ * <p>Reuses {@link RandomRegexGenerator}/{@link RandomInputGenerator} from the existing algorithmic
+ * fuzz harness but with an independent seed, so this sweep covers a disjoint area of the pattern
+ * space from {@link AlgorithmicFuzzTest}. Patterns that {@code LaurikariEligibility.isEligible}
+ * rejects are skipped (not findings) — this test is only about whether the new engine agrees with
+ * the JDK on the patterns it does accept.
+ *
+ * <p>Unlike {@link AlgorithmicFuzzTest}'s {@code KNOWN_FINDINGS_BUDGET} (pre-existing, tracked
+ * divergences in the shipped fallback routing), this gate is zero-tolerance: {@code
+ * LaurikariDfaMatcher} has no production callers yet, so any divergence here is a genuine new bug,
+ * not a known one.
+ */
+public class LaurikariAlgorithmicFuzzTest {
+
+  private static final long BASE_SEED = 0xCAFEF00D_ABCDEFL;
+
+  @Test
+  @Timeout(value = 300, unit = TimeUnit.SECONDS)
+  public void smokeFuzz_eligiblePatternsAgreeWithJdk() {
+    int patternCount = intProp("reggie.fuzz.laurikari.size", 2000);
+    int inputsPerPattern = intProp("reggie.fuzz.laurikari.inputsPerPattern", 8);
+    int patternDepth = intProp("reggie.fuzz.laurikari.patternDepth", 3);
+    int inputMaxLength = intProp("reggie.fuzz.laurikari.inputMaxLength", 12);
+
+    Random patternRng = new Random(BASE_SEED);
+    Random inputRng = new Random(BASE_SEED ^ 0x9E3779B97F4A7C15L);
+    RandomRegexGenerator regexGen = new RandomRegexGenerator(patternRng, patternDepth);
+    RandomInputGenerator inputGen = new RandomInputGenerator(inputRng, inputMaxLength);
+    RegexFuzzOracle oracle = new RegexFuzzOracle();
+
+    int patternsTried = 0;
+    int patternsEligible = 0;
+    int inputsChecked = 0;
+    List<Finding> findings = new ArrayList<>();
+
+    for (int p = 0; p < patternCount; p++) {
+      String pattern = regexGen.generate();
+      patternsTried++;
+
+      ReggieMatcher candidate = tryBuildLaurikari(pattern);
+      if (candidate == null) continue;
+      patternsEligible++;
+
+      for (int i = 0; i < inputsPerPattern; i++) {
+        String input = inputGen.generate();
+        Result result = oracle.checkAgainst(pattern, input, candidate);
+        if (result.skipped) continue;
+        inputsChecked++;
+        findings.addAll(result.findings);
+      }
+    }
+
+    System.out.println(
+        String.format(
+            "[laurikari-fuzz] patterns=%d eligible=%d inputs-checked=%d findings=%d",
+            patternsTried, patternsEligible, inputsChecked, findings.size()));
+    for (Finding f : findings) {
+      System.out.println("[laurikari-fuzz-finding] " + f);
+    }
+
+    assertTrue(
+        patternsEligible > 0,
+        "no generated pattern was Laurikari-eligible; the eligibility gate or generator may have"
+            + " drifted");
+    assertTrue(
+        findings.isEmpty(),
+        "LaurikariDfaMatcher diverged from JDK on "
+            + findings.size()
+            + " (pattern, input) pairs — see printed findings above; this is a new engine with no"
+            + " production callers yet, so any divergence is a real bug, not a known one.");
+  }
+
+  /**
+   * Parses {@code pattern}, builds its NFA, and asks {@link LaurikariDfaSupport#tryCreate} for a
+   * matcher — mirroring {@code LaurikariDfaMatcherTest}'s direct-construction pattern. Returns
+   * {@code null} if the JDK rejects the pattern, Reggie's parser/NFA builder rejects it, or {@code
+   * LaurikariEligibility} rejects it (none of these are findings — only comparable pairs are).
+   */
+  private static ReggieMatcher tryBuildLaurikari(String pattern) {
+    int groupCount;
+    try {
+      groupCount = Pattern.compile(pattern).matcher("").groupCount();
+    } catch (PatternSyntaxException e) {
+      return null;
+    }
+    RegexNode ast;
+    NFA nfa;
+    try {
+      ast = new RegexParser().parse(pattern);
+      // lazyAware=true: non-greedy quantifiers (e.g. `.+?`) need the "prefer accept, then loop"
+      // epsilon-priority ordering to produce shortest-match semantics -- see ThompsonBuilder's
+      // lazyAware javadoc and PatternAnalyzer's identical lazyNfa flag for the PIKEVM_CAPTURE
+      // route. Safe for every other pattern: lazyAware only changes construction for quantifiers
+      // with !greedy, so greedy/possessive shapes build identically either way.
+      nfa = new ThompsonBuilder(true).build(ast, groupCount);
+    } catch (Throwable t) {
+      return null;
+    }
+    boolean usePosixLastMatch;
+    try {
+      usePosixLastMatch = new PatternAnalyzer(ast, nfa).analyzeAndRecommend().usePosixLastMatch;
+    } catch (Throwable t) {
+      // PatternAnalyzer has its own pre-existing gaps (e.g. some anchor combinations
+      // LinearPatternAnalyzer doesn't handle) unrelated to Laurikari; skip rather than fail this
+      // sweep on an unrelated bug.
+      return null;
+    }
+    return LaurikariDfaSupport.tryCreate(nfa, pattern, groupCount, usePosixLastMatch);
+  }
+
+  private static int intProp(String name, int dflt) {
+    String v = System.getProperty(name);
+    if (v == null || v.isEmpty()) return dflt;
+    try {
+      int parsed = Integer.parseInt(v);
+      return parsed > 0 ? parsed : dflt;
+    } catch (NumberFormatException e) {
+      return dflt;
+    }
+  }
+}

--- a/reggie-processor/src/main/java/com/datadoghq/reggie/processor/ReggieMatcherBytecodeGenerator.java
+++ b/reggie-processor/src/main/java/com/datadoghq/reggie/processor/ReggieMatcherBytecodeGenerator.java
@@ -362,6 +362,9 @@ public class ReggieMatcherBytecodeGenerator {
             (PatternAnalyzer.FixedSequenceInfo) result.patternInfo;
         FixedSequenceBytecodeGenerator fixedGen =
             new FixedSequenceBytecodeGenerator(fixedInfo, nfa.getGroupCount());
+        if (fixedGen.needsBoundaryHelpers()) {
+          fixedGen.generateBoundaryHelperMethods(cw, getJavaClassName());
+        }
         fixedGen.generateMatchesMethod(cw, getJavaClassName());
         fixedGen.generateFindMethod(cw, getJavaClassName());
         fixedGen.generateFindFromMethod(cw, getJavaClassName());

--- a/reggie-processor/src/test/java/com/datadoghq/reggie/processor/ReggieMatcherBytecodeGeneratorTest.java
+++ b/reggie-processor/src/test/java/com/datadoghq/reggie/processor/ReggieMatcherBytecodeGeneratorTest.java
@@ -371,6 +371,40 @@ class ReggieMatcherBytecodeGeneratorTest {
   }
 
   @Test
+  void testFixedSequenceWithWordBoundaryStrategy() throws Exception {
+    // Bare \b/\B + literal patterns route to SPECIALIZED_FIXED_SEQUENCE (see
+    // WordBoundaryFixedSequenceTest in reggie-runtime for the runtime-compiler-path coverage of
+    // this same strategy). This test exercises the annotation-processor path
+    // (ReggieMatcherBytecodeGenerator), which generates the leading/trailing isBoundary check via
+    // its own FixedSequenceBytecodeGenerator instance -- a call to matches()/find() here fails with
+    // a verification/NoSuchMethodError if the generated class references isBoundary without the
+    // helper methods actually being emitted.
+    Object leading = compile("\\bfoo", "LeadingBoundaryMatcher");
+    Method leadingMatches = leading.getClass().getMethod("matches", String.class);
+    Method leadingFind = leading.getClass().getMethod("find", String.class);
+    assertTrue((Boolean) leadingMatches.invoke(leading, "foo"));
+    assertTrue((Boolean) leadingFind.invoke(leading, "xx foo"));
+    assertFalse((Boolean) leadingFind.invoke(leading, "xfoo"));
+
+    Object trailing = compile("foo\\b", "TrailingBoundaryMatcher");
+    Method trailingMatches = trailing.getClass().getMethod("matches", String.class);
+    Method trailingFind = trailing.getClass().getMethod("find", String.class);
+    assertTrue((Boolean) trailingMatches.invoke(trailing, "foo"));
+    assertTrue((Boolean) trailingFind.invoke(trailing, "foo bar"));
+    assertFalse((Boolean) trailingFind.invoke(trailing, "foox"));
+
+    Object both = compile("\\bfoo\\b", "BothBoundaryMatcher");
+    Method bothMatches = both.getClass().getMethod("matches", String.class);
+    assertTrue((Boolean) bothMatches.invoke(both, "foo"));
+    assertFalse((Boolean) bothMatches.invoke(both, "foox"));
+
+    Object nonWord = compile("\\Bfoo\\B", "NonWordBoundaryMatcher");
+    Method nonWordFind = nonWord.getClass().getMethod("find", String.class);
+    assertTrue((Boolean) nonWordFind.invoke(nonWord, "xfoox"));
+    assertFalse((Boolean) nonWordFind.invoke(nonWord, "foo"));
+  }
+
+  @Test
   void testBitStateBytecodeStrategy() throws Exception {
     // Prefix-guarded-scan shape recognized by PatternAnalyzer#detectPrefixGuardedScan; exercises
     // the compile-time BITSTATE_BYTECODE dispatch case (com.datadoghq.reggie.codegen.codegen.

--- a/reggie-runtime/build.gradle
+++ b/reggie-runtime/build.gradle
@@ -66,7 +66,10 @@ java {
 
 tasks.named('test') {
     useJUnitPlatform()
-    jvmArgs('--add-opens', 'java.base/java.lang=ALL-UNNAMED')
+    // JDK's own java.util.regex engine recurses per repetition when matching large quantified
+    // groups (used as an oracle in some Laurikari tests); CI runners' default worker-thread stack
+    // is smaller than typical local JVMs and can StackOverflowError on those oracle calls alone.
+    jvmArgs('--add-opens', 'java.base/java.lang=ALL-UNNAMED', '-Xss8m')
     // Pass system properties for bytecode debugging
     systemProperty 'reggie.debug.trace', System.getProperty('reggie.debug.trace')
     // Pass the meta-test enforcement flag through to the test JVM (StrategyCorrectnessMetaTest).

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BackrefBacktrackMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BackrefBacktrackMatcher.java
@@ -269,6 +269,12 @@ public final class BackrefBacktrackMatcher extends ReggieMatcher {
           boolean afterWord = pos < regionEnd && Character.isLetterOrDigit(input.charAt(pos));
           return beforeWord != afterWord;
         }
+      case NON_WORD_BOUNDARY:
+        {
+          boolean beforeWord = pos > 0 && Character.isLetterOrDigit(input.charAt(pos - 1));
+          boolean afterWord = pos < regionEnd && Character.isLetterOrDigit(input.charAt(pos));
+          return beforeWord == afterWord;
+        }
       case RESET_MATCH:
         return true;
       default:

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BackrefBacktrackMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BackrefBacktrackMatcher.java
@@ -246,6 +246,14 @@ public final class BackrefBacktrackMatcher extends ReggieMatcher {
     return new MatchResultImpl(input, starts, ends, groupCount);
   }
 
+  /**
+   * ASCII word-char predicate used by {@code \b}/{@code \B} — mirrors {@link
+   * PikeVMMatcher#isWordChar}.
+   */
+  private static boolean isWordChar(char c) {
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_';
+  }
+
   /** Mirrors {@link PikeVMMatcher}'s anchor semantics. */
   private static boolean checkAnchor(
       NFA.AnchorType anchor, String input, int pos, int regionStart, int regionEnd) {
@@ -265,14 +273,14 @@ public final class BackrefBacktrackMatcher extends ReggieMatcher {
         return pos == regionEnd || (pos < regionEnd && input.charAt(pos) == '\n');
       case WORD_BOUNDARY:
         {
-          boolean beforeWord = pos > 0 && Character.isLetterOrDigit(input.charAt(pos - 1));
-          boolean afterWord = pos < regionEnd && Character.isLetterOrDigit(input.charAt(pos));
+          boolean beforeWord = pos > 0 && isWordChar(input.charAt(pos - 1));
+          boolean afterWord = pos < regionEnd && isWordChar(input.charAt(pos));
           return beforeWord != afterWord;
         }
       case NON_WORD_BOUNDARY:
         {
-          boolean beforeWord = pos > 0 && Character.isLetterOrDigit(input.charAt(pos - 1));
-          boolean afterWord = pos < regionEnd && Character.isLetterOrDigit(input.charAt(pos));
+          boolean beforeWord = pos > 0 && isWordChar(input.charAt(pos - 1));
+          boolean afterWord = pos < regionEnd && isWordChar(input.charAt(pos));
           return beforeWord == afterWord;
         }
       case RESET_MATCH:

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BitStateMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BitStateMatcher.java
@@ -43,9 +43,13 @@ import java.util.List;
  * anti-pattern of restarting a fresh search at every candidate start position.
  *
  * <p>When the per-search budget ({@code stateCount × (spanLength + 1)}) exceeds {@link
- * #BUDGET_CELLS}, the whole call is delegated to a lazily-constructed {@link PikeVMMatcher} over
- * the same NFA, and {@link #fallbackCount()} is incremented — the budget overflow is observable,
- * never silently truncated.
+ * #BUDGET_CELLS}, the whole call is delegated either to a caller-supplied {@code laurikari} matcher
+ * (Phase 2 Task 2.1, Option A: a {@link LaurikariDfaMatcher} over the same NFA, tried when {@link
+ * LaurikariEligibility} accepted the pattern — see {@link #laurikariCount()}) or, if none was
+ * supplied or eligible, to a lazily-constructed {@link PikeVMMatcher} over the same NFA, with
+ * {@link #fallbackCount()} incremented — the budget overflow is observable, never silently
+ * truncated. {@code matchesBounded}/{@code matchBounded} always go straight to the {@code
+ * PikeVMMatcher} fallback: {@link LaurikariDfaMatcher} has no bounded-region API.
  *
  * <p>v1 scope (see design doc §10, "P1"): no atomic groups, possessive quantifiers, backreferences,
  * or lookaround — patterns using those constructs must not be routed to this matcher (an
@@ -113,6 +117,12 @@ final class BitStateMatcher extends ReggieMatcher {
   private PikeVMMatcher fallback;
   private long fallbackCount;
 
+  // Phase 2 Task 2.1 (Option A): pre-built by the caller (RuntimeCompiler) when
+  // LaurikariEligibility accepted this pattern, null otherwise. Tried before falling all the way
+  // through to PikeVMMatcher on BUDGET_CELLS overflow.
+  private final ReggieMatcher laurikari;
+  private long laurikariCount;
+
   // Single-char SIMD fast-reject (mirrors PikeVMMatcher.singleFirstCharAscii): when exactly one
   // ASCII char can begin a match, String.indexOf() gives a SIMD-accelerated scan that rejects
   // no-match inputs without running the DFS at every position. -1 when zero or multiple chars
@@ -133,7 +143,12 @@ final class BitStateMatcher extends ReggieMatcher {
   private final int[] localizeScratch = new int[2];
 
   BitStateMatcher(NFA nfa, String pattern) {
+    this(nfa, pattern, null);
+  }
+
+  BitStateMatcher(NFA nfa, String pattern, ReggieMatcher laurikari) {
     super(pattern);
+    this.laurikari = laurikari;
     this.nfa = nfa;
     this.patternText = pattern;
     this.groupCount = nfa.getGroupCount();
@@ -232,6 +247,10 @@ final class BitStateMatcher extends ReggieMatcher {
   @Override
   public boolean matches(String input) {
     if (exceedsBudget(input.length())) {
+      if (laurikari != null) {
+        laurikariCount++;
+        return laurikari.matches(input);
+      }
       fallbackCount++;
       return fallback().matches(input);
     }
@@ -251,6 +270,10 @@ final class BitStateMatcher extends ReggieMatcher {
     int scanStart = localizeScratch[0];
     int spanEnd = localizeScratch[1];
     if (exceedsBudget(spanEnd - scanStart)) {
+      if (laurikari != null) {
+        laurikariCount++;
+        return laurikari.find(input);
+      }
       fallbackCount++;
       return fallback().findFrom(input, scanStart) >= 0;
     }
@@ -271,6 +294,10 @@ final class BitStateMatcher extends ReggieMatcher {
     int scanStart = localizeScratch[0];
     int spanEnd = localizeScratch[1];
     if (exceedsBudget(spanEnd - scanStart)) {
+      if (laurikari != null) {
+        laurikariCount++;
+        return laurikari.findFrom(input, start);
+      }
       fallbackCount++;
       return fallback().findFrom(input, scanStart);
     }
@@ -281,6 +308,10 @@ final class BitStateMatcher extends ReggieMatcher {
   @Override
   public MatchResult match(String input) {
     if (exceedsBudget(input.length())) {
+      if (laurikari != null) {
+        laurikariCount++;
+        return laurikari.match(input);
+      }
       fallbackCount++;
       return fallback().match(input);
     }
@@ -307,6 +338,10 @@ final class BitStateMatcher extends ReggieMatcher {
     int scanStart = localizeScratch[0];
     int spanEnd = localizeScratch[1];
     if (exceedsBudget(spanEnd - scanStart)) {
+      if (laurikari != null) {
+        laurikariCount++;
+        return laurikari.findMatchFrom(input, start);
+      }
       fallbackCount++;
       return fallback().findMatchFrom(input, scanStart);
     }
@@ -404,6 +439,15 @@ final class BitStateMatcher extends ReggieMatcher {
   /** Number of calls delegated to the {@link PikeVMMatcher} fallback (design §5, §8). */
   long fallbackCount() {
     return fallbackCount;
+  }
+
+  /**
+   * Number of calls delegated to the {@code laurikari} matcher supplied at construction (Phase 2
+   * Task 2.1/2.2: TDFA capture engine served this BUDGET_CELLS-overflow call instead of {@link
+   * PikeVMMatcher}).
+   */
+  long laurikariCount() {
+    return laurikariCount;
   }
 
   private boolean exceedsBudget(int spanLen) {

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BitStateMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/BitStateMatcher.java
@@ -467,6 +467,7 @@ final class BitStateMatcher extends ReggieMatcher {
   private PikeVMMatcher fallback() {
     if (fallback == null) {
       fallback = new PikeVMMatcher(nfa, patternText);
+      fallback.setNameToIndex(nameToIndex);
     }
     return fallback;
   }

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariCaptureNfaStep.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariCaptureNfaStep.java
@@ -101,6 +101,24 @@ final class LaurikariCaptureNfaStep implements LaurikariNfaStep {
 
   private final int[][] reinjectAfterNlRegs;
 
+  /**
+   * True if any NFA state carries one of the 5 position-dependent anchor types ({@code END}, {@code
+   * STRING_END}, {@code STRING_END_ABSOLUTE}, {@code END_MULTILINE}, {@code WORD_BOUNDARY}) that
+   * must be evaluated live against the real input/position via {@link PikeVMMatcher#checkAnchor} —
+   * see the TDFA Phase 2 end-anchor/{@code \b} extension design. {@code false} for every pattern
+   * this class handled before that extension, in which case every closure accessor below returns
+   * its constructor-precomputed field unchanged (byte-identical to pre-extension behavior).
+   */
+  final boolean hasNewAnchor;
+
+  /**
+   * Parallel to {@link #statesById}: {@code anchorBearingStates[id]} is true if that NFA state
+   * carries one of the 5 new anchor types. Exposed via {@link #anchorBearingStates()} so {@link
+   * LaurikariDFACache} can flag which of its interned DFA states must never have their outgoing
+   * transitions memoized (see that class's {@code anchorSensitive} field).
+   */
+  private final boolean[] anchorBearingStates;
+
   final int tagCount;
 
   LaurikariCaptureNfaStep(NFA nfa, int groupCount) {
@@ -109,16 +127,18 @@ final class LaurikariCaptureNfaStep implements LaurikariNfaStep {
     this.isAccept = isAccept(nfa, statesById.length);
     this.startStateId = nfa.getStartState().id;
     this.tagCount = LaurikariTagNumbering.tagCount(groupCount);
-    LaurikariStepResult initial = closureFromStart(false, false);
+    this.anchorBearingStates = anchorBearingStates(statesById);
+    this.hasNewAnchor = anyTrue(anchorBearingStates);
+    LaurikariStepResult initial = closureFromStart(false, false, "", 0, 0);
     this.initialStates = initial.states;
     this.initialRegs = initial.regs;
 
     boolean hasMultiline = hasMultilineAnchor(nfa);
-    LaurikariStepResult reinject = closureFromStart(true, true);
+    LaurikariStepResult reinject = closureFromStart(true, true, "", 0, 0);
     this.reinjectStates = reinject.states;
     this.reinjectRegs = reinject.regs;
     if (hasMultiline) {
-      LaurikariStepResult afterNl = closureFromStart(true, false);
+      LaurikariStepResult afterNl = closureFromStart(true, false, "", 0, 0);
       this.reinjectAfterNlStates = afterNl.states;
       this.reinjectAfterNlRegs = afterNl.regs;
     } else {
@@ -132,6 +152,38 @@ final class LaurikariCaptureNfaStep implements LaurikariNfaStep {
       if (s.anchor == NFA.AnchorType.START_MULTILINE) return true;
     }
     return false;
+  }
+
+  private static boolean isNewAnchorType(NFA.AnchorType a) {
+    return a == NFA.AnchorType.END
+        || a == NFA.AnchorType.STRING_END
+        || a == NFA.AnchorType.STRING_END_ABSOLUTE
+        || a == NFA.AnchorType.END_MULTILINE
+        || a == NFA.AnchorType.WORD_BOUNDARY;
+  }
+
+  private static boolean[] anchorBearingStates(NFA.NFAState[] statesById) {
+    boolean[] flags = new boolean[statesById.length];
+    for (int i = 0; i < statesById.length; i++) {
+      flags[i] = isNewAnchorType(statesById[i].anchor);
+    }
+    return flags;
+  }
+
+  private static boolean anyTrue(boolean[] flags) {
+    for (boolean f : flags) {
+      if (f) return true;
+    }
+    return false;
+  }
+
+  /**
+   * @return {@link #anchorBearingStates}, for {@link LaurikariDFACache} to test its own interned
+   *     subsets against — {@code null} when {@link #hasNewAnchor} is false (then every DFA state is
+   *     guaranteed non-anchor-sensitive, so the cache need not consult this array at all).
+   */
+  boolean[] anchorBearingStates() {
+    return hasNewAnchor ? anchorBearingStates : null;
   }
 
   private static boolean[] isAccept(NFA nfa, int stateCount) {
@@ -158,7 +210,11 @@ final class LaurikariCaptureNfaStep implements LaurikariNfaStep {
    *     particular fresh attempt is allowed to cross — see {@link #reinjectStates}'s javadoc.
    */
   private LaurikariStepResult closureFromStart(
-      boolean blockStartAnchor, boolean blockMultilineAnchor) {
+      boolean blockStartAnchor,
+      boolean blockMultilineAnchor,
+      String input,
+      int pos,
+      int regionEnd) {
     int[] allUnset = new int[tagCount];
     Arrays.fill(allUnset, -1);
     allUnset[0] = 0; // group 0 opens here, age 0
@@ -166,7 +222,16 @@ final class LaurikariCaptureNfaStep implements LaurikariNfaStep {
     List<Integer> outIds = new ArrayList<>();
     List<int[]> outRegs = new ArrayList<>();
     addClosure(
-        visited, outIds, outRegs, startStateId, allUnset, blockStartAnchor, blockMultilineAnchor);
+        visited,
+        outIds,
+        outRegs,
+        startStateId,
+        allUnset,
+        blockStartAnchor,
+        blockMultilineAnchor,
+        input,
+        pos,
+        regionEnd);
     // Unblocked (blockStartAnchor=false) is initialClosure(), seeding the anchored matches()/
     // match() path: never truncate, mirroring PikeVMMatcher.runMatches/runMatchResult, which keep
     // lower-priority threads alive after a mid-string accept since they may still be needed to
@@ -223,7 +288,10 @@ final class LaurikariCaptureNfaStep implements LaurikariNfaStep {
       int id,
       int[] regs,
       boolean blockStartAnchor,
-      boolean blockMultilineAnchor) {
+      boolean blockMultilineAnchor,
+      String input,
+      int pos,
+      int regionEnd) {
     if (visited[id]) return;
     visited[id] = true;
     int tag = tagOfState[id];
@@ -240,9 +308,20 @@ final class LaurikariCaptureNfaStep implements LaurikariNfaStep {
         return;
       }
       if (blockMultilineAnchor && a == NFA.AnchorType.START_MULTILINE) return;
+      if (isNewAnchorType(a) && !PikeVMMatcher.checkAnchor(a, input, pos, 0, regionEnd)) return;
     }
     for (NFA.NFAState e : statesById[id].getEpsilonTransitions()) {
-      addClosure(visited, outIds, outRegs, e.id, r, blockStartAnchor, blockMultilineAnchor);
+      addClosure(
+          visited,
+          outIds,
+          outRegs,
+          e.id,
+          r,
+          blockStartAnchor,
+          blockMultilineAnchor,
+          input,
+          pos,
+          regionEnd);
     }
   }
 
@@ -253,6 +332,18 @@ final class LaurikariCaptureNfaStep implements LaurikariNfaStep {
    */
   LaurikariStepResult initialClosure() {
     return new LaurikariStepResult(initialStates, initialRegs);
+  }
+
+  /**
+   * Live variant of {@link #initialClosure} for {@code hasNewAnchor} patterns: recomputes the
+   * closure against the real input/regionEnd (position 0) instead of returning the
+   * constructor-precomputed fields, which were built before any real input existed. Returns the
+   * precomputed fields unchanged when {@code !hasNewAnchor} (byte-identical to pre-extension
+   * behavior).
+   */
+  LaurikariStepResult initialClosure(String input, int regionEnd) {
+    if (!hasNewAnchor) return initialClosure();
+    return closureFromStart(false, false, input, 0, regionEnd);
   }
 
   /**
@@ -271,6 +362,18 @@ final class LaurikariCaptureNfaStep implements LaurikariNfaStep {
   }
 
   /**
+   * Live variant of {@link #truncatedInitialClosure} for {@code hasNewAnchor} patterns — see {@link
+   * #initialClosure(String, int)}.
+   */
+  LaurikariStepResult truncatedInitialClosure(String input, int regionEnd) {
+    if (!hasNewAnchor) return truncatedInitialClosure();
+    LaurikariStepResult initial = closureFromStart(false, false, input, 0, regionEnd);
+    List<Integer> ids = new ArrayList<>(initial.states.length);
+    for (int id : initial.states) ids.add(id);
+    return truncateAtFirstAccept(ids, new ArrayList<>(Arrays.asList(initial.regs)));
+  }
+
+  /**
    * @return the anchor-blocked closure {@link LaurikariDfaMatcher} seeds a {@code findFrom(input,
    *     start)} scan from when {@code start > 0} — {@link #initialClosure} is only valid when the
    *     scan truly begins at absolute position 0 ({@code ^}/{@code \A} satisfied); starting mid-
@@ -279,6 +382,15 @@ final class LaurikariCaptureNfaStep implements LaurikariNfaStep {
    */
   LaurikariStepResult reinjectClosure() {
     return new LaurikariStepResult(reinjectStates, reinjectRegs);
+  }
+
+  /**
+   * Live variant of {@link #reinjectClosure} for {@code hasNewAnchor} patterns — see {@link
+   * #initialClosure(String, int)}.
+   */
+  LaurikariStepResult reinjectClosure(String input, int pos, int regionEnd) {
+    if (!hasNewAnchor) return reinjectClosure();
+    return closureFromStart(true, true, input, pos, regionEnd);
   }
 
   /**
@@ -292,9 +404,27 @@ final class LaurikariCaptureNfaStep implements LaurikariNfaStep {
         : new LaurikariStepResult(reinjectAfterNlStates, reinjectAfterNlRegs);
   }
 
+  /**
+   * Live variant of {@link #reinjectAfterNlClosure} for {@code hasNewAnchor} patterns — see {@link
+   * #initialClosure(String, int)}. Note this is only meaningful when the pattern also has a
+   * multiline start anchor ({@code reinjectAfterNlStates != null} in the non-live case); when
+   * {@code hasNewAnchor} but the pattern has no multiline start anchor, this still returns {@code
+   * null} exactly like the no-arg variant.
+   */
+  LaurikariStepResult reinjectAfterNlClosure(String input, int pos, int regionEnd) {
+    if (!hasNewAnchor) return reinjectAfterNlClosure();
+    if (reinjectAfterNlStates == null) return null;
+    return closureFromStart(true, false, input, pos, regionEnd);
+  }
+
+  LaurikariStepResult apply(int[] curStates, int[][] curRegs, int c) {
+    return apply(curStates, curRegs, c, "", 0, 0, false);
+  }
+
   @Override
-  public LaurikariStepResult apply(int[] curStates, int[][] curRegs, int c) {
-    return apply(curStates, curRegs, c, false);
+  public LaurikariStepResult apply(
+      int[] curStates, int[][] curRegs, int c, String input, int pos, int regionEnd) {
+    return apply(curStates, curRegs, c, input, pos, regionEnd, false);
   }
 
   /**
@@ -304,10 +434,22 @@ final class LaurikariCaptureNfaStep implements LaurikariNfaStep {
    * correctly with leftmost-first priority and the age-based {@link #absolutePositions} formula.
    */
   LaurikariStepResult applyFind(int[] curStates, int[][] curRegs, int c) {
-    return apply(curStates, curRegs, c, true);
+    return apply(curStates, curRegs, c, "", 0, 0, true);
   }
 
-  private LaurikariStepResult apply(int[] curStates, int[][] curRegs, int c, boolean reinject) {
+  LaurikariStepResult applyFind(
+      int[] curStates, int[][] curRegs, int c, String input, int pos, int regionEnd) {
+    return apply(curStates, curRegs, c, input, pos, regionEnd, true);
+  }
+
+  private LaurikariStepResult apply(
+      int[] curStates,
+      int[][] curRegs,
+      int c,
+      String input,
+      int pos,
+      int regionEnd,
+      boolean reinject) {
     int stateCount = statesById.length;
     // Step 1: consuming transitions from every NFA state in the current subset, in the same
     // priority order PikeVMMatcher.addThread walks (curStates' array order, index 0 highest
@@ -324,7 +466,17 @@ final class LaurikariCaptureNfaStep implements LaurikariNfaStep {
     List<Integer> outIds = new ArrayList<>();
     List<int[]> outRegs = new ArrayList<>();
     for (int i = 0; i < seedIds.size(); i++) {
-      addClosure(visited, outIds, outRegs, seedIds.get(i), seedRegs.get(i), false, false);
+      addClosure(
+          visited,
+          outIds,
+          outRegs,
+          seedIds.get(i),
+          seedRegs.get(i),
+          false,
+          false,
+          input,
+          pos,
+          regionEnd);
     }
     if (reinject) {
       // Lowest priority: a fresh, already-closed, anchor-blocked start candidate appended straight
@@ -332,10 +484,21 @@ final class LaurikariCaptureNfaStep implements LaurikariNfaStep {
       // never displaces a higher-priority (more leftmost) candidate already present. Mirrors
       // PikeVMMatcher.findStepClosure's sortedUnion(tc, reinjectClosureIds) exactly; see the class
       // javadoc for why this must be un-transitioned rather than fed through collectConsumingSeeds.
-      int[] rStates =
-          (reinjectAfterNlStates != null && c == '\n') ? reinjectAfterNlStates : reinjectStates;
-      int[][] rRegs =
-          (reinjectAfterNlStates != null && c == '\n') ? reinjectAfterNlRegs : reinjectRegs;
+      int[] rStates;
+      int[][] rRegs;
+      if (hasNewAnchor) {
+        boolean afterNl = reinjectAfterNlStates != null && c == '\n';
+        LaurikariStepResult live =
+            afterNl
+                ? reinjectAfterNlClosure(input, pos, regionEnd)
+                : reinjectClosure(input, pos, regionEnd);
+        rStates = live.states;
+        rRegs = live.regs;
+      } else {
+        rStates =
+            (reinjectAfterNlStates != null && c == '\n') ? reinjectAfterNlStates : reinjectStates;
+        rRegs = (reinjectAfterNlStates != null && c == '\n') ? reinjectAfterNlRegs : reinjectRegs;
+      }
       for (int i = 0; i < rStates.length; i++) {
         int id = rStates[i];
         if (!visited[id]) {

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariCaptureNfaStep.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariCaptureNfaStep.java
@@ -58,31 +58,80 @@ import java.util.List;
  * {@code PikeVMMatcher}'s thread-list reinjection at the tail of {@code clist}/{@code nlist} (an
  * implicit lowest-priority {@code .*?} prefix). {@link #apply} and {@link #applyFind} share the
  * same closure machinery via a private {@code apply(..., boolean reinject)}: when {@code reinject}
- * is true, the epsilon-closure of the start state (tag 0 = age 0, computed once in the constructor
- * and cached as {@link #initialStates}/{@link #initialRegs}) is scanned for {@code c}-consuming
- * transitions too, appended AFTER every existing candidate's seeds — i.e. at the lowest priority —
- * so an already-visited target from an older (more leftmost) start is left untouched by {@code
- * visited}'s first-visit-wins rule. The existing {@code totalConsumed - age} formula in {@link
- * #absolutePositions} needs no special-casing for reinjected candidates: age is still "characters
- * consumed since tag 0 was set," regardless of when within the scan that set happened.
+ * is true, a fresh <em>un-consumed</em>, already-closed start candidate (tag 0 = age 0) is appended
+ * directly into this step's output — AFTER every existing candidate's closure — mirroring {@code
+ * PikeVMMatcher.findStepClosure}'s {@code sortedUnion(tc, reinjectClosureIds)} exactly: {@code
+ * reinjectClosureIds} is itself a closure of the raw start state that is unioned into the result
+ * un-transitioned, ready to consume the next character on a later step, not transitioned on this
+ * step's {@code c} directly. Getting this right matters because the reinjected candidate must be
+ * <b>anchor-blocked</b> ({@link #reinjectStates}/{@link #reinjectRegs}, built by closing over the
+ * start state with {@code blockStartAnchor=true}): {@code ^}/{@code \A} must never re-fire from any
+ * position other than the true start of input, exactly as {@code PikeVMMatcher.reinjectClosureIds}
+ * excludes those branches. {@code (?m)^} additionally depends on whether the character just
+ * consumed by <em>this</em> step was {@code '\n'} — see {@link #reinjectAfterNlStates}/{@link
+ * #reinjectAfterNlRegs} and {@code PikeVMMatcher.reinjectAfterNlClosureIds}'s identical split. The
+ * existing {@code totalConsumed - age} formula in {@link #absolutePositions} needs no
+ * special-casing for reinjected candidates: age is still "characters consumed since tag 0 was set,"
+ * regardless of when within the scan that set happened.
  */
 final class LaurikariCaptureNfaStep implements LaurikariNfaStep {
 
   private final NFA.NFAState[] statesById;
   private final int[] tagOfState;
   private final boolean[] isAccept;
+  private final int startStateId;
   private final int[] initialStates;
   private final int[][] initialRegs;
+
+  /**
+   * Anchor-blocked closure of the start state, for reinjection mid-scan (blocks every start anchor,
+   * including {@code (?m)^} — safe to use unconditionally when the pattern has no multiline anchor,
+   * and as the "previous char wasn't '\n'" case when it does.
+   */
+  private final int[] reinjectStates;
+
+  private final int[][] reinjectRegs;
+
+  /**
+   * Reinjection closure for the "previous consumed char was '\n'" case: crosses {@code (?m)^}
+   * (which fires at every line start) but still blocks {@code ^}/{@code \A}. {@code null} when the
+   * pattern has no {@code START_MULTILINE} anchor (then {@link #reinjectStates} covers every case).
+   */
+  private final int[] reinjectAfterNlStates;
+
+  private final int[][] reinjectAfterNlRegs;
+
   final int tagCount;
 
   LaurikariCaptureNfaStep(NFA nfa, int groupCount) {
     this.statesById = statesById(nfa);
     this.tagOfState = LaurikariTagNumbering.tagOfState(nfa);
     this.isAccept = isAccept(nfa, statesById.length);
+    this.startStateId = nfa.getStartState().id;
     this.tagCount = LaurikariTagNumbering.tagCount(groupCount);
-    LaurikariStepResult initial = initial(nfa, this);
+    LaurikariStepResult initial = closureFromStart(false, false);
     this.initialStates = initial.states;
     this.initialRegs = initial.regs;
+
+    boolean hasMultiline = hasMultilineAnchor(nfa);
+    LaurikariStepResult reinject = closureFromStart(true, true);
+    this.reinjectStates = reinject.states;
+    this.reinjectRegs = reinject.regs;
+    if (hasMultiline) {
+      LaurikariStepResult afterNl = closureFromStart(true, false);
+      this.reinjectAfterNlStates = afterNl.states;
+      this.reinjectAfterNlRegs = afterNl.regs;
+    } else {
+      this.reinjectAfterNlStates = null;
+      this.reinjectAfterNlRegs = null;
+    }
+  }
+
+  private static boolean hasMultilineAnchor(NFA nfa) {
+    for (NFA.NFAState s : nfa.getStates()) {
+      if (s.anchor == NFA.AnchorType.START_MULTILINE) return true;
+    }
+    return false;
   }
 
   private static boolean[] isAccept(NFA nfa, int stateCount) {
@@ -102,20 +151,37 @@ final class LaurikariCaptureNfaStep implements LaurikariNfaStep {
   }
 
   /**
-   * @return the initial (states, regs) pair for an anchored match attempt starting at the current
-   *     position: the epsilon-closure of {@code nfa.getStartState()}, with tag 0 (group 0's open —
-   *     never carried by any NFA state, see {@link LaurikariTagNumbering}) seeded to age 0 and
-   *     every other tag unset ({@code -1}).
+   * @return the (states, regs) pair for a fresh match attempt anchored at some position: the
+   *     epsilon-closure of the start state, with tag 0 (group 0's open — never carried by any NFA
+   *     state, see {@link LaurikariTagNumbering}) seeded to age 0 and every other tag unset ({@code
+   *     -1}). {@code blockStartAnchor}/{@code blockMultilineAnchor} select which anchors this
+   *     particular fresh attempt is allowed to cross — see {@link #reinjectStates}'s javadoc.
    */
-  static LaurikariStepResult initial(NFA nfa, LaurikariCaptureNfaStep step) {
-    int[] allUnset = new int[step.tagCount];
+  private LaurikariStepResult closureFromStart(
+      boolean blockStartAnchor, boolean blockMultilineAnchor) {
+    int[] allUnset = new int[tagCount];
     Arrays.fill(allUnset, -1);
     allUnset[0] = 0; // group 0 opens here, age 0
-    boolean[] visited = new boolean[step.statesById.length];
+    boolean[] visited = new boolean[statesById.length];
     List<Integer> outIds = new ArrayList<>();
     List<int[]> outRegs = new ArrayList<>();
-    step.addClosure(visited, outIds, outRegs, nfa.getStartState().id, allUnset);
-    return step.truncateAtFirstAccept(outIds, outRegs);
+    addClosure(
+        visited, outIds, outRegs, startStateId, allUnset, blockStartAnchor, blockMultilineAnchor);
+    // Unblocked (blockStartAnchor=false) is initialClosure(), seeding the anchored matches()/
+    // match() path: never truncate, mirroring PikeVMMatcher.runMatches/runMatchResult, which keep
+    // lower-priority threads alive after a mid-string accept since they may still be needed to
+    // satisfy a full-input match (see truncateAtFirstAccept's javadoc on why that cut is only
+    // valid for find()-style leftmost-first semantics). Blocked variants seed the find()-family
+    // reinject closures, where truncation is correct.
+    return blockStartAnchor
+        ? truncateAtFirstAccept(outIds, outRegs)
+        : new LaurikariStepResult(toArray(outIds), outRegs.toArray(new int[0][]));
+  }
+
+  private static int[] toArray(List<Integer> ids) {
+    int[] out = new int[ids.size()];
+    for (int i = 0; i < out.length; i++) out[i] = ids.get(i);
+    return out;
   }
 
   /**
@@ -140,9 +206,24 @@ final class LaurikariCaptureNfaStep implements LaurikariNfaStep {
    * terms), and a target NFA state already visited by a higher-priority arrival discards this
    * arrival's entire register vector (step 3's whole-mapping discard) since {@code visited[id]}
    * short-circuits before this state's mapping is ever recorded.
+   *
+   * <p>{@code blockStartAnchor}/{@code blockMultilineAnchor}, when set, stop the DFS from crossing
+   * through a {@code START}/{@code STRING_START} or {@code START_MULTILINE} anchor state
+   * (respectively) — mirroring {@code PikeVMMatcher.sortedEpsilonClosure}'s identical skip. The
+   * anchor state itself is still recorded (harmless: it carries no tag and has no consuming
+   * transitions of its own), only its onward epsilon edges are pruned. Ordinary mid-scan closures
+   * (every call site except the reinject-closure construction) pass both flags {@code false}: the
+   * eligibility gate ({@code LaurikariEligibility}) already guarantees no anchor is reachable after
+   * a consuming transition, so blocking never triggers there anyway.
    */
   private void addClosure(
-      boolean[] visited, List<Integer> outIds, List<int[]> outRegs, int id, int[] regs) {
+      boolean[] visited,
+      List<Integer> outIds,
+      List<int[]> outRegs,
+      int id,
+      int[] regs,
+      boolean blockStartAnchor,
+      boolean blockMultilineAnchor) {
     if (visited[id]) return;
     visited[id] = true;
     int tag = tagOfState[id];
@@ -153,9 +234,62 @@ final class LaurikariCaptureNfaStep implements LaurikariNfaStep {
     }
     outIds.add(id);
     outRegs.add(r);
-    for (NFA.NFAState e : statesById[id].getEpsilonTransitions()) {
-      addClosure(visited, outIds, outRegs, e.id, r);
+    NFA.AnchorType a = statesById[id].anchor;
+    if (a != null) {
+      if (blockStartAnchor && (a == NFA.AnchorType.START || a == NFA.AnchorType.STRING_START)) {
+        return;
+      }
+      if (blockMultilineAnchor && a == NFA.AnchorType.START_MULTILINE) return;
     }
+    for (NFA.NFAState e : statesById[id].getEpsilonTransitions()) {
+      addClosure(visited, outIds, outRegs, e.id, r, blockStartAnchor, blockMultilineAnchor);
+    }
+  }
+
+  /**
+   * @return the (states, regs) pair for an anchored match attempt starting at the true beginning of
+   *     the scan (every start anchor satisfied) — the seed {@link LaurikariDfaMatcher} uses to
+   *     construct its DFA caches' start state.
+   */
+  LaurikariStepResult initialClosure() {
+    return new LaurikariStepResult(initialStates, initialRegs);
+  }
+
+  /**
+   * @return {@link #initialClosure}, truncated at its first accept — the seed {@code
+   *     LaurikariDfaMatcher} uses for {@code findCache}'s state 0 (a {@code find()}-family scan
+   *     that happens to start at absolute position 0). Unlike {@link #initialClosure} itself (used
+   *     for the anchored {@code matches()}/{@code match()} cache, which must never truncate — see
+   *     {@link #truncateAtFirstAccept}'s javadoc), a {@code find()}-family scan starting at
+   *     position 0 needs the same leftmost-first truncation every other {@code find()} start
+   *     position gets.
+   */
+  LaurikariStepResult truncatedInitialClosure() {
+    List<Integer> ids = new ArrayList<>(initialStates.length);
+    for (int id : initialStates) ids.add(id);
+    return truncateAtFirstAccept(ids, new ArrayList<>(Arrays.asList(initialRegs)));
+  }
+
+  /**
+   * @return the anchor-blocked closure {@link LaurikariDfaMatcher} seeds a {@code findFrom(input,
+   *     start)} scan from when {@code start > 0} — {@link #initialClosure} is only valid when the
+   *     scan truly begins at absolute position 0 ({@code ^}/{@code \A} satisfied); starting mid-
+   *     string must never let those anchors fire (see {@code PikeVMMatcher.checkAnchor}'s identical
+   *     absolute-0 pinning).
+   */
+  LaurikariStepResult reinjectClosure() {
+    return new LaurikariStepResult(reinjectStates, reinjectRegs);
+  }
+
+  /**
+   * @return {@link #reinjectClosure}'s "previous character was '\n'" variant (crosses {@code
+   *     (?m)^}), or {@code null} if the pattern has no {@code START_MULTILINE} anchor (then {@link
+   *     #reinjectClosure} covers every case).
+   */
+  LaurikariStepResult reinjectAfterNlClosure() {
+    return reinjectAfterNlStates == null
+        ? null
+        : new LaurikariStepResult(reinjectAfterNlStates, reinjectAfterNlRegs);
   }
 
   @Override
@@ -182,12 +316,6 @@ final class LaurikariCaptureNfaStep implements LaurikariNfaStep {
     List<Integer> seedIds = new ArrayList<>();
     List<int[]> seedRegs = new ArrayList<>();
     collectConsumingSeeds(curStates, curRegs, c, seenTarget, seedIds, seedRegs);
-    if (reinject) {
-      // Lowest priority: appended after every existing candidate's seeds, so an already-visited
-      // target from an older (more leftmost) start is left untouched by addClosure's
-      // first-visit-wins rule below.
-      collectConsumingSeeds(initialStates, initialRegs, c, seenTarget, seedIds, seedRegs);
-    }
     // Step 2/3: epsilon-close each seed in the same priority order, applying each transition's
     // register ops (copy for pass-through tags, set-to-current-pos -- age 0 -- for the tag(s)
     // matching that transition's enterGroup/exitGroup) via addClosure, and discarding a
@@ -196,10 +324,37 @@ final class LaurikariCaptureNfaStep implements LaurikariNfaStep {
     List<Integer> outIds = new ArrayList<>();
     List<int[]> outRegs = new ArrayList<>();
     for (int i = 0; i < seedIds.size(); i++) {
-      addClosure(visited, outIds, outRegs, seedIds.get(i), seedRegs.get(i));
+      addClosure(visited, outIds, outRegs, seedIds.get(i), seedRegs.get(i), false, false);
+    }
+    if (reinject) {
+      // Lowest priority: a fresh, already-closed, anchor-blocked start candidate appended straight
+      // into this step's output -- un-transitioned, ready to consume the *next* character -- so it
+      // never displaces a higher-priority (more leftmost) candidate already present. Mirrors
+      // PikeVMMatcher.findStepClosure's sortedUnion(tc, reinjectClosureIds) exactly; see the class
+      // javadoc for why this must be un-transitioned rather than fed through collectConsumingSeeds.
+      int[] rStates =
+          (reinjectAfterNlStates != null && c == '\n') ? reinjectAfterNlStates : reinjectStates;
+      int[][] rRegs =
+          (reinjectAfterNlStates != null && c == '\n') ? reinjectAfterNlRegs : reinjectRegs;
+      for (int i = 0; i < rStates.length; i++) {
+        int id = rStates[i];
+        if (!visited[id]) {
+          visited[id] = true;
+          outIds.add(id);
+          outRegs.add(rRegs[i]);
+        }
+      }
     }
     // Step 4: the caller (LaurikariDFACache) interns (states, regs) via LaurikariStateSetKey.
-    return truncateAtFirstAccept(outIds, outRegs);
+    // Only truncate for applyFind()'s find()-family semantics (reinject=true): a mid-string
+    // accept there is already the leftmost, highest-priority match, so lower-priority threads
+    // can never win (mirrors PikeVMMatcher.findPosFrom's clistSize = t cut). apply()'s
+    // matches()/match() semantics (reinject=false) must keep lower-priority threads alive past a
+    // mid-string accept, since the whole input still needs to match (mirrors
+    // PikeVMMatcher.runMatches/runMatchResult, which never truncate on clistFirstAccept).
+    return reinject
+        ? truncateAtFirstAccept(outIds, outRegs)
+        : new LaurikariStepResult(toArray(outIds), outRegs.toArray(new int[0][]));
   }
 
   /**

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariCaptureNfaStep.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariCaptureNfaStep.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import com.datadoghq.reggie.codegen.automaton.NFA;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Impl-plan Task 1.2 (doc/2026-07-10-tdfa-capture-engine-impl-plan.md §3): full priority-ordered
+ * register-merge determinization over the real {@code 2 * (groupCount + 1)} tags {@link
+ * LaurikariTagNumbering} derives, generalizing {@code LaurikariPhase05Test}'s hand-rolled,
+ * 2-3-tag-only test driver into shippable production code that works for any {@code groupCount}.
+ *
+ * <p><b>Register encoding: ages, not absolute positions.</b> {@link LaurikariNfaStep#apply} has no
+ * {@code pos} parameter, so — exactly like {@code LaurikariPhase05Test}'s driver — each register
+ * holds an <em>age</em> (characters consumed since that tag was last set, or {@code -1} if never
+ * set), not an absolute position. Consuming a character ages every currently-set register by 1;
+ * closure resets a specific tag's age to {@code 0} the moment it passes through that tag's marker
+ * state (a real {@code enterGroup}/{@code exitGroup} state, or an accept state for tag 1 — see
+ * {@link LaurikariTagNumbering}). The absolute tag position is recovered once, at the end, as
+ * {@code totalConsumed - age} (see {@link #absolutePositions}) — the same formula {@code
+ * LaurikariDFACache#acceptAge}/{@code LaurikariPhase05Test#runToEnd} already use for their smaller
+ * tag counts. This is a deliberate scope decision, not an oversight: switching to literal absolute
+ * positions would need runtime-substituted register operations threaded through a {@code pos}
+ * parameter this interface doesn't have — that is exactly the "eventual real mechanism" the {@code
+ * LaurikariNfaStep} class javadoc already earmarks as future work, not something Task 1.2 asks for.
+ *
+ * <p><b>Priority order</b> (design §4, "whole-mapping priority discard"): a DFS through epsilon
+ * transitions in {@code curStates}' array order (index 0 = highest priority), first-visit wins —
+ * mirrors {@code PikeVMMatcher.addThread}'s {@code for (int i = 0; i < epsilons.size(); i++)}
+ * traversal over {@code state.getEpsilonTransitions()} exactly (that list's insertion order is
+ * itself documented as load-bearing Perl-priority order by {@code NFA.NFAState}). {@code
+ * curStates}' order is therefore load-bearing and must never be sorted/canonicalized, matching
+ * {@link LaurikariStateSetKey}'s order-sensitive {@code equals}/{@code hashCode}.
+ *
+ * <p><b>Scope</b>: no lookaround, backreference, or atomic-group handling — those NFA constructs
+ * are simply not traversed specially here (this class only walks {@code getEpsilonTransitions()}/
+ * {@code getTransitions()}), matching this task's explicit exclusion of eligibility gating (Task
+ * 1.3, not built here).
+ *
+ * <p><b>Task 1.4a — self-anchoring {@link #applyFind}:</b> {@code find()}-family semantics require
+ * re-injecting a fresh "candidate starts here" closure at every character step, exactly mirroring
+ * {@code PikeVMMatcher}'s thread-list reinjection at the tail of {@code clist}/{@code nlist} (an
+ * implicit lowest-priority {@code .*?} prefix). {@link #apply} and {@link #applyFind} share the
+ * same closure machinery via a private {@code apply(..., boolean reinject)}: when {@code reinject}
+ * is true, the epsilon-closure of the start state (tag 0 = age 0, computed once in the constructor
+ * and cached as {@link #initialStates}/{@link #initialRegs}) is scanned for {@code c}-consuming
+ * transitions too, appended AFTER every existing candidate's seeds — i.e. at the lowest priority —
+ * so an already-visited target from an older (more leftmost) start is left untouched by {@code
+ * visited}'s first-visit-wins rule. The existing {@code totalConsumed - age} formula in {@link
+ * #absolutePositions} needs no special-casing for reinjected candidates: age is still "characters
+ * consumed since tag 0 was set," regardless of when within the scan that set happened.
+ */
+final class LaurikariCaptureNfaStep implements LaurikariNfaStep {
+
+  private final NFA.NFAState[] statesById;
+  private final int[] tagOfState;
+  private final boolean[] isAccept;
+  private final int[] initialStates;
+  private final int[][] initialRegs;
+  final int tagCount;
+
+  LaurikariCaptureNfaStep(NFA nfa, int groupCount) {
+    this.statesById = statesById(nfa);
+    this.tagOfState = LaurikariTagNumbering.tagOfState(nfa);
+    this.isAccept = isAccept(nfa, statesById.length);
+    this.tagCount = LaurikariTagNumbering.tagCount(groupCount);
+    LaurikariStepResult initial = initial(nfa, this);
+    this.initialStates = initial.states;
+    this.initialRegs = initial.regs;
+  }
+
+  private static boolean[] isAccept(NFA nfa, int stateCount) {
+    boolean[] accept = new boolean[stateCount];
+    for (NFA.NFAState s : nfa.getAcceptStates()) {
+      accept[s.id] = true;
+    }
+    return accept;
+  }
+
+  private static NFA.NFAState[] statesById(NFA nfa) {
+    NFA.NFAState[] arr = new NFA.NFAState[nfa.getStates().size()];
+    for (NFA.NFAState s : nfa.getStates()) {
+      arr[s.id] = s;
+    }
+    return arr;
+  }
+
+  /**
+   * @return the initial (states, regs) pair for an anchored match attempt starting at the current
+   *     position: the epsilon-closure of {@code nfa.getStartState()}, with tag 0 (group 0's open —
+   *     never carried by any NFA state, see {@link LaurikariTagNumbering}) seeded to age 0 and
+   *     every other tag unset ({@code -1}).
+   */
+  static LaurikariStepResult initial(NFA nfa, LaurikariCaptureNfaStep step) {
+    int[] allUnset = new int[step.tagCount];
+    Arrays.fill(allUnset, -1);
+    allUnset[0] = 0; // group 0 opens here, age 0
+    boolean[] visited = new boolean[step.statesById.length];
+    List<Integer> outIds = new ArrayList<>();
+    List<int[]> outRegs = new ArrayList<>();
+    step.addClosure(visited, outIds, outRegs, nfa.getStartState().id, allUnset);
+    return step.truncateAtFirstAccept(outIds, outRegs);
+  }
+
+  /**
+   * @return {@code regs}, aged by one character (every set register incremented by 1; unset {@code
+   *     -1} registers stay unset).
+   */
+  private static int[] ageAll(int[] regs) {
+    int[] out = new int[regs.length];
+    for (int i = 0; i < regs.length; i++) {
+      out[i] = regs[i] < 0 ? -1 : regs[i] + 1;
+    }
+    return out;
+  }
+
+  /**
+   * Priority-ordered epsilon-closure DFS (first-visit wins per {@code visited}, mirroring {@code
+   * PikeVMMatcher.addThread}'s traversal order exactly), resetting {@code tagOfState[id]}'s age to
+   * 0 at each tag boundary crossed and propagating every other tag's age unchanged. This is Task
+   * 1.2's step 2/3: the register ops a transition carries fall out of this rule directly — pass-
+   * through tags are copied via {@code ageAll} before the DFS starts, the one tag matching this
+   * state's marker (if any) is overwritten to age 0 (the "set-to-current-pos" op, expressed in age
+   * terms), and a target NFA state already visited by a higher-priority arrival discards this
+   * arrival's entire register vector (step 3's whole-mapping discard) since {@code visited[id]}
+   * short-circuits before this state's mapping is ever recorded.
+   */
+  private void addClosure(
+      boolean[] visited, List<Integer> outIds, List<int[]> outRegs, int id, int[] regs) {
+    if (visited[id]) return;
+    visited[id] = true;
+    int tag = tagOfState[id];
+    int[] r = regs;
+    if (tag >= 0) {
+      r = regs.clone();
+      r[tag] = 0;
+    }
+    outIds.add(id);
+    outRegs.add(r);
+    for (NFA.NFAState e : statesById[id].getEpsilonTransitions()) {
+      addClosure(visited, outIds, outRegs, e.id, r);
+    }
+  }
+
+  @Override
+  public LaurikariStepResult apply(int[] curStates, int[][] curRegs, int c) {
+    return apply(curStates, curRegs, c, false);
+  }
+
+  /**
+   * Self-anchoring variant of {@link #apply} for {@code find()}-family semantics: re-injects a
+   * fresh lowest-priority "candidate starts here" closure at this character step, on top of {@code
+   * apply}'s ordinary carried-forward candidates. See the class javadoc for why this composes
+   * correctly with leftmost-first priority and the age-based {@link #absolutePositions} formula.
+   */
+  LaurikariStepResult applyFind(int[] curStates, int[][] curRegs, int c) {
+    return apply(curStates, curRegs, c, true);
+  }
+
+  private LaurikariStepResult apply(int[] curStates, int[][] curRegs, int c, boolean reinject) {
+    int stateCount = statesById.length;
+    // Step 1: consuming transitions from every NFA state in the current subset, in the same
+    // priority order PikeVMMatcher.addThread walks (curStates' array order, index 0 highest
+    // priority) -- first arrival to a given target state wins (step 3's whole-mapping discard).
+    boolean[] seenTarget = new boolean[stateCount];
+    List<Integer> seedIds = new ArrayList<>();
+    List<int[]> seedRegs = new ArrayList<>();
+    collectConsumingSeeds(curStates, curRegs, c, seenTarget, seedIds, seedRegs);
+    if (reinject) {
+      // Lowest priority: appended after every existing candidate's seeds, so an already-visited
+      // target from an older (more leftmost) start is left untouched by addClosure's
+      // first-visit-wins rule below.
+      collectConsumingSeeds(initialStates, initialRegs, c, seenTarget, seedIds, seedRegs);
+    }
+    // Step 2/3: epsilon-close each seed in the same priority order, applying each transition's
+    // register ops (copy for pass-through tags, set-to-current-pos -- age 0 -- for the tag(s)
+    // matching that transition's enterGroup/exitGroup) via addClosure, and discarding a
+    // lower-priority arrival's whole mapping the moment a target is already visited.
+    boolean[] visited = new boolean[stateCount];
+    List<Integer> outIds = new ArrayList<>();
+    List<int[]> outRegs = new ArrayList<>();
+    for (int i = 0; i < seedIds.size(); i++) {
+      addClosure(visited, outIds, outRegs, seedIds.get(i), seedRegs.get(i));
+    }
+    // Step 4: the caller (LaurikariDFACache) interns (states, regs) via LaurikariStateSetKey.
+    return truncateAtFirstAccept(outIds, outRegs);
+  }
+
+  /**
+   * Priority-kill (mirrors {@code PikeVMMatcher}'s {@code clistSize = t} truncation at its
+   * first-accept index): once a higher-priority arrival reaches an accept state, every
+   * strictly-lower-priority arrival in this subset can never win a leftmost-first match and must
+   * not survive into the next step's seed collection. The accept member itself is kept (its
+   * register vector is what {@code LaurikariDFACache#acceptRegs} reads), but nothing after it in
+   * priority order is retained. Applies uniformly to every closure result, including {@link
+   * #initial} — an accept reachable ahead of a lower-priority consuming state at position 0 (e.g.
+   * {@code "|a"}) must kill that lower-priority state just as it would mid-scan.
+   */
+  private LaurikariStepResult truncateAtFirstAccept(List<Integer> outIds, List<int[]> outRegs) {
+    int size = outIds.size();
+    for (int i = 0; i < size; i++) {
+      if (isAccept[outIds.get(i)]) {
+        size = i + 1;
+        break;
+      }
+    }
+    int[] states = new int[size];
+    int[][] regsOut = new int[size][];
+    for (int i = 0; i < size; i++) {
+      states[i] = outIds.get(i);
+      regsOut[i] = outRegs.get(i);
+    }
+    return new LaurikariStepResult(states, regsOut);
+  }
+
+  /**
+   * Appends, to {@code seedIds}/{@code seedRegs}, one aged seed per distinct target state reached
+   * by a {@code c}-consuming transition from {@code states}[i] (skipping targets already present in
+   * {@code seenTarget}, and marking newly-added ones) — the shared core of step 1 for both {@code
+   * apply}'s ordinary candidates and {@code applyFind}'s reinjected fresh-start candidate.
+   */
+  private void collectConsumingSeeds(
+      int[] states,
+      int[][] regs,
+      int c,
+      boolean[] seenTarget,
+      List<Integer> seedIds,
+      List<int[]> seedRegs) {
+    for (int i = 0; i < states.length; i++) {
+      NFA.NFAState s = statesById[states[i]];
+      for (NFA.Transition t : s.getTransitions()) {
+        if (t.chars.contains((char) c)) {
+          int targetId = t.target.id;
+          if (!seenTarget[targetId]) {
+            seenTarget[targetId] = true;
+            seedIds.add(targetId);
+            seedRegs.add(ageAll(regs[i]));
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * @return absolute tag positions ({@code totalConsumed - age}, or {@code -1} for a tag never set)
+   *     recovered from an accept-state register vector after {@code totalConsumed} characters have
+   *     been consumed from the anchored start.
+   */
+  int[] absolutePositions(int[] acceptRegs, int totalConsumed) {
+    int[] absolute = new int[tagCount];
+    for (int t = 0; t < tagCount; t++) {
+      absolute[t] = acceptRegs[t] < 0 ? -1 : totalConsumed - acceptRegs[t];
+    }
+    return absolute;
+  }
+}

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariCaptureNfaStep.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariCaptureNfaStep.java
@@ -102,18 +102,19 @@ final class LaurikariCaptureNfaStep implements LaurikariNfaStep {
   private final int[][] reinjectAfterNlRegs;
 
   /**
-   * True if any NFA state carries one of the 5 position-dependent anchor types ({@code END}, {@code
-   * STRING_END}, {@code STRING_END_ABSOLUTE}, {@code END_MULTILINE}, {@code WORD_BOUNDARY}) that
-   * must be evaluated live against the real input/position via {@link PikeVMMatcher#checkAnchor} —
-   * see the TDFA Phase 2 end-anchor/{@code \b} extension design. {@code false} for every pattern
-   * this class handled before that extension, in which case every closure accessor below returns
-   * its constructor-precomputed field unchanged (byte-identical to pre-extension behavior).
+   * True if any NFA state carries one of the 6 position-dependent anchor types ({@code END}, {@code
+   * STRING_END}, {@code STRING_END_ABSOLUTE}, {@code END_MULTILINE}, {@code WORD_BOUNDARY}, {@code
+   * NON_WORD_BOUNDARY}) that must be evaluated live against the real input/position via {@link
+   * PikeVMMatcher#checkAnchor} — see the TDFA Phase 2 end-anchor/{@code \b} extension design.
+   * {@code false} for every pattern this class handled before that extension, in which case every
+   * closure accessor below returns its constructor-precomputed field unchanged (byte-identical to
+   * pre-extension behavior).
    */
   final boolean hasNewAnchor;
 
   /**
    * Parallel to {@link #statesById}: {@code anchorBearingStates[id]} is true if that NFA state
-   * carries one of the 5 new anchor types. Exposed via {@link #anchorBearingStates()} so {@link
+   * carries one of the 6 new anchor types. Exposed via {@link #anchorBearingStates()} so {@link
    * LaurikariDFACache} can flag which of its interned DFA states must never have their outgoing
    * transitions memoized (see that class's {@code anchorSensitive} field).
    */
@@ -159,7 +160,8 @@ final class LaurikariCaptureNfaStep implements LaurikariNfaStep {
         || a == NFA.AnchorType.STRING_END
         || a == NFA.AnchorType.STRING_END_ABSOLUTE
         || a == NFA.AnchorType.END_MULTILINE
-        || a == NFA.AnchorType.WORD_BOUNDARY;
+        || a == NFA.AnchorType.WORD_BOUNDARY
+        || a == NFA.AnchorType.NON_WORD_BOUNDARY;
   }
 
   private static boolean[] anchorBearingStates(NFA.NFAState[] statesById) {

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDFACache.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDFACache.java
@@ -118,6 +118,16 @@ final class LaurikariDFACache {
    * always calls {@link #lookupOrCompute} directly. Always all-false when {@code
    * anchorBearingStates} is {@code null} (every pre-extension caller), so behavior for those
    * callers is byte-identical to before this field existed.
+   *
+   * <p>{@link #lookupOrCompute}'s caching gate additionally checks this flag on the
+   * <em>destination</em> state of a transition, not just the source: a source state with no
+   * anchor-bearing member of its own can still transition into a destination whose subset newly
+   * touches one (e.g. entering the first repetition of a one-or-more loop that feeds a trailing
+   * anchor). {@code addClosure} adds an anchor-bearing NFA state to a closure unconditionally the
+   * moment it becomes epsilon-reachable, so this is a purely structural, position-independent check
+   * — see issue #108, where checking only the source let a live, position-specific {@code
+   * checkAnchor} outcome get memoized under {@code (state, c)} and wrongly replayed at a later
+   * position.
    */
   final boolean[] anchorSensitive;
 
@@ -284,7 +294,18 @@ final class LaurikariDFACache {
     LaurikariStepResult result =
         step.apply(nfaStateSets[state], regs[state], c, input, pos, regionEnd);
     int id = intern(result.states, result.regs);
-    if (id != FALLBACK && !anchorSensitive[state]) cacheEntry(state, c, id);
+    // Gating on anchorSensitive[state] alone is not enough: a source state whose OWN subset
+    // has no anchor-bearing member can still transition into a destination whose subset newly
+    // touches one (e.g. the first repetition of a one-or-more loop feeding a trailing anchor).
+    // addClosure adds an anchor-bearing NFA state to a closure unconditionally the moment it is
+    // epsilon-reachable, so anchorSensitive[id] is a structural (position-independent) signal
+    // that THIS transition's closure build evaluated a live, position-specific checkAnchor call
+    // -- caching it under (state, c) alone would silently replay that one call's outcome at a
+    // different position later (issue #108).
+    boolean destinationAnchorSensitive = id >= 0 && anchorSensitive[id];
+    if (id != FALLBACK && !anchorSensitive[state] && !destinationAnchorSensitive) {
+      cacheEntry(state, c, id);
+    }
     return id;
   }
 

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDFACache.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDFACache.java
@@ -73,7 +73,7 @@ final class LaurikariDFACache {
 
   /**
    * Number of {@link #lookaheadClass} buckets. See that method's javadoc for why exactly these 3
-   * suffice to make every one of the 5 new anchor types' {@code checkAnchor} outcome a pure
+   * suffice to make every one of the 6 new anchor types' {@code checkAnchor} outcome a pure
    * function of {@code (consumed char, lookahead class)} away from {@code regionEnd}.
    */
   private static final int LOOKAHEAD_CLASSES = 3;
@@ -108,16 +108,17 @@ final class LaurikariDFACache {
 
   /**
    * {@code anchorSensitive[id]} is true when DFA state {@code id}'s NFA subset touches at least one
-   * of the 5 position-dependent anchor types ({@code END}, {@code STRING_END}, {@code
-   * STRING_END_ABSOLUTE}, {@code END_MULTILINE}, {@code WORD_BOUNDARY}) — see the TDFA Phase 2
-   * end-anchor/{@code \b} extension design. Such states' outgoing transitions must never be
-   * memoized in {@link #asciiTables} keyed on the consumed char alone (the cached result would
-   * silently apply one call's anchor outcome to a different position/call); {@link #step} instead
-   * memoizes them in {@link #anchorLookaheadTables}, additionally keyed on {@link #lookaheadClass},
-   * except within {@link #ANCHOR_LOOKAHEAD_LIVE_MARGIN} characters of {@code regionEnd}, where it
-   * always calls {@link #lookupOrCompute} directly. Always all-false when {@code
-   * anchorBearingStates} is {@code null} (every pre-extension caller), so behavior for those
-   * callers is byte-identical to before this field existed.
+   * of the 6 position-dependent anchor types ({@code END}, {@code STRING_END}, {@code
+   * STRING_END_ABSOLUTE}, {@code END_MULTILINE}, {@code WORD_BOUNDARY}, {@code NON_WORD_BOUNDARY})
+   * — see the TDFA Phase 2 end-anchor/{@code \b} extension design. Such states' outgoing
+   * transitions must never be memoized in {@link #asciiTables} keyed on the consumed char alone
+   * (the cached result would silently apply one call's anchor outcome to a different
+   * position/call); {@link #step} instead memoizes them in {@link #anchorLookaheadTables},
+   * additionally keyed on {@link #lookaheadClass}, except within {@link
+   * #ANCHOR_LOOKAHEAD_LIVE_MARGIN} characters of {@code regionEnd}, where it always calls {@link
+   * #lookupOrCompute} directly. Always all-false when {@code anchorBearingStates} is {@code null}
+   * (every pre-extension caller), so behavior for those callers is byte-identical to before this
+   * field existed.
    *
    * <p>{@link #lookupOrCompute}'s caching gate additionally checks this flag on the
    * <em>destination</em> state of a transition, not just the source: a source state with no
@@ -133,7 +134,7 @@ final class LaurikariDFACache {
 
   /**
    * Parallel to {@link LaurikariCaptureNfaStep#statesById}: {@code anchorBearingStates[nfaId]} is
-   * true if that NFA state carries one of the 5 new anchor types. {@code null} for callers with no
+   * true if that NFA state carries one of the 6 new anchor types. {@code null} for callers with no
    * anchor-sensitive states (every Phase 0/0.5 driver, and any {@code hasNewAnchor == false}
    * pattern) — then {@link #anchorSensitive} stays all-false without needing to consult this array.
    */
@@ -359,7 +360,7 @@ final class LaurikariDFACache {
   /**
    * Classifies the not-yet-consumed character at {@code input.charAt(pos)} into one of {@link
    * #LOOKAHEAD_CLASSES} buckets, sufficient (together with the already-consumed char {@code c},
-   * which is a separate cache dimension) to determine every one of the 5 new anchor types' {@code
+   * which is a separate cache dimension) to determine every one of the 6 new anchor types' {@code
    * PikeVMMatcher.checkAnchor} outcome, <b>provided</b> the caller has already excluded positions
    * within {@link #ANCHOR_LOOKAHEAD_LIVE_MARGIN} of {@code regionEnd} (guaranteed by {@link
    * #step}):
@@ -373,6 +374,9 @@ final class LaurikariDFACache {
    *       pos))}. The first operand is {@code isLetterOrDigit((char) c)} (already a cache
    *       dimension); the second is true iff {@link #LOOKAHEAD_WORD} (a newline is never a word
    *       char, so {@link #LOOKAHEAD_NEWLINE} and {@link #LOOKAHEAD_WORD} are mutually exclusive).
+   *   <li>{@code NON_WORD_BOUNDARY}: the negation of {@code WORD_BOUNDARY}'s equation above — same
+   *       two operands, {@code ==} instead of {@code !=} — so it depends on this class exactly the
+   *       same way.
    * </ul>
    */
   private static int lookaheadClass(String input, int pos) {

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDFACache.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDFACache.java
@@ -71,8 +71,36 @@ final class LaurikariDFACache {
   static final int DEAD = -2;
   static final int FALLBACK = -3;
 
+  /**
+   * Number of {@link #lookaheadClass} buckets. See that method's javadoc for why exactly these 3
+   * suffice to make every one of the 5 new anchor types' {@code checkAnchor} outcome a pure
+   * function of {@code (consumed char, lookahead class)} away from {@code regionEnd}.
+   */
+  private static final int LOOKAHEAD_CLASSES = 3;
+
+  private static final int LOOKAHEAD_WORD = 0;
+  private static final int LOOKAHEAD_NEWLINE = 1;
+  private static final int LOOKAHEAD_OTHER = 2;
+
+  /**
+   * Below this distance from {@code regionEnd}, {@code checkAnchor}'s {@code END}/{@code
+   * STRING_END}/{@code STRING_END_ABSOLUTE} cases depend on more than just {@link #lookaheadClass}
+   * (up to 2 characters of literal lookahead for a {@code \r\n} pair, plus the {@code pos ==
+   * regionEnd} case itself) — see {@link #lookaheadClass}'s javadoc. Transitions this close to the
+   * end are always recomputed live, never memoized.
+   */
+  private static final int ANCHOR_LOOKAHEAD_LIVE_MARGIN = 2;
+
   private final ConcurrentHashMap<LaurikariStateSetKey, Integer> stateIndex;
   final int[][] asciiTables; // asciiTables[id] = int[128] or null
+
+  /**
+   * {@code anchorLookaheadTables[id]} = {@code int[128 * LOOKAHEAD_CLASSES]} or {@code null} — the
+   * anchor-sensitive counterpart to {@link #asciiTables}, indexed by {@code consumed-char *
+   * LOOKAHEAD_CLASSES + lookaheadClass(...)}. See {@link #step}.
+   */
+  final int[][] anchorLookaheadTables;
+
   final int[][]
       nfaStateSets; // nfaStateSets[id] = NFA state IDs, order per the driving step's convention
   final int[][][] regs; // regs[id][i] = register vector for nfaStateSets[id][i]
@@ -83,9 +111,11 @@ final class LaurikariDFACache {
    * of the 5 position-dependent anchor types ({@code END}, {@code STRING_END}, {@code
    * STRING_END_ABSOLUTE}, {@code END_MULTILINE}, {@code WORD_BOUNDARY}) — see the TDFA Phase 2
    * end-anchor/{@code \b} extension design. Such states' outgoing transitions must never be
-   * memoized in {@link #asciiTables} (the cached result would silently apply one call's anchor
-   * outcome to a different position/call); {@link #step}/{@link #lookupOrCompute} check this flag
-   * to bypass caching for exactly (and only) these states. Always all-false when {@code
+   * memoized in {@link #asciiTables} keyed on the consumed char alone (the cached result would
+   * silently apply one call's anchor outcome to a different position/call); {@link #step} instead
+   * memoizes them in {@link #anchorLookaheadTables}, additionally keyed on {@link #lookaheadClass},
+   * except within {@link #ANCHOR_LOOKAHEAD_LIVE_MARGIN} characters of {@code regionEnd}, where it
+   * always calls {@link #lookupOrCompute} directly. Always all-false when {@code
    * anchorBearingStates} is {@code null} (every pre-extension caller), so behavior for those
    * callers is byte-identical to before this field existed.
    */
@@ -130,6 +160,7 @@ final class LaurikariDFACache {
     this.anchorBearingStates = anchorBearingStates;
     this.stateIndex = new ConcurrentHashMap<>();
     this.asciiTables = new int[cap][];
+    this.anchorLookaheadTables = new int[cap][];
     this.nfaStateSets = new int[cap][];
     this.regs = new int[cap][][];
     this.accepting = new boolean[cap];
@@ -215,7 +246,23 @@ final class LaurikariDFACache {
 
   int step(int state, int c, LaurikariNfaStep nfaStep, String input, int pos, int regionEnd) {
     if (anchorSensitive[state]) {
-      return lookupOrCompute(state, c, nfaStep, input, pos, regionEnd);
+      if (c >= 128 || regionEnd - pos <= ANCHOR_LOOKAHEAD_LIVE_MARGIN) {
+        return lookupOrCompute(state, c, nfaStep, input, pos, regionEnd);
+      }
+      int cls = lookaheadClass(input, pos);
+      int[] table =
+          NEEDS_INT_ARRAY_ACQUIRE
+              ? (int[]) TABLES_VH.getAcquire(anchorLookaheadTables, state)
+              : anchorLookaheadTables[state];
+      if (table != null) {
+        int idx = c * LOOKAHEAD_CLASSES + cls;
+        int cached =
+            NEEDS_INT_ARRAY_ACQUIRE ? (int) INT_ARRAY_VH.getAcquire(table, idx) : table[idx];
+        if (cached != UNCACHED) return cached;
+      }
+      int next = lookupOrCompute(state, c, nfaStep, input, pos, regionEnd);
+      if (next != FALLBACK) cacheAnchorLookaheadEntry(state, c, cls, next);
+      return next;
     }
     int[] table =
         NEEDS_INT_ARRAY_ACQUIRE
@@ -285,6 +332,44 @@ final class LaurikariDFACache {
       TABLES_VH.setRelease(asciiTables, state, t);
     } else {
       INT_ARRAY_VH.setRelease(table, c, value);
+    }
+  }
+
+  /**
+   * Classifies the not-yet-consumed character at {@code input.charAt(pos)} into one of {@link
+   * #LOOKAHEAD_CLASSES} buckets, sufficient (together with the already-consumed char {@code c},
+   * which is a separate cache dimension) to determine every one of the 5 new anchor types' {@code
+   * PikeVMMatcher.checkAnchor} outcome, <b>provided</b> the caller has already excluded positions
+   * within {@link #ANCHOR_LOOKAHEAD_LIVE_MARGIN} of {@code regionEnd} (guaranteed by {@link
+   * #step}):
+   *
+   * <ul>
+   *   <li>{@code END}/{@code STRING_END}/{@code STRING_END_ABSOLUTE}: always false away from {@code
+   *       regionEnd} — no dependency on this class at all.
+   *   <li>{@code END_MULTILINE}: {@code pos < regionEnd && charAt(pos) == '\n'} — true iff {@link
+   *       #LOOKAHEAD_NEWLINE}.
+   *   <li>{@code WORD_BOUNDARY}: {@code isLetterOrDigit(charAt(pos-1)) != isLetterOrDigit(charAt(
+   *       pos))}. The first operand is {@code isLetterOrDigit((char) c)} (already a cache
+   *       dimension); the second is true iff {@link #LOOKAHEAD_WORD} (a newline is never a word
+   *       char, so {@link #LOOKAHEAD_NEWLINE} and {@link #LOOKAHEAD_WORD} are mutually exclusive).
+   * </ul>
+   */
+  private static int lookaheadClass(String input, int pos) {
+    char next = input.charAt(pos);
+    if (next == '\n') return LOOKAHEAD_NEWLINE;
+    return Character.isLetterOrDigit(next) ? LOOKAHEAD_WORD : LOOKAHEAD_OTHER;
+  }
+
+  private void cacheAnchorLookaheadEntry(int state, int c, int cls, int value) {
+    int idx = c * LOOKAHEAD_CLASSES + cls;
+    int[] table = anchorLookaheadTables[state];
+    if (table == null) {
+      int[] t = new int[128 * LOOKAHEAD_CLASSES];
+      Arrays.fill(t, UNCACHED);
+      t[idx] = value;
+      TABLES_VH.setRelease(anchorLookaheadTables, state, t);
+    } else {
+      INT_ARRAY_VH.setRelease(table, idx, value);
     }
   }
 

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDFACache.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDFACache.java
@@ -163,6 +163,26 @@ final class LaurikariDFACache {
     return -1;
   }
 
+  /**
+   * O(1) cached transition lookup, falling back to {@link #lookupOrCompute} only on a genuine cache
+   * miss — the same ASCII-table-then-fallback check {@link #findLeftmostStart} inlines at the top
+   * of its per-character loop, factored out so callers that need the full register vector (rather
+   * than {@link #findLeftmostStart}'s Phase-0-specific single-age recovery) don't have to pay for a
+   * closure recomputation (via {@link LaurikariNfaStep#apply}) and a hashed state-set lookup on
+   * every character.
+   */
+  int step(int state, int c, LaurikariNfaStep nfaStep) {
+    int[] table =
+        NEEDS_INT_ARRAY_ACQUIRE
+            ? (int[]) TABLES_VH.getAcquire(asciiTables, state)
+            : asciiTables[state];
+    int next =
+        (table != null && c < 128)
+            ? (NEEDS_INT_ARRAY_ACQUIRE ? (int) INT_ARRAY_VH.getAcquire(table, c) : table[c])
+            : UNCACHED;
+    return next == UNCACHED ? lookupOrCompute(state, c, nfaStep) : next;
+  }
+
   int lookupOrCompute(int state, int c, LaurikariNfaStep step) {
     LaurikariStepResult result = step.apply(nfaStateSets[state], regs[state], c);
     if (result.states.length == 0) {

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDFACache.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDFACache.java
@@ -185,14 +185,22 @@ final class LaurikariDFACache {
 
   int lookupOrCompute(int state, int c, LaurikariNfaStep step) {
     LaurikariStepResult result = step.apply(nfaStateSets[state], regs[state], c);
-    if (result.states.length == 0) {
-      cacheEntry(state, c, DEAD);
-      return DEAD;
-    }
+    int id = intern(result.states, result.regs);
+    if (id != FALLBACK) cacheEntry(state, c, id);
+    return id;
+  }
 
-    LaurikariStateSetKey key = new LaurikariStateSetKey(result.states, result.regs);
+  /**
+   * Interns an arbitrary (states, regs) closure as a DFA state, reusing an existing entry if an
+   * equal one is already cached. Unlike {@link #lookupOrCompute}, this has no {@code (state, c)}
+   * transition to cache the result under — used by {@link LaurikariDfaMatcher} to seed a {@code
+   * findFrom(start > 0)} scan directly from a precomputed closure (state 0 is only valid when the
+   * scan begins at absolute position 0).
+   */
+  int intern(int[] states, int[][] stateRegs) {
+    if (states.length == 0) return DEAD;
+    LaurikariStateSetKey key = new LaurikariStateSetKey(states, stateRegs);
     Integer id = stateIndex.get(key);
-
     if (id == null && !frozen) {
       id =
           stateIndex.computeIfAbsent(
@@ -212,10 +220,7 @@ final class LaurikariDFACache {
         return FALLBACK;
       }
     }
-    if (id == null) return FALLBACK;
-
-    cacheEntry(state, c, id);
-    return id;
+    return id == null ? FALLBACK : id;
   }
 
   void cacheEntry(int state, int c, int value) {

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDFACache.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDFACache.java
@@ -370,8 +370,8 @@ final class LaurikariDFACache {
    *       regionEnd} — no dependency on this class at all.
    *   <li>{@code END_MULTILINE}: {@code pos < regionEnd && charAt(pos) == '\n'} — true iff {@link
    *       #LOOKAHEAD_NEWLINE}.
-   *   <li>{@code WORD_BOUNDARY}: {@code isLetterOrDigit(charAt(pos-1)) != isLetterOrDigit(charAt(
-   *       pos))}. The first operand is {@code isLetterOrDigit((char) c)} (already a cache
+   *   <li>{@code WORD_BOUNDARY}: {@code isWordChar(charAt(pos-1)) != isWordChar(charAt(
+   *       pos))}. The first operand is {@code PikeVMMatcher.isWordChar((char) c)} (already a cache
    *       dimension); the second is true iff {@link #LOOKAHEAD_WORD} (a newline is never a word
    *       char, so {@link #LOOKAHEAD_NEWLINE} and {@link #LOOKAHEAD_WORD} are mutually exclusive).
    *   <li>{@code NON_WORD_BOUNDARY}: the negation of {@code WORD_BOUNDARY}'s equation above — same
@@ -382,7 +382,7 @@ final class LaurikariDFACache {
   private static int lookaheadClass(String input, int pos) {
     char next = input.charAt(pos);
     if (next == '\n') return LOOKAHEAD_NEWLINE;
-    return Character.isLetterOrDigit(next) ? LOOKAHEAD_WORD : LOOKAHEAD_OTHER;
+    return PikeVMMatcher.isWordChar(next) ? LOOKAHEAD_WORD : LOOKAHEAD_OTHER;
   }
 
   private void cacheAnchorLookaheadEntry(int state, int c, int cls, int value) {

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDFACache.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDFACache.java
@@ -77,29 +77,77 @@ final class LaurikariDFACache {
       nfaStateSets; // nfaStateSets[id] = NFA state IDs, order per the driving step's convention
   final int[][][] regs; // regs[id][i] = register vector for nfaStateSets[id][i]
   final boolean[] accepting;
+
+  /**
+   * {@code anchorSensitive[id]} is true when DFA state {@code id}'s NFA subset touches at least one
+   * of the 5 position-dependent anchor types ({@code END}, {@code STRING_END}, {@code
+   * STRING_END_ABSOLUTE}, {@code END_MULTILINE}, {@code WORD_BOUNDARY}) — see the TDFA Phase 2
+   * end-anchor/{@code \b} extension design. Such states' outgoing transitions must never be
+   * memoized in {@link #asciiTables} (the cached result would silently apply one call's anchor
+   * outcome to a different position/call); {@link #step}/{@link #lookupOrCompute} check this flag
+   * to bypass caching for exactly (and only) these states. Always all-false when {@code
+   * anchorBearingStates} is {@code null} (every pre-extension caller), so behavior for those
+   * callers is byte-identical to before this field existed.
+   */
+  final boolean[] anchorSensitive;
+
+  /**
+   * Parallel to {@link LaurikariCaptureNfaStep#statesById}: {@code anchorBearingStates[nfaId]} is
+   * true if that NFA state carries one of the 5 new anchor types. {@code null} for callers with no
+   * anchor-sensitive states (every Phase 0/0.5 driver, and any {@code hasNewAnchor == false}
+   * pattern) — then {@link #anchorSensitive} stays all-false without needing to consult this array.
+   */
+  private final boolean[] anchorBearingStates;
+
   private final int[] acceptStateIds;
   private final AtomicInteger nextId;
   private volatile boolean frozen;
   private final int cap;
 
   LaurikariDFACache(int[] startStateSet, int[][] startRegs, int[] acceptStateIds) {
-    this(startStateSet, startRegs, acceptStateIds, DEFAULT_CAP);
+    this(startStateSet, startRegs, acceptStateIds, null, DEFAULT_CAP);
+  }
+
+  LaurikariDFACache(
+      int[] startStateSet, int[][] startRegs, int[] acceptStateIds, boolean[] anchorBearingStates) {
+    this(startStateSet, startRegs, acceptStateIds, anchorBearingStates, DEFAULT_CAP);
   }
 
   // package-private for tests
   LaurikariDFACache(int[] startStateSet, int[][] startRegs, int[] acceptStateIds, int cap) {
+    this(startStateSet, startRegs, acceptStateIds, null, cap);
+  }
+
+  // package-private for tests
+  LaurikariDFACache(
+      int[] startStateSet,
+      int[][] startRegs,
+      int[] acceptStateIds,
+      boolean[] anchorBearingStates,
+      int cap) {
     this.cap = cap;
     this.acceptStateIds = acceptStateIds;
+    this.anchorBearingStates = anchorBearingStates;
     this.stateIndex = new ConcurrentHashMap<>();
     this.asciiTables = new int[cap][];
     this.nfaStateSets = new int[cap][];
     this.regs = new int[cap][][];
     this.accepting = new boolean[cap];
+    this.anchorSensitive = new boolean[cap];
     this.nextId = new AtomicInteger(1); // 0 = start state
     nfaStateSets[0] = startStateSet;
     regs[0] = startRegs;
     accepting[0] = firstAcceptIndex(startStateSet) >= 0;
+    anchorSensitive[0] = isAnchorSensitive(startStateSet);
     stateIndex.put(new LaurikariStateSetKey(startStateSet, startRegs), 0);
+  }
+
+  private boolean isAnchorSensitive(int[] states) {
+    if (anchorBearingStates == null) return false;
+    for (int s : states) {
+      if (anchorBearingStates[s]) return true;
+    }
+    return false;
   }
 
   /**
@@ -127,17 +175,7 @@ final class LaurikariDFACache {
     int dfaState = 0;
     for (int pos = scanFrom; pos < len; pos++) {
       int c = input.charAt(pos);
-      int[] table =
-          NEEDS_INT_ARRAY_ACQUIRE
-              ? (int[]) TABLES_VH.getAcquire(asciiTables, dfaState)
-              : asciiTables[dfaState];
-      int next =
-          (table != null && c < 128)
-              ? (NEEDS_INT_ARRAY_ACQUIRE ? (int) INT_ARRAY_VH.getAcquire(table, c) : table[c])
-              : UNCACHED;
-      if (next == UNCACHED) {
-        next = lookupOrCompute(dfaState, c, step);
-      }
+      int next = step(dfaState, c, step, input, pos + 1, len);
       if (next == FALLBACK) {
         // Cache is frozen; delegate the remaining scan to a plain (uncached) NFA-level
         // re-simulation that tracks ages the same way the cached transitions do. This does NOT
@@ -172,6 +210,13 @@ final class LaurikariDFACache {
    * every character.
    */
   int step(int state, int c, LaurikariNfaStep nfaStep) {
+    return step(state, c, nfaStep, "", 0, 0);
+  }
+
+  int step(int state, int c, LaurikariNfaStep nfaStep, String input, int pos, int regionEnd) {
+    if (anchorSensitive[state]) {
+      return lookupOrCompute(state, c, nfaStep, input, pos, regionEnd);
+    }
     int[] table =
         NEEDS_INT_ARRAY_ACQUIRE
             ? (int[]) TABLES_VH.getAcquire(asciiTables, state)
@@ -180,13 +225,19 @@ final class LaurikariDFACache {
         (table != null && c < 128)
             ? (NEEDS_INT_ARRAY_ACQUIRE ? (int) INT_ARRAY_VH.getAcquire(table, c) : table[c])
             : UNCACHED;
-    return next == UNCACHED ? lookupOrCompute(state, c, nfaStep) : next;
+    return next == UNCACHED ? lookupOrCompute(state, c, nfaStep, input, pos, regionEnd) : next;
   }
 
   int lookupOrCompute(int state, int c, LaurikariNfaStep step) {
-    LaurikariStepResult result = step.apply(nfaStateSets[state], regs[state], c);
+    return lookupOrCompute(state, c, step, "", 0, 0);
+  }
+
+  int lookupOrCompute(
+      int state, int c, LaurikariNfaStep step, String input, int pos, int regionEnd) {
+    LaurikariStepResult result =
+        step.apply(nfaStateSets[state], regs[state], c, input, pos, regionEnd);
     int id = intern(result.states, result.regs);
-    if (id != FALLBACK) cacheEntry(state, c, id);
+    if (id != FALLBACK && !anchorSensitive[state]) cacheEntry(state, c, id);
     return id;
   }
 
@@ -211,6 +262,7 @@ final class LaurikariDFACache {
                   nfaStateSets[newId] = k.getStates();
                   regs[newId] = k.getRegs();
                   accepting[newId] = firstAcceptIndex(k.getStates()) >= 0;
+                  anchorSensitive[newId] = isAnchorSensitive(k.getStates());
                   return newId;
                 }
                 return null; // over cap: don't insert, keeps map bounded at cap entries
@@ -253,7 +305,7 @@ final class LaurikariDFACache {
     int[] states = nfaStates;
     int[][] r = nfaRegs;
     for (int pos = frozenPos; pos < len; pos++) {
-      LaurikariStepResult result = step.apply(states, r, input.charAt(pos));
+      LaurikariStepResult result = step.apply(states, r, input.charAt(pos), input, pos + 1, len);
       states = result.states;
       r = result.regs;
       if (states.length == 0) {

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDFACache.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDFACache.java
@@ -370,10 +370,10 @@ final class LaurikariDFACache {
    *       regionEnd} — no dependency on this class at all.
    *   <li>{@code END_MULTILINE}: {@code pos < regionEnd && charAt(pos) == '\n'} — true iff {@link
    *       #LOOKAHEAD_NEWLINE}.
-   *   <li>{@code WORD_BOUNDARY}: {@code isWordChar(charAt(pos-1)) != isWordChar(charAt(
-   *       pos))}. The first operand is {@code PikeVMMatcher.isWordChar((char) c)} (already a cache
-   *       dimension); the second is true iff {@link #LOOKAHEAD_WORD} (a newline is never a word
-   *       char, so {@link #LOOKAHEAD_NEWLINE} and {@link #LOOKAHEAD_WORD} are mutually exclusive).
+   *   <li>{@code WORD_BOUNDARY}: {@code isWordChar(charAt(pos-1)) != isWordChar(charAt( pos))}. The
+   *       first operand is {@code PikeVMMatcher.isWordChar((char) c)} (already a cache dimension);
+   *       the second is true iff {@link #LOOKAHEAD_WORD} (a newline is never a word char, so {@link
+   *       #LOOKAHEAD_NEWLINE} and {@link #LOOKAHEAD_WORD} are mutually exclusive).
    *   <li>{@code NON_WORD_BOUNDARY}: the negation of {@code WORD_BOUNDARY}'s equation above — same
    *       two operands, {@code ==} instead of {@code !=} — so it depends on this class exactly the
    *       same way.

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDFACache.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDFACache.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Arrays;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Laurikari-style lazily-materialized DFA cache: same lazily-materialized/ASCII-table caching
+ * structure as {@link LazyDFACache}, but each interned DFA state is keyed on (NFA state subset,
+ * per-state register vector) via {@link LaurikariStateSetKey} instead of on the subset alone.
+ *
+ * <p>Generalized from Phase 0's single-scalar "age" register to a fixed-size {@code int[]} register
+ * file per state (impl-plan Task 0.5.1). This class is deliberately agnostic to what the vector
+ * holds or how ties between colliding arrivals were resolved — that is entirely the calling {@link
+ * LaurikariNfaStep}'s business (see its class javadoc for the two coexisting tie-break
+ * disciplines). This class only interns whatever {@code (states, regs)} pairs the step function
+ * returns and caches transitions between the resulting DFA states.
+ *
+ * <p>{@link #findLeftmostStart} is Phase 0's specific find()-localization entry point: it assumes
+ * register slot 0 is an "age" value (candidate's characters-consumed-since-self-anchoring) and
+ * recovers the leftmost start as {@code (pos + 1) - age} the moment an accept state is reached. It
+ * is meaningless to call this method with a step function that doesn't populate slot 0 this way
+ * (e.g. Phase 0.5's multi-tag capture checkpoint, which instead reads {@link #acceptRegs}
+ * directly).
+ */
+final class LaurikariDFACache {
+
+  /** Same VarHandle/publication discipline as {@link LazyDFACache#TABLES_VH}. */
+  static final VarHandle TABLES_VH;
+
+  /** Same VarHandle/publication discipline as {@link LazyDFACache#INT_ARRAY_VH}. */
+  static final VarHandle INT_ARRAY_VH;
+
+  /** Same architecture gate as {@link LazyDFACache#NEEDS_INT_ARRAY_ACQUIRE}. */
+  static final boolean NEEDS_INT_ARRAY_ACQUIRE;
+
+  static {
+    try {
+      TABLES_VH = MethodHandles.arrayElementVarHandle(int[][].class);
+      INT_ARRAY_VH = MethodHandles.arrayElementVarHandle(int[].class);
+    } catch (Exception e) {
+      throw new ExceptionInInitializerError(e);
+    }
+    String arch = System.getProperty("os.arch", "");
+    NEEDS_INT_ARRAY_ACQUIRE =
+        !arch.equals("x86")
+            && !arch.equals("x86_64")
+            && !arch.equals("amd64")
+            && !arch.equals("i386");
+  }
+
+  static final int DEFAULT_CAP = 4096;
+  static final int UNCACHED = -1;
+  static final int DEAD = -2;
+  static final int FALLBACK = -3;
+
+  private final ConcurrentHashMap<LaurikariStateSetKey, Integer> stateIndex;
+  final int[][] asciiTables; // asciiTables[id] = int[128] or null
+  final int[][]
+      nfaStateSets; // nfaStateSets[id] = NFA state IDs, order per the driving step's convention
+  final int[][][] regs; // regs[id][i] = register vector for nfaStateSets[id][i]
+  final boolean[] accepting;
+  private final int[] acceptStateIds;
+  private final AtomicInteger nextId;
+  private volatile boolean frozen;
+  private final int cap;
+
+  LaurikariDFACache(int[] startStateSet, int[][] startRegs, int[] acceptStateIds) {
+    this(startStateSet, startRegs, acceptStateIds, DEFAULT_CAP);
+  }
+
+  // package-private for tests
+  LaurikariDFACache(int[] startStateSet, int[][] startRegs, int[] acceptStateIds, int cap) {
+    this.cap = cap;
+    this.acceptStateIds = acceptStateIds;
+    this.stateIndex = new ConcurrentHashMap<>();
+    this.asciiTables = new int[cap][];
+    this.nfaStateSets = new int[cap][];
+    this.regs = new int[cap][][];
+    this.accepting = new boolean[cap];
+    this.nextId = new AtomicInteger(1); // 0 = start state
+    nfaStateSets[0] = startStateSet;
+    regs[0] = startRegs;
+    accepting[0] = firstAcceptIndex(startStateSet) >= 0;
+    stateIndex.put(new LaurikariStateSetKey(startStateSet, startRegs), 0);
+  }
+
+  /**
+   * O(n) DFA-based search for the leftmost start position of the first completable match in {@code
+   * input}, scanning left-to-right from {@code scanFrom} while maintaining a single interned
+   * (subset, register-vector) DFA state.
+   *
+   * <p>Phase 0-specific: assumes register slot 0 is an "age" value and {@code step} merges a fresh
+   * self-anchored (age 0) candidate into every application (see {@link LaurikariNfaStep}'s class
+   * javadoc, value-based discipline). Unlike {@link LazyDFACache#findFrom}, there is no separate
+   * {@code matchStart}/restart-on-DEAD bookkeeping: the current DFA state always reflects every
+   * live start candidate at once, and the leftmost start is recovered directly from the winning age
+   * the moment an accepting state is reached: {@code (pos + 1) - age}.
+   *
+   * @return the leftmost match start position (0-based), or {@code -1} if no match exists at or
+   *     after {@code scanFrom}
+   */
+  int findLeftmostStart(String input, int scanFrom, LaurikariNfaStep step) {
+    if (input == null) return -1;
+    int len = input.length();
+    if (accepting[0]) {
+      // Zero-length match: state 0 (freshly self-anchored, age 0) is already accepting.
+      return scanFrom - acceptAge(0);
+    }
+    int dfaState = 0;
+    for (int pos = scanFrom; pos < len; pos++) {
+      int c = input.charAt(pos);
+      int[] table =
+          NEEDS_INT_ARRAY_ACQUIRE
+              ? (int[]) TABLES_VH.getAcquire(asciiTables, dfaState)
+              : asciiTables[dfaState];
+      int next =
+          (table != null && c < 128)
+              ? (NEEDS_INT_ARRAY_ACQUIRE ? (int) INT_ARRAY_VH.getAcquire(table, c) : table[c])
+              : UNCACHED;
+      if (next == UNCACHED) {
+        next = lookupOrCompute(dfaState, c, step);
+      }
+      if (next == FALLBACK) {
+        // Cache is frozen; delegate the remaining scan to a plain (uncached) NFA-level
+        // re-simulation that tracks ages the same way the cached transitions do. This does NOT
+        // need LazyDFACache.nfaFallbackFindFrom's O(n^2) retry-per-start-position loop: because
+        // every LaurikariNfaStep application already merges in a fresh self-anchored (age 0)
+        // candidate, a single forward pass carrying per-state ages is enough to recover the true
+        // leftmost start the moment an accepting state is reached.
+        return nfaFallbackFindLeftmostStart(
+            input, pos, nfaStateSets[dfaState], regs[dfaState], step);
+      }
+      if (next == DEAD) {
+        // Unreachable in practice: LaurikariNfaStep's step 3/4 always merge in a fresh
+        // closure(startNfaState) at age 0, so the merged result can only be empty if the start
+        // state's own closure is empty (a degenerate NFA). Kept for parity with LazyDFACache's
+        // DEAD handling and as a defensive stop rather than continuing with an unusable state.
+        return -1;
+      }
+      dfaState = next;
+      if (accepting[dfaState]) {
+        return (pos + 1) - acceptAge(dfaState);
+      }
+    }
+    return -1;
+  }
+
+  int lookupOrCompute(int state, int c, LaurikariNfaStep step) {
+    LaurikariStepResult result = step.apply(nfaStateSets[state], regs[state], c);
+    if (result.states.length == 0) {
+      cacheEntry(state, c, DEAD);
+      return DEAD;
+    }
+
+    LaurikariStateSetKey key = new LaurikariStateSetKey(result.states, result.regs);
+    Integer id = stateIndex.get(key);
+
+    if (id == null && !frozen) {
+      id =
+          stateIndex.computeIfAbsent(
+              key,
+              k -> {
+                int newId = nextId.getAndIncrement();
+                if (newId < cap) {
+                  nfaStateSets[newId] = k.getStates();
+                  regs[newId] = k.getRegs();
+                  accepting[newId] = firstAcceptIndex(k.getStates()) >= 0;
+                  return newId;
+                }
+                return null; // over cap: don't insert, keeps map bounded at cap entries
+              });
+      if (id == null) {
+        frozen = true;
+        return FALLBACK;
+      }
+    }
+    if (id == null) return FALLBACK;
+
+    cacheEntry(state, c, id);
+    return id;
+  }
+
+  void cacheEntry(int state, int c, int value) {
+    if (c >= 128) return;
+    int[] table = asciiTables[state];
+    if (table == null) {
+      int[] t = new int[128];
+      Arrays.fill(t, UNCACHED);
+      t[c] = value;
+      TABLES_VH.setRelease(asciiTables, state, t);
+    } else {
+      INT_ARRAY_VH.setRelease(table, c, value);
+    }
+  }
+
+  /**
+   * NFA fallback for {@link #findLeftmostStart} when the cache is frozen. Continues stepping the
+   * raw (state, register) set forward from {@code frozenPos} using {@code step} directly (no
+   * caching), returning as soon as an accepting state is reached — see {@link #findLeftmostStart}'s
+   * FALLBACK comment for why a single pass suffices here, unlike {@link LazyDFACache}'s
+   * boolean-only fallback.
+   *
+   * @param frozenPos position in the input where the FALLBACK transition was encountered
+   * @param nfaStates NFA state subset at {@code frozenPos} (before consuming that position's char)
+   * @param nfaRegs {@code nfaStates}' parallel register vectors
+   */
+  private int nfaFallbackFindLeftmostStart(
+      String input, int frozenPos, int[] nfaStates, int[][] nfaRegs, LaurikariNfaStep step) {
+    int len = input.length();
+    int[] states = nfaStates;
+    int[][] r = nfaRegs;
+    for (int pos = frozenPos; pos < len; pos++) {
+      LaurikariStepResult result = step.apply(states, r, input.charAt(pos));
+      states = result.states;
+      r = result.regs;
+      if (states.length == 0) {
+        // Unreachable in practice; see findLeftmostStart's DEAD comment.
+        return -1;
+      }
+      int idx = firstAcceptIndex(states);
+      if (idx >= 0) {
+        return (pos + 1) - r[idx][0];
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * @return the age (register slot 0) of the winning accept-state candidate present in the DFA
+   *     state {@code dfaState}'s subset, per Phase 0's value-based tie-break (larger age wins among
+   *     accept-state members — see {@link #firstAcceptIndex}'s javadoc for why "first" and "larger
+   *     age" coincide when this method's caller uses this class as intended).
+   */
+  private int acceptAge(int dfaState) {
+    int idx = firstAcceptIndex(nfaStateSets[dfaState]);
+    return regs[dfaState][idx][0];
+  }
+
+  /**
+   * @return the register vector of the accept-state member of {@code dfaState}'s subset (per Task
+   *     0.5.3's multi-tag capture checkpoint, which reads this directly instead of {@link
+   *     #findLeftmostStart}'s age-specific math), or {@code null} if no accept state is present.
+   */
+  int[] acceptRegs(int dfaState) {
+    int idx = firstAcceptIndex(nfaStateSets[dfaState]);
+    return idx < 0 ? null : regs[dfaState][idx];
+  }
+
+  /**
+   * @return the index within {@code states} of the first accept-state member (by array order), or
+   *     {@code -1} if none of {@code states} is an accept state. "First" is safe for both
+   *     coexisting tie-break disciplines: Phase 0's value-based driver never presents more than one
+   *     accept-state member per subset in practice (a single shared NFA accept state per pattern,
+   *     see {@code LaurikariDFACacheTest}'s traced examples), so "first" and "largest age" coincide
+   *     trivially; Phase 0.5's priority-order driver's whole-mapping-discard already guarantees at
+   *     most one entry per NFA state id, and "first" here means "highest priority", matching {@code
+   *     PikeVMMatcher}'s "first accepting thread in priority order is highest priority" convention.
+   */
+  private int firstAcceptIndex(int[] states) {
+    for (int i = 0; i < states.length; i++) {
+      if (isAcceptState(states[i])) return i;
+    }
+    return -1;
+  }
+
+  private boolean isAcceptState(int state) {
+    for (int t : acceptStateIds) {
+      if (t == state) return true;
+    }
+    return false;
+  }
+
+  // package-private for tests: current number of materialized (interned) DFA states, used to
+  // check that the cache stays bounded by NFA structure rather than growing with input length.
+  int stateCount() {
+    return Math.min(nextId.get(), cap);
+  }
+}

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcher.java
@@ -57,6 +57,14 @@ final class LaurikariDfaMatcher extends ReggieMatcher {
    */
   private final LaurikariNfaStep findStep;
 
+  /**
+   * True when {@code step} has at least one end-anchor/{@code \b}-bearing NFA state — the seed
+   * closures ({@code anchoredCache}/{@code findCache} state 0, {@link #reinjectDfaState}) were then
+   * constructed against an empty placeholder input and must be recomputed live from the real input
+   * at the top of every {@link #runAnchored}/{@link #runFind} call.
+   */
+  private final boolean hasNewAnchor;
+
   private final LaurikariDFACache anchoredCache;
   private final LaurikariDFACache findCache;
 
@@ -86,12 +94,19 @@ final class LaurikariDfaMatcher extends ReggieMatcher {
     this.groupCount = groupCount;
     this.step = new LaurikariCaptureNfaStep(nfa, groupCount);
     this.findStep = step::applyFind;
+    this.hasNewAnchor = step.hasNewAnchor;
+    // When hasNewAnchor, initial/truncatedInitial/reinject closures below are just placeholder
+    // empty-input seeds to satisfy constructor plumbing -- runAnchored/runFind recompute the true
+    // seed live against the real input at the top of every call (see below).
     LaurikariStepResult initial = step.initialClosure();
     LaurikariStepResult truncatedInitial = step.truncatedInitialClosure();
     int[] acceptIds = acceptStateIds(nfa);
-    this.anchoredCache = new LaurikariDFACache(initial.states, initial.regs, acceptIds);
+    boolean[] anchorBearingStates = step.anchorBearingStates();
+    this.anchoredCache =
+        new LaurikariDFACache(initial.states, initial.regs, acceptIds, anchorBearingStates);
     this.findCache =
-        new LaurikariDFACache(truncatedInitial.states, truncatedInitial.regs, acceptIds);
+        new LaurikariDFACache(
+            truncatedInitial.states, truncatedInitial.regs, acceptIds, anchorBearingStates);
     LaurikariStepResult reinject = step.reinjectClosure();
     this.reinjectDfaState = findCache.intern(reinject.states, reinject.regs);
     LaurikariStepResult reinjectAfterNl = step.reinjectAfterNlClosure();
@@ -152,8 +167,17 @@ final class LaurikariDfaMatcher extends ReggieMatcher {
   private int[] runAnchored(String input) {
     int len = input.length();
     int dfaState = 0;
+    if (hasNewAnchor) {
+      LaurikariStepResult seed = step.initialClosure(input, len);
+      dfaState = anchoredCache.intern(seed.states, seed.regs);
+      if (dfaState == LaurikariDFACache.DEAD) return null;
+      if (dfaState == LaurikariDFACache.FALLBACK) {
+        fallbackCount++;
+        return fallbackAnchored(input);
+      }
+    }
     for (int i = 0; i < len; i++) {
-      int next = anchoredCache.step(dfaState, input.charAt(i), step);
+      int next = anchoredCache.step(dfaState, input.charAt(i), step, input, i + 1, len);
       if (next == LaurikariDFACache.DEAD) return null;
       if (next == LaurikariDFACache.FALLBACK) {
         fallbackCount++;
@@ -230,7 +254,7 @@ final class LaurikariDfaMatcher extends ReggieMatcher {
     int clamped = Math.max(0, start);
     int len = input.length();
     if (clamped > len) return null;
-    int dfaState = startDfaStateFor(input, clamped);
+    int dfaState = startDfaStateFor(input, clamped, len);
     if (dfaState == LaurikariDFACache.DEAD) {
       // reinjectDfaState (or its after-'\n' variant) collapsed to DEAD when the anchor-blocked
       // closure has no live states (e.g. a wholly start-anchored pattern reinjected at clamped >
@@ -238,16 +262,24 @@ final class LaurikariDfaMatcher extends ReggieMatcher {
       // both unnecessary and unsafe (DEAD is a negative sentinel, not a real array index).
       return null;
     }
+    if (dfaState == LaurikariDFACache.FALLBACK) {
+      fallbackCount++;
+      return fallbackFind(input, clamped);
+    }
     int[] best = null;
     if (findCache.accepting[dfaState]) {
       // Zero-length match at the very start of the scan: no characters consumed yet.
       best = shiftByClamped(step.absolutePositions(findCache.acceptRegs(dfaState), 0), clamped);
     }
     for (int i = clamped; i < len; i++) {
-      int next = findCache.step(dfaState, input.charAt(i), findStep);
+      int next = findCache.step(dfaState, input.charAt(i), findStep, input, i + 1, len);
       if (next == LaurikariDFACache.FALLBACK) {
         fallbackCount++;
-        return best == null ? fallbackFind(input, i) : best;
+        // The whole call is redone from the scan's original start (clamped), not the frozen
+        // position i: a match may have started anywhere in [clamped, i) and not yet reached an
+        // accept, and restarting PikeVMMatcher at i would silently lose that prefix (see class
+        // javadoc -- this is meant to be a whole-call delegation, not a tail continuation).
+        return best == null ? fallbackFind(input, clamped) : best;
       }
       if (next == LaurikariDFACache.DEAD) {
         // Every applyFind() call reinjects a fresh (anchor-blocked) start candidate (see
@@ -279,7 +311,19 @@ final class LaurikariDfaMatcher extends ReggieMatcher {
    *     {@link #reinjectDfaState}, or its after-{@code '\n'} variant when the character immediately
    *     before {@code clamped} is {@code '\n'} — see {@link #reinjectDfaState}'s javadoc.
    */
-  private int startDfaStateFor(String input, int clamped) {
+  private int startDfaStateFor(String input, int clamped, int len) {
+    if (hasNewAnchor) {
+      LaurikariStepResult liveSeed;
+      if (clamped == 0) {
+        liveSeed = step.truncatedInitialClosure(input, len);
+      } else if (input.charAt(clamped - 1) == '\n') {
+        LaurikariStepResult afterNl = step.reinjectAfterNlClosure(input, clamped, len);
+        liveSeed = afterNl != null ? afterNl : step.reinjectClosure(input, clamped, len);
+      } else {
+        liveSeed = step.reinjectClosure(input, clamped, len);
+      }
+      return findCache.intern(liveSeed.states, liveSeed.regs);
+    }
     if (clamped == 0) return 0;
     if (reinjectAfterNlDfaState >= 0 && input.charAt(clamped - 1) == '\n') {
       return reinjectAfterNlDfaState;
@@ -297,8 +341,8 @@ final class LaurikariDfaMatcher extends ReggieMatcher {
     return relative;
   }
 
-  private int[] fallbackFind(String input, int frozenPos) {
-    MatchResult r = fallback().findMatchFrom(input, frozenPos);
+  private int[] fallbackFind(String input, int start) {
+    MatchResult r = fallback().findMatchFrom(input, start);
     if (r == null) return null;
     return toAbsolute(r);
   }

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcher.java
@@ -66,7 +66,8 @@ final class LaurikariDfaMatcher extends ReggieMatcher {
   private final boolean hasNewAnchor;
 
   private final LaurikariDFACache anchoredCache;
-  private final LaurikariDFACache findCache;
+  // package-private for tests: anchorSensitiveCount()/stateCount() proxy checks
+  final LaurikariDFACache findCache;
 
   /**
    * {@code findCache} state to seed a {@code findFrom(input, start)} scan from when {@code start >

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcher.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import com.datadoghq.reggie.codegen.automaton.NFA;
+import java.util.Collections;
+
+/**
+ * Impl-plan Task 1.4b (doc/2026-07-10-tdfa-capture-engine-impl-plan.md §3): standalone capture
+ * matcher over a {@link LaurikariDFACache}-cached tagged DFA, an O(n) alternative to {@link
+ * PikeVMMatcher}'s per-thread-per-character capture-array copying for {@link
+ * LaurikariEligibility}-eligible patterns.
+ *
+ * <p>Two independent {@link LaurikariDFACache} instances share one {@link LaurikariCaptureNfaStep}:
+ * one driven by {@link LaurikariCaptureNfaStep#apply} for anchored calls ({@link #matches}/{@link
+ * #match}), one driven by {@code applyFind} for self-anchoring calls ({@link #find}/{@link
+ * #findFrom}/{@link #findMatch}/{@link #findMatchFrom}) — mirroring how {@code PikeVMMatcher} keeps
+ * separate anchored/self-anchoring thread-list drivers over the same NFA.
+ *
+ * <p>This class does not itself check {@link LaurikariEligibility#isEligible} — same division of
+ * responsibility as {@link BitStateMatcher}, which assumes its caller already gated eligibility.
+ *
+ * <p>On {@link LaurikariDFACache#FALLBACK} (cache-cap overflow, {@code cap} = 4096 states), the
+ * entire call is delegated to a lazily-built {@link PikeVMMatcher} rather than continuing the scan
+ * from the frozen position — a deliberate scope-narrowing (see the approved plan): correctness-
+ * equivalent, simpler than replicating {@link LaurikariDFACache}'s finer-grained tail-continuation
+ * for a general N-tag register vector, at the cost of re-doing the whole call on this expected-rare
+ * path.
+ */
+final class LaurikariDfaMatcher extends ReggieMatcher {
+
+  private final NFA nfa;
+  private final String patternText;
+  private final int groupCount;
+  private final LaurikariCaptureNfaStep step;
+  private final LaurikariDFACache anchoredCache;
+  private final LaurikariDFACache findCache;
+
+  private PikeVMMatcher fallback;
+  private long fallbackCount;
+
+  LaurikariDfaMatcher(NFA nfa, String pattern, int groupCount) {
+    super(pattern);
+    this.nfa = nfa;
+    this.patternText = pattern;
+    this.groupCount = groupCount;
+    this.step = new LaurikariCaptureNfaStep(nfa, groupCount);
+    LaurikariStepResult initial = LaurikariCaptureNfaStep.initial(nfa, step);
+    int[] acceptIds = acceptStateIds(nfa);
+    this.anchoredCache = new LaurikariDFACache(initial.states, initial.regs, acceptIds);
+    this.findCache = new LaurikariDFACache(initial.states, initial.regs, acceptIds);
+    markNativeRichApi();
+  }
+
+  private static int[] acceptStateIds(NFA nfa) {
+    int[] ids = new int[nfa.getAcceptStates().size()];
+    int i = 0;
+    for (NFA.NFAState s : nfa.getAcceptStates()) {
+      ids[i++] = s.id;
+    }
+    return ids;
+  }
+
+  /** Number of calls delegated to the {@link PikeVMMatcher} fallback (cache-cap overflow). */
+  long fallbackCount() {
+    return fallbackCount;
+  }
+
+  private PikeVMMatcher fallback() {
+    if (fallback == null) {
+      fallback = new PikeVMMatcher(nfa, patternText);
+    }
+    return fallback;
+  }
+
+  @Override
+  boolean embedsNameMap() {
+    return true;
+  }
+
+  // -------------------------------------------------------------------------
+  // Anchored (matches/match): driven by LaurikariCaptureNfaStep.apply
+  // -------------------------------------------------------------------------
+
+  @Override
+  public boolean matches(String input) {
+    return runAnchored(input) != null;
+  }
+
+  @Override
+  public MatchResult match(String input) {
+    int[] absolute = runAnchored(input);
+    if (absolute == null) return null;
+    return buildResult(input, absolute);
+  }
+
+  /**
+   * @return absolute tag positions for a whole-input match, or {@code null} if the entire input
+   *     does not match, or the fallback sentinel {@code new int[0]}'s caller-visible equivalent
+   *     (handled internally — this method never returns without a definitive answer).
+   */
+  private int[] runAnchored(String input) {
+    int len = input.length();
+    int dfaState = 0;
+    for (int i = 0; i < len; i++) {
+      int next = anchoredCache.step(dfaState, input.charAt(i), step);
+      if (next == LaurikariDFACache.DEAD) return null;
+      if (next == LaurikariDFACache.FALLBACK) {
+        fallbackCount++;
+        return fallbackAnchored(input);
+      }
+      dfaState = next;
+    }
+    if (!anchoredCache.accepting[dfaState]) return null;
+    int[] acceptRegs = anchoredCache.acceptRegs(dfaState);
+    return step.absolutePositions(acceptRegs, len);
+  }
+
+  private int[] fallbackAnchored(String input) {
+    MatchResult r = fallback().match(input);
+    if (r == null) return null;
+    return toAbsolute(r);
+  }
+
+  // -------------------------------------------------------------------------
+  // Self-anchoring (find/findFrom/findMatch/findMatchFrom): driven by applyFind
+  // -------------------------------------------------------------------------
+
+  @Override
+  public boolean find(String input) {
+    return findFrom(input, 0) >= 0;
+  }
+
+  @Override
+  public int findFrom(String input, int start) {
+    int[] absolute = runFind(input, start);
+    return absolute == null ? -1 : absolute[0];
+  }
+
+  @Override
+  public MatchResult findMatch(String input) {
+    return findMatchFrom(input, 0);
+  }
+
+  @Override
+  public MatchResult findMatchFrom(String input, int start) {
+    int[] absolute = runFind(input, start);
+    if (absolute == null) return null;
+    return buildResult(input, absolute);
+  }
+
+  /**
+   * Self-anchoring scan of {@code input} from {@code start}: at every position, {@code findCache}
+   * (driven by {@code applyFind}) already carries every live start candidate at once — including
+   * one freshly reinjected at this very position — so a single left-to-right pass, with no
+   * restart-on-DEAD bookkeeping, finds the leftmost completable match.
+   *
+   * <p>Reaching an accepting state does not end the scan: {@code LaurikariCaptureNfaStep}'s
+   * priority-kill truncation already dropped every candidate strictly lower-priority than the
+   * accept just observed, but a strictly higher-priority candidate (e.g. a greedy loop's "keep
+   * going" branch) may still be alive and could still reach its own, preferred accept later —
+   * mirroring {@code PikeVMMatcher}'s "last write wins: each surviving override comes from a
+   * strictly higher-priority thread" comment. So: keep scanning while the subset is non-empty,
+   * remembering the most recent accept snapshot, and only return once every candidate has died or
+   * the input ends.
+   *
+   * @return absolute tag positions for the leftmost match at or after {@code start}, or {@code
+   *     null} if none exists
+   */
+  private int[] runFind(String input, int start) {
+    int clamped = Math.max(0, start);
+    int len = input.length();
+    if (clamped > len) return null;
+    int dfaState = 0;
+    int[] best = null;
+    if (findCache.accepting[dfaState]) {
+      // Zero-length match at the very start of the scan: no characters consumed yet.
+      best = shiftByClamped(step.absolutePositions(findCache.acceptRegs(dfaState), 0), clamped);
+    }
+    for (int i = clamped; i < len; i++) {
+      int next = findCache.step(dfaState, input.charAt(i), step);
+      if (next == LaurikariDFACache.FALLBACK) {
+        fallbackCount++;
+        return best == null ? fallbackFind(input, i) : best;
+      }
+      if (next == LaurikariDFACache.DEAD) {
+        if (best != null) return best;
+        // No candidate has matched yet: a fresh one is reinjected at the very next character (see
+        // LaurikariCaptureNfaStep's applyFind), so resume scanning from a clean state.
+        dfaState = 0;
+        continue;
+      }
+      dfaState = next;
+      if (findCache.accepting[dfaState]) {
+        // Ages are relative to this scan's own step count (i - clamped + 1 apply() calls so far),
+        // not the input's absolute indexing -- shift back to absolute positions afterward.
+        int[] acceptRegs = findCache.acceptRegs(dfaState);
+        best = shiftByClamped(step.absolutePositions(acceptRegs, i + 1 - clamped), clamped);
+      }
+    }
+    return best;
+  }
+
+  /** Adds {@code clamped} to every set ({@code >= 0}) entry of {@code relative}, in place. */
+  private static int[] shiftByClamped(int[] relative, int clamped) {
+    if (clamped != 0) {
+      for (int i = 0; i < relative.length; i++) {
+        if (relative[i] >= 0) relative[i] += clamped;
+      }
+    }
+    return relative;
+  }
+
+  private int[] fallbackFind(String input, int frozenPos) {
+    MatchResult r = fallback().findMatchFrom(input, frozenPos);
+    if (r == null) return null;
+    return toAbsolute(r);
+  }
+
+  // -------------------------------------------------------------------------
+  // Result construction
+  // -------------------------------------------------------------------------
+
+  private int[] toAbsolute(MatchResult r) {
+    int[] absolute = new int[2 * (groupCount + 1)];
+    for (int g = 0; g <= groupCount; g++) {
+      absolute[2 * g] = r.start(g);
+      absolute[2 * g + 1] = r.end(g);
+    }
+    return absolute;
+  }
+
+  private MatchResult buildResult(String input, int[] absolute) {
+    int[] starts = new int[groupCount + 1];
+    int[] ends = new int[groupCount + 1];
+    for (int g = 0; g <= groupCount; g++) {
+      starts[g] = absolute[2 * g];
+      ends[g] = absolute[2 * g + 1];
+    }
+    if (!nameToIndex.isEmpty()) {
+      return new NamedMatchResultImpl(input, starts, ends, groupCount, nameToIndex);
+    }
+    return new MatchResultImpl(input, starts, ends, groupCount, Collections.emptyMap());
+  }
+}

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcher.java
@@ -46,8 +46,35 @@ final class LaurikariDfaMatcher extends ReggieMatcher {
   private final String patternText;
   private final int groupCount;
   private final LaurikariCaptureNfaStep step;
+
+  /**
+   * Adapter binding {@link LaurikariDFACache#step}'s single {@code LaurikariNfaStep.apply} call to
+   * {@link LaurikariCaptureNfaStep#applyFind} instead of the ordinary {@link
+   * LaurikariCaptureNfaStep#apply}: {@code LaurikariNfaStep} is a functional interface, so passing
+   * {@link #step} itself to {@code findCache} would silently invoke its plain, non-reinjecting
+   * {@code apply} override — this field exists so {@code findCache} actually drives the
+   * self-anchoring closure the class javadoc says it does.
+   */
+  private final LaurikariNfaStep findStep;
+
   private final LaurikariDFACache anchoredCache;
   private final LaurikariDFACache findCache;
+
+  /**
+   * {@code findCache} state to seed a {@code findFrom(input, start)} scan from when {@code start >
+   * 0} — the anchor-blocked closure ({@link LaurikariCaptureNfaStep#reinjectClosure}), never state
+   * 0 (the anchor-<em>satisfied</em> initial closure, valid only when the scan truly begins at
+   * absolute position 0). Mirrors {@code PikeVMMatcher.checkAnchor}'s absolute-0 pinning: {@code
+   * ^}/{@code \A} must never fire at a {@code findFrom(start > 0)} offset.
+   */
+  private final int reinjectDfaState;
+
+  /**
+   * {@link #reinjectDfaState}'s "previous character was '\n'" variant (crosses {@code (?m)^}), or
+   * {@code -1} if the pattern has no {@code START_MULTILINE} anchor (then {@link #reinjectDfaState}
+   * covers every case).
+   */
+  private final int reinjectAfterNlDfaState;
 
   private PikeVMMatcher fallback;
   private long fallbackCount;
@@ -58,10 +85,20 @@ final class LaurikariDfaMatcher extends ReggieMatcher {
     this.patternText = pattern;
     this.groupCount = groupCount;
     this.step = new LaurikariCaptureNfaStep(nfa, groupCount);
-    LaurikariStepResult initial = LaurikariCaptureNfaStep.initial(nfa, step);
+    this.findStep = step::applyFind;
+    LaurikariStepResult initial = step.initialClosure();
+    LaurikariStepResult truncatedInitial = step.truncatedInitialClosure();
     int[] acceptIds = acceptStateIds(nfa);
     this.anchoredCache = new LaurikariDFACache(initial.states, initial.regs, acceptIds);
-    this.findCache = new LaurikariDFACache(initial.states, initial.regs, acceptIds);
+    this.findCache =
+        new LaurikariDFACache(truncatedInitial.states, truncatedInitial.regs, acceptIds);
+    LaurikariStepResult reinject = step.reinjectClosure();
+    this.reinjectDfaState = findCache.intern(reinject.states, reinject.regs);
+    LaurikariStepResult reinjectAfterNl = step.reinjectAfterNlClosure();
+    this.reinjectAfterNlDfaState =
+        reinjectAfterNl == null
+            ? -1
+            : findCache.intern(reinjectAfterNl.states, reinjectAfterNl.regs);
     markNativeRichApi();
   }
 
@@ -170,12 +207,21 @@ final class LaurikariDfaMatcher extends ReggieMatcher {
    *
    * <p>Reaching an accepting state does not end the scan: {@code LaurikariCaptureNfaStep}'s
    * priority-kill truncation already dropped every candidate strictly lower-priority than the
-   * accept just observed, but a strictly higher-priority candidate (e.g. a greedy loop's "keep
-   * going" branch) may still be alive and could still reach its own, preferred accept later —
-   * mirroring {@code PikeVMMatcher}'s "last write wins: each surviving override comes from a
-   * strictly higher-priority thread" comment. So: keep scanning while the subset is non-empty,
-   * remembering the most recent accept snapshot, and only return once every candidate has died or
-   * the input ends.
+   * accept just observed <em>within that step</em>, but a strictly higher-priority candidate (e.g.
+   * a greedy loop's "keep going" branch) may still be alive and could still reach its own,
+   * preferred accept later — mirroring {@code PikeVMMatcher}'s "last write wins: each surviving
+   * override comes from a strictly higher-priority thread" comment. So: keep scanning while the
+   * subset is non-empty, remembering the most recent accept snapshot, and only return once every
+   * candidate has died or the input ends.
+   *
+   * <p>That "last write wins" rule holds only <em>within</em> one still-alive thread's lineage: it
+   * does not license a later step's accept to overwrite an earlier, already-recorded {@code best}
+   * when the later accept comes from a freshly reinjected (necessarily later-starting, lowest-
+   * priority) candidate rather than a surviving continuation of the same or an earlier start — e.g.
+   * {@code a*} on {@code "b"} must report the empty match at position 0, not the empty match {@code
+   * applyFind}'s position-1 reinject also (correctly, for its own start) reaches. Guarded by
+   * comparing each candidate accept's own start (tag 0's absolute position): only a same-or-
+   * earlier start may overwrite {@code best}.
    *
    * @return absolute tag positions for the leftmost match at or after {@code start}, or {@code
    *     null} if none exists
@@ -184,34 +230,61 @@ final class LaurikariDfaMatcher extends ReggieMatcher {
     int clamped = Math.max(0, start);
     int len = input.length();
     if (clamped > len) return null;
-    int dfaState = 0;
+    int dfaState = startDfaStateFor(input, clamped);
+    if (dfaState == LaurikariDFACache.DEAD) {
+      // reinjectDfaState (or its after-'\n' variant) collapsed to DEAD when the anchor-blocked
+      // closure has no live states (e.g. a wholly start-anchored pattern reinjected at clamped >
+      // 0) -- no candidate can ever reach an accept, so indexing accepting[]/interning further is
+      // both unnecessary and unsafe (DEAD is a negative sentinel, not a real array index).
+      return null;
+    }
     int[] best = null;
     if (findCache.accepting[dfaState]) {
       // Zero-length match at the very start of the scan: no characters consumed yet.
       best = shiftByClamped(step.absolutePositions(findCache.acceptRegs(dfaState), 0), clamped);
     }
     for (int i = clamped; i < len; i++) {
-      int next = findCache.step(dfaState, input.charAt(i), step);
+      int next = findCache.step(dfaState, input.charAt(i), findStep);
       if (next == LaurikariDFACache.FALLBACK) {
         fallbackCount++;
         return best == null ? fallbackFind(input, i) : best;
       }
       if (next == LaurikariDFACache.DEAD) {
-        if (best != null) return best;
-        // No candidate has matched yet: a fresh one is reinjected at the very next character (see
-        // LaurikariCaptureNfaStep's applyFind), so resume scanning from a clean state.
-        dfaState = 0;
-        continue;
+        // Every applyFind() call reinjects a fresh (anchor-blocked) start candidate (see
+        // LaurikariCaptureNfaStep), so an empty result here means no candidate -- carried-forward
+        // or freshly reinjected -- can ever reach an accept from this point on; no restart needed.
+        return best;
       }
       dfaState = next;
       if (findCache.accepting[dfaState]) {
         // Ages are relative to this scan's own step count (i - clamped + 1 apply() calls so far),
         // not the input's absolute indexing -- shift back to absolute positions afterward.
         int[] acceptRegs = findCache.acceptRegs(dfaState);
-        best = shiftByClamped(step.absolutePositions(acceptRegs, i + 1 - clamped), clamped);
+        int[] candidate =
+            shiftByClamped(step.absolutePositions(acceptRegs, i + 1 - clamped), clamped);
+        // Only a same-or-earlier start may override an already-recorded match -- see this method's
+        // javadoc. A later start can only arise from a lower-priority reinjected candidate, never
+        // from a legitimate extension of the leftmost thread.
+        if (best == null || candidate[0] <= best[0]) {
+          best = candidate;
+        }
       }
     }
     return best;
+  }
+
+  /**
+   * @return the {@code findCache} state to begin a {@code findFrom(input, clamped)} scan from:
+   *     state 0 (anchor-satisfied) only when {@code clamped == 0}; otherwise the anchor-blocked
+   *     {@link #reinjectDfaState}, or its after-{@code '\n'} variant when the character immediately
+   *     before {@code clamped} is {@code '\n'} — see {@link #reinjectDfaState}'s javadoc.
+   */
+  private int startDfaStateFor(String input, int clamped) {
+    if (clamped == 0) return 0;
+    if (reinjectAfterNlDfaState >= 0 && input.charAt(clamped - 1) == '\n') {
+      return reinjectAfterNlDfaState;
+    }
+    return reinjectDfaState;
   }
 
   /** Adds {@code clamped} to every set ({@code >= 0}) entry of {@code relative}, in place. */

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDfaSupport.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariDfaSupport.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import com.datadoghq.reggie.codegen.automaton.NFA;
+
+/**
+ * Task 1.6b seam (doc/2026-07-10-tdfa-capture-engine-impl-plan.md §3): {@link LaurikariDfaMatcher}
+ * and {@link LaurikariEligibility} are package-private, so a JDK-oracle fuzz harness living in
+ * another module (e.g. {@code reggie-integration-tests}, which only depends on this module's main
+ * sourceset) cannot construct or gate one directly. This class is the minimal public crossing
+ * point: it runs the same eligibility gate {@link BitStateMatcher}/{@code RuntimeCompiler} would
+ * use in Phase 2, then upcasts the result to {@link ReggieMatcher} so the concrete engine stays
+ * hidden from callers.
+ */
+public final class LaurikariDfaSupport {
+
+  private LaurikariDfaSupport() {}
+
+  /**
+   * @return a {@link LaurikariDfaMatcher} over {@code nfa} if {@link
+   *     LaurikariEligibility#isEligible} accepts it, otherwise {@code null}.
+   */
+  public static ReggieMatcher tryCreate(
+      NFA nfa, String pattern, int groupCount, boolean usePosixLastMatch) {
+    if (!LaurikariEligibility.isEligible(nfa, usePosixLastMatch)) return null;
+    return new LaurikariDfaMatcher(nfa, pattern, groupCount);
+  }
+}

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariEligibility.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariEligibility.java
@@ -29,14 +29,17 @@ import java.util.Set;
  * {@link LaurikariDfaMatcher}, deciding whether an NFA is safe to route through the Laurikari
  * tagged-DFA capture engine rather than {@link PikeVMMatcher}'s thread simulation.
  *
- * <p><b>Scope note (deliberate narrowing, not an oversight):</b> anchor eligibility here mirrors
- * {@code PikeVMMatcher.findDfaEligible} exactly — only {@code START}/{@code STRING_START}/{@code
- * START_MULTILINE} are handleable, everything else ({@code \b}, {@code $}, {@code \Z}, {@code \z},
- * {@code (?m)$}) is rejected. Design doc §5 sketches a fuller per-step/per-accept {@code regionEnd}
- * check for end anchors and {@code \b}; that is deferred to a follow-up. This narrowing is strictly
- * conservative — it only shrinks the eligible set, never admits a pattern that wasn't already safe
- * — so patterns like {@code SQL_ANSI} (which uses {@code \b} and {@code $}) simply stay on {@code
- * PikeVMMatcher} exactly as they do today.
+ * <p><b>Anchor scope (TDFA Phase 2 end-anchor/{@code \b} extension):</b> every {@link
+ * NFA.AnchorType} except {@code RESET_MATCH} (untouched, always-passing) is handleable: the {@code
+ * START}-family ({@code START}/{@code STRING_START}/{@code START_MULTILINE}) via the
+ * build-time-precomputed anchor-blocked closures {@link LaurikariCaptureNfaStep} always used, and
+ * {@code END}/{@code STRING_END}/{@code STRING_END_ABSOLUTE}/{@code END_MULTILINE}/{@code
+ * WORD_BOUNDARY} via a live per-occurrence {@code PikeVMMatcher.checkAnchor} call inside {@code
+ * addClosure} (see that class). Only the {@code START}-family needs the "leading-only" structural
+ * restriction below — an anchor inside a loop can fire across empty iterations, which the
+ * subset/register model here cannot represent for anchors baked into precomputed closures — the 5
+ * new types are evaluated fresh on every occurrence, so no equivalent restriction applies to them
+ * (worked through adversarial pattern shapes; see the TDFA Phase 2 plan).
  */
 final class LaurikariEligibility {
 
@@ -58,14 +61,14 @@ final class LaurikariEligibility {
     for (NFA.NFAState s : nfa.getStates()) {
       if (s.assertionType != null || s.backrefCheck != null) return false;
       if (s.atomicEntry >= 0 || s.atomicExit >= 0) return false; // atomic groups not DFA-safe
-      // Handleable anchors: START (^), STRING_START (\A), START_MULTILINE ((?m)^).
-      // Everything else (\b, $, end-class) needs char/end context this engine doesn't supply yet.
+      // RESET_MATCH (\K) is the only anchor type with no explicit gate: PikeVMMatcher.checkAnchor
+      // always passes it, and LaurikariCaptureNfaStep.addClosure never special-cases it either.
       NFA.AnchorType a = s.anchor;
-      if (a != null
-          && a != NFA.AnchorType.START
-          && a != NFA.AnchorType.STRING_START
-          && a != NFA.AnchorType.START_MULTILINE) return false;
-      if (a != null) hasStartAnchor = true;
+      if (a == NFA.AnchorType.START
+          || a == NFA.AnchorType.STRING_START
+          || a == NFA.AnchorType.START_MULTILINE) {
+        hasStartAnchor = true;
+      }
     }
 
     // A capturing group's enter/exit marker sitting on an epsilon-only cycle (a loop body that can

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariEligibility.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariEligibility.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import com.datadoghq.reggie.codegen.automaton.NFA;
+import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Impl-plan Task 1.3 (doc/2026-07-10-tdfa-capture-engine-impl-plan.md §3): eligibility gate for
+ * {@link LaurikariDfaMatcher}, deciding whether an NFA is safe to route through the Laurikari
+ * tagged-DFA capture engine rather than {@link PikeVMMatcher}'s thread simulation.
+ *
+ * <p><b>Scope note (deliberate narrowing, not an oversight):</b> anchor eligibility here mirrors
+ * {@code PikeVMMatcher.findDfaEligible} exactly — only {@code START}/{@code STRING_START}/{@code
+ * START_MULTILINE} are handleable, everything else ({@code \b}, {@code $}, {@code \Z}, {@code \z},
+ * {@code (?m)$}) is rejected. Design doc §5 sketches a fuller per-step/per-accept {@code regionEnd}
+ * check for end anchors and {@code \b}; that is deferred to a follow-up. This narrowing is strictly
+ * conservative — it only shrinks the eligible set, never admits a pattern that wasn't already safe
+ * — so patterns like {@code SQL_ANSI} (which uses {@code \b} and {@code $}) simply stay on {@code
+ * PikeVMMatcher} exactly as they do today.
+ */
+final class LaurikariEligibility {
+
+  private LaurikariEligibility() {}
+
+  /**
+   * @param nfa the pattern's NFA
+   * @param usePosixLastMatch {@code PatternAnalyzer.MatchingStrategyResult.usePosixLastMatch} —
+   *     must be checked explicitly (design §5: neither the backref/lookaround/atomic-group checks
+   *     below nor the anchor check cover it). Excludes capture-ambiguous patterns like {@code
+   *     (a|a)+}, whose correct group spans require POSIX-last-match semantics, not the
+   *     leftmost-first priority this engine replicates.
+   * @return {@code true} if {@code nfa} is safe to route through {@link LaurikariDfaMatcher}
+   */
+  static boolean isEligible(NFA nfa, boolean usePosixLastMatch) {
+    if (usePosixLastMatch) return false;
+
+    boolean hasStartAnchor = false;
+    for (NFA.NFAState s : nfa.getStates()) {
+      if (s.assertionType != null || s.backrefCheck != null) return false;
+      if (s.atomicEntry >= 0 || s.atomicExit >= 0) return false; // atomic groups not DFA-safe
+      // Handleable anchors: START (^), STRING_START (\A), START_MULTILINE ((?m)^).
+      // Everything else (\b, $, end-class) needs char/end context this engine doesn't supply yet.
+      NFA.AnchorType a = s.anchor;
+      if (a != null
+          && a != NFA.AnchorType.START
+          && a != NFA.AnchorType.STRING_START
+          && a != NFA.AnchorType.START_MULTILINE) return false;
+      if (a != null) hasStartAnchor = true;
+    }
+    if (!hasStartAnchor) return true; // anchor-free: always eligible
+
+    // Anchored: sound only when every start anchor is leading — i.e. NOT reachable after
+    // consuming a character (an anchor inside a loop can fire across empty iterations, which the
+    // subset/register model here cannot represent) — same check as PikeVMMatcher.findDfaEligible.
+    Set<Integer> reached = new HashSet<>();
+    ArrayDeque<NFA.NFAState> q = new ArrayDeque<>();
+    for (NFA.NFAState s : nfa.getStates()) {
+      for (NFA.Transition t : s.getTransitions()) {
+        if (reached.add(t.target.id)) q.add(t.target);
+      }
+    }
+    while (!q.isEmpty()) {
+      NFA.NFAState s = q.poll();
+      NFA.AnchorType a = s.anchor;
+      if (a == NFA.AnchorType.START
+          || a == NFA.AnchorType.STRING_START
+          || a == NFA.AnchorType.START_MULTILINE) {
+        return false; // start anchor reachable after a consume -> not leading-only
+      }
+      for (NFA.NFAState e : s.getEpsilonTransitions()) {
+        if (reached.add(e.id)) q.add(e);
+      }
+    }
+    return true;
+  }
+}

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariEligibility.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariEligibility.java
@@ -34,12 +34,13 @@ import java.util.Set;
  * START}-family ({@code START}/{@code STRING_START}/{@code START_MULTILINE}) via the
  * build-time-precomputed anchor-blocked closures {@link LaurikariCaptureNfaStep} always used, and
  * {@code END}/{@code STRING_END}/{@code STRING_END_ABSOLUTE}/{@code END_MULTILINE}/{@code
- * WORD_BOUNDARY} via a live per-occurrence {@code PikeVMMatcher.checkAnchor} call inside {@code
- * addClosure} (see that class). Only the {@code START}-family needs the "leading-only" structural
- * restriction below — an anchor inside a loop can fire across empty iterations, which the
- * subset/register model here cannot represent for anchors baked into precomputed closures — the 5
- * new types are evaluated fresh on every occurrence, so no equivalent restriction applies to them
- * (worked through adversarial pattern shapes; see the TDFA Phase 2 plan).
+ * WORD_BOUNDARY}/{@code NON_WORD_BOUNDARY} via a live per-occurrence {@code
+ * PikeVMMatcher.checkAnchor} call inside {@code addClosure} (see that class). Only the {@code
+ * START}-family needs the "leading-only" structural restriction below — an anchor inside a loop can
+ * fire across empty iterations, which the subset/register model here cannot represent for anchors
+ * baked into precomputed closures — the 6 new types are evaluated fresh on every occurrence, so no
+ * equivalent restriction applies to them (worked through adversarial pattern shapes; see the TDFA
+ * Phase 2 plan).
  */
 final class LaurikariEligibility {
 

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariEligibility.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariEligibility.java
@@ -17,7 +17,11 @@ package com.datadoghq.reggie.runtime;
 
 import com.datadoghq.reggie.codegen.automaton.NFA;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -63,6 +67,16 @@ final class LaurikariEligibility {
           && a != NFA.AnchorType.START_MULTILINE) return false;
       if (a != null) hasStartAnchor = true;
     }
+
+    // A capturing group's enter/exit marker sitting on an epsilon-only cycle (a loop body that can
+    // match zero-width, looping back to itself entirely via epsilon transitions) is not DFA-safe:
+    // LaurikariCaptureNfaStep.addClosure's DFS marks a state visited on first arrival, so a cyclic
+    // re-arrival at the same state with a fresher (later) register vector — the extra zero-width
+    // loop iteration JDK/PCRE backtracking takes whenever it lets downstream content match — never
+    // propagates past that already-visited state. Conservative: rejects only patterns containing
+    // such a cycle, never admits anything not already eligible.
+    if (hasTaggedEpsilonCycle(nfa, LaurikariTagNumbering.tagOfState(nfa))) return false;
+
     if (!hasStartAnchor) return true; // anchor-free: always eligible
 
     // Anchored: sound only when every start anchor is leading — i.e. NOT reachable after
@@ -85,6 +99,152 @@ final class LaurikariEligibility {
       }
       for (NFA.NFAState e : s.getEpsilonTransitions()) {
         if (reached.add(e.id)) q.add(e);
+      }
+    }
+    return true;
+  }
+
+  /**
+   * @return {@code true} if the epsilon-only subgraph of {@code nfa} contains a cycle passing
+   *     through a real capturing-group marker state (tag {@code >= 2} — excludes tag {@code 0}/
+   *     {@code 1}, group 0's implicit whole-match open/close) whose enclosing loop construct is
+   *     <b>not</b> in tail position — i.e. more pattern content (a consuming transition) follows
+   *     the loop, which is exactly the shape where JDK/PCRE's extra zero-width loop iteration
+   *     (taken whenever it lets that downstream content match) is observable. A tagged epsilon
+   *     cycle with nothing but accept states downstream (e.g. {@code ((a)|())*} at the end of a
+   *     pattern) is unaffected — no downstream content means no observable difference in which
+   *     iteration's tag value wins.
+   *     <p>The "enclosing loop construct" is the epsilon cycle's full strongly-connected component
+   *     over ALL transitions (epsilon and consuming) — this also pulls in sibling loop-body
+   *     branches that consume characters before looping back (e.g. {@code (a)} in {@code
+   *     ((a)|())*}, which does loop back to the same states via a consuming transition, just not
+   *     within a single epsilon-only closure step), so a normal consuming branch of the same loop
+   *     isn't mistaken for downstream content.
+   */
+  private static boolean hasTaggedEpsilonCycle(NFA nfa, int[] tagOfState) {
+    int[] color = new int[tagOfState.length]; // 0 = white, 1 = gray (on stack), 2 = black (done)
+    List<Integer> stack = new ArrayList<>();
+    List<Set<Integer>> taggedCycles = new ArrayList<>();
+    for (NFA.NFAState s : nfa.getStates()) {
+      if (color[s.id] == 0) collectTaggedEpsilonCycles(s, color, stack, tagOfState, taggedCycles);
+    }
+    if (taggedCycles.isEmpty()) return false;
+
+    int[] sccOf = computeSccs(nfa);
+    for (Set<Integer> cycle : taggedCycles) {
+      int scc = sccOf[cycle.iterator().next()];
+      Set<Integer> sccMembers = new HashSet<>();
+      for (NFA.NFAState s : nfa.getStates()) {
+        if (sccOf[s.id] == scc) sccMembers.add(s.id);
+      }
+      if (!tailPositionOnly(nfa, sccMembers)) return true;
+    }
+    return false;
+  }
+
+  /** Tarjan's algorithm over both epsilon and consuming transitions. */
+  private static int[] computeSccs(NFA nfa) {
+    int n = nfa.getStates().size();
+    int[] index = new int[n];
+    int[] lowlink = new int[n];
+    int[] sccOf = new int[n];
+    boolean[] onStack = new boolean[n];
+    Arrays.fill(index, -1);
+    Deque<Integer> stack = new ArrayDeque<>();
+    int[] counter = {0};
+    int[] sccCounter = {0};
+    for (NFA.NFAState s : nfa.getStates()) {
+      if (index[s.id] == -1) {
+        tarjan(s, index, lowlink, onStack, stack, counter, sccCounter, sccOf);
+      }
+    }
+    return sccOf;
+  }
+
+  private static void tarjan(
+      NFA.NFAState v,
+      int[] index,
+      int[] lowlink,
+      boolean[] onStack,
+      Deque<Integer> stack,
+      int[] counter,
+      int[] sccCounter,
+      int[] sccOf) {
+    index[v.id] = counter[0];
+    lowlink[v.id] = counter[0];
+    counter[0]++;
+    stack.push(v.id);
+    onStack[v.id] = true;
+
+    List<NFA.NFAState> successors = new ArrayList<>(v.getEpsilonTransitions());
+    for (NFA.Transition t : v.getTransitions()) successors.add(t.target);
+
+    for (NFA.NFAState w : successors) {
+      if (index[w.id] == -1) {
+        tarjan(w, index, lowlink, onStack, stack, counter, sccCounter, sccOf);
+        lowlink[v.id] = Math.min(lowlink[v.id], lowlink[w.id]);
+      } else if (onStack[w.id]) {
+        lowlink[v.id] = Math.min(lowlink[v.id], index[w.id]);
+      }
+    }
+
+    if (lowlink[v.id] == index[v.id]) {
+      int scc = sccCounter[0]++;
+      int w;
+      do {
+        w = stack.pop();
+        onStack[w] = false;
+        sccOf[w] = scc;
+      } while (w != v.id);
+    }
+  }
+
+  private static void collectTaggedEpsilonCycles(
+      NFA.NFAState s, int[] color, List<Integer> stack, int[] tagOfState, List<Set<Integer>> out) {
+    color[s.id] = 1;
+    stack.add(s.id);
+    for (NFA.NFAState e : s.getEpsilonTransitions()) {
+      if (color[e.id] == 1) {
+        int idx = stack.indexOf(e.id); // back edge -> cycle is stack[idx..top]
+        Set<Integer> members = new HashSet<>();
+        boolean tagged = false;
+        for (int i = idx; i < stack.size(); i++) {
+          int id = stack.get(i);
+          members.add(id);
+          if (tagOfState[id] >= 2) tagged = true;
+        }
+        if (tagged) out.add(members);
+      } else if (color[e.id] == 0) {
+        collectTaggedEpsilonCycles(e, color, stack, tagOfState, out);
+      }
+    }
+    stack.remove(stack.size() - 1);
+    color[s.id] = 2;
+  }
+
+  /**
+   * @return {@code true} if nothing reachable from {@code sccMembers} (directly, or via epsilon
+   *     transitions leaving the SCC) has a consuming transition — i.e. the loop construct sits at
+   *     the tail of the pattern, so no downstream content's outcome can depend on which loop
+   *     iteration's register vector the cyclic closure kept.
+   */
+  private static boolean tailPositionOnly(NFA nfa, Set<Integer> sccMembers) {
+    Set<Integer> visited = new HashSet<>(sccMembers);
+    ArrayDeque<NFA.NFAState> queue = new ArrayDeque<>();
+    for (NFA.NFAState s : nfa.getStates()) {
+      if (!sccMembers.contains(s.id)) continue;
+      for (NFA.Transition t : s.getTransitions()) {
+        if (!sccMembers.contains(t.target.id)) return false; // consuming exit -> downstream content
+      }
+      for (NFA.NFAState e : s.getEpsilonTransitions()) {
+        if (!sccMembers.contains(e.id) && visited.add(e.id)) queue.add(e);
+      }
+    }
+    while (!queue.isEmpty()) {
+      NFA.NFAState s = queue.poll();
+      if (!s.getTransitions().isEmpty()) return false;
+      for (NFA.NFAState e : s.getEpsilonTransitions()) {
+        if (visited.add(e.id)) queue.add(e);
       }
     }
     return true;

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariNfaStep.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariNfaStep.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+/**
+ * One tagged-NFA step: given active (state, register-vector) pairs and a character, returns the
+ * next active state ids together with each one's winning register vector.
+ *
+ * <p>Generalized from Phase 0's single-scalar "age" register (design doc §4/§5) to a fixed-size
+ * {@code int[]} register file per state, per impl-plan Task 0.5.1: {@code curRegs[i]}/the returned
+ * {@code regs[i]} is now a vector, not a bare {@code int}. {@link LaurikariDFACache} itself is
+ * agnostic to what the vector holds or how ties are resolved — it only interns whatever {@code
+ * (states, regs)} pairs a step implementation returns. Two tie-break disciplines coexist across
+ * this codebase's step implementations, and each is free to pick whichever fits its own semantics:
+ *
+ * <ul>
+ *   <li><b>Value-based ("larger wins"):</b> Phase 0's find()-localization driver (see {@code
+ *       LaurikariDFACacheTest}/{@code LaurikariPhase0SpikeTest}/{@code LaurikariPhase0Benchmark})
+ *       wraps its scalar age in a length-1 vector and keeps comparing values directly — correct
+ *       because age is a genuine total order and doesn't need positional information. Callers using
+ *       this discipline may freely canonicalize {@code states}/{@code regs} order (e.g. sort
+ *       ascending by state id) since order carries no meaning for them.
+ *   <li><b>Priority-order ("whole-mapping discard"):</b> Phase 0.5's multi-tag capture checkpoint
+ *       (design §4) has no single scalar to compare when two arrivals reach the same target NFA
+ *       state, so it instead tracks explicit priority — mirroring {@code PikeVMMatcher.addThread}'s
+ *       insertion-order-through-epsilons DFS (first visit wins, later arrivals' entire register
+ *       mapping is discarded rather than merged tag-by-tag). For this discipline, {@code
+ *       curStates}'/{@code states}' array ORDER *is* the priority (index 0 = highest priority) and
+ *       must be preserved verbatim across steps — {@code LaurikariStateSetKey}'s order-sensitive
+ *       {@code equals}/{@code hashCode} (plain {@link java.util.Arrays#equals}, no sorting) exists
+ *       specifically so two different priority orderings of the same underlying subset intern as
+ *       distinct DFA states, matching classical tagged-DFA determinization.
+ * </ul>
+ *
+ * <p>Kept as a separate interface from {@link NfaStep} rather than changing NfaStep's shape,
+ * matching how {@link RejectDfaFactory}/{@link PikeVMMatcher} already keep multiple independent
+ * NfaStep-shaped lambdas per purpose.
+ */
+@FunctionalInterface
+interface LaurikariNfaStep {
+  /**
+   * @param curStates active NFA state ids (subset); order is meaningful or not, per the
+   *     implementation's tie-break discipline (see class javadoc)
+   * @param curRegs curStates[i]'s register vector
+   * @param c the character being consumed
+   * @return next active state ids and their per-state winning register vectors, after
+   *     epsilon-closure and this step's merge/tie-break rule
+   */
+  LaurikariStepResult apply(int[] curStates, int[][] curRegs, int c);
+}

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariNfaStep.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariNfaStep.java
@@ -48,6 +48,14 @@ package com.datadoghq.reggie.runtime;
  * <p>Kept as a separate interface from {@link NfaStep} rather than changing NfaStep's shape,
  * matching how {@link RejectDfaFactory}/{@link PikeVMMatcher} already keep multiple independent
  * NfaStep-shaped lambdas per purpose.
+ *
+ * <p><b>{@code input}/{@code pos}/{@code regionEnd}:</b> added to support end-anchor ({@code $},
+ * {@code \Z}, {@code \z}, {@code (?m)$}) and {@code \b} eligibility — those anchor types need the
+ * true input and absolute position to evaluate via {@link PikeVMMatcher#checkAnchor}, which
+ * ages-based registers alone don't supply. {@code pos} is the absolute position of the closure
+ * being built, i.e. the caller's "characters consumed so far" count <em>after</em> consuming {@code
+ * c} (see implementations for the exact convention). Step functions/drivers with no
+ * anchor-sensitive states (every Phase 0/0.5 driver today) simply ignore these three parameters.
  */
 @FunctionalInterface
 interface LaurikariNfaStep {
@@ -56,8 +64,14 @@ interface LaurikariNfaStep {
    *     implementation's tie-break discipline (see class javadoc)
    * @param curRegs curStates[i]'s register vector
    * @param c the character being consumed
+   * @param input the full input being scanned, for end-anchor/{@code \b} evaluation; may be ignored
+   *     by implementations with no anchor-sensitive states
+   * @param pos absolute position of the closure being built (after consuming {@code c})
+   * @param regionEnd the true end of the scan region (anchor-context {@code regionEnd}, never a
+   *     scan-bound optimization's narrower limit)
    * @return next active state ids and their per-state winning register vectors, after
    *     epsilon-closure and this step's merge/tie-break rule
    */
-  LaurikariStepResult apply(int[] curStates, int[][] curRegs, int c);
+  LaurikariStepResult apply(
+      int[] curStates, int[][] curRegs, int c, String input, int pos, int regionEnd);
 }

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariStateSetKey.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariStateSetKey.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import java.util.Arrays;
+
+/**
+ * Interning key for a Laurikari DFA state: an active NFA state subset together with each state's
+ * per-candidate register vector (see {@link LaurikariNfaStep} for what the registers hold).
+ *
+ * <p>Unlike {@link StateSetKey}, which hashes and compares only the state-id array, this key also
+ * hashes and compares the parallel register array: two Laurikari DFA states are the same only if
+ * both the subset and every state's register vector match, since a given subset with different
+ * registers represents different match-priority candidates.
+ *
+ * <p><b>Deliberately order-sensitive.</b> {@code states}/{@code regs} are compared with plain
+ * {@link Arrays#equals}/{@link Arrays#deepEquals} — no sorting, here or in the constructor. This
+ * matters for {@link LaurikariNfaStep}'s priority-order tie-break discipline (see its class
+ * javadoc): two different priority orderings of the same underlying subset are genuinely different
+ * DFA states there, since order-of-arrival is exactly what tag-vector comparison alone cannot
+ * recover. Phase 0's value-based ("larger age wins") driver instead canonicalizes to ascending
+ * state-id order before construction, since order carries no meaning for it — either convention
+ * works with this key as long as the caller who feeds it is consistent with itself.
+ */
+final class LaurikariStateSetKey {
+  private final int[] states;
+  private final int[][] regs;
+  private final int hash;
+
+  LaurikariStateSetKey(int[] states, int[][] regs) {
+    this.states = states;
+    this.regs = regs;
+    this.hash = 31 * Arrays.hashCode(states) + Arrays.deepHashCode(regs);
+  }
+
+  int[] getStates() {
+    return states;
+  }
+
+  int[][] getRegs() {
+    return regs;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof LaurikariStateSetKey)) return false;
+    LaurikariStateSetKey other = (LaurikariStateSetKey) o;
+    return Arrays.equals(states, other.states) && Arrays.deepEquals(regs, other.regs);
+  }
+
+  @Override
+  public int hashCode() {
+    return hash;
+  }
+}

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariStepResult.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariStepResult.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+/**
+ * Result of one {@link LaurikariNfaStep} application: the next active NFA state subset together
+ * with each state's per-candidate register vector (see {@link LaurikariNfaStep} for what the
+ * registers hold and, critically, whether {@code states}' array order carries meaning for a given
+ * step implementation).
+ *
+ * <p>{@code states} and {@code regs} are parallel arrays: {@code regs[i]} is the winning register
+ * vector for {@code states[i]}, after whatever closure/merge tie-break the producing {@link
+ * LaurikariNfaStep} implements. No defensive copy is taken, matching {@link StateSetKey}'s
+ * convention of trusting the caller to hand over arrays it will not mutate afterward.
+ */
+final class LaurikariStepResult {
+  final int[] states;
+  final int[][] regs; // regs[i] is states[i]'s register vector
+
+  LaurikariStepResult(int[] states, int[][] regs) {
+    this.states = states;
+    this.regs = regs;
+  }
+}

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariTagNumbering.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LaurikariTagNumbering.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import com.datadoghq.reggie.codegen.automaton.NFA;
+import java.util.Arrays;
+
+/**
+ * Impl-plan Task 1.1 (doc/2026-07-10-tdfa-capture-engine-impl-plan.md §3): derives the full {@code
+ * 2 * (groupCount + 1)} tag numbering from an {@link NFA}, generalizing the hand-picked {@code
+ * tagSpecs} tables {@code LaurikariPhase05Test} used for exactly 2-3 checkpoint patterns into an
+ * automatic, pattern-independent mechanism driven directly by {@link NFA.NFAState#enterGroup}/
+ * {@link NFA.NFAState#exitGroup}.
+ *
+ * <p><b>Slot convention</b> — matches {@code PikeVMMatcher.java}'s existing {@code slotCount = 2 *
+ * (groupCount + 1)} layout exactly (see {@code PikeVMMatcher.updateCaptures}, which writes {@code
+ * copy[2 * state.enterGroup] = pos} / {@code copy[2 * state.exitGroup + 1] = pos}): tag {@code 2*g}
+ * is group {@code g}'s open, tag {@code 2*g+1} is group {@code g}'s close, for {@code g} in {@code
+ * 0..groupCount} inclusive (group 0 is the implicit whole-match group).
+ *
+ * <p><b>Group 0 is not represented by any {@code enterGroup}/{@code exitGroup} NFA state</b> —
+ * confirmed against {@code ThompsonBuilder.visitGroup}, which only ever assigns {@code
+ * node.groupNumber >= 1} (group 0 is reserved for the whole match and is never wrapped in a
+ * dedicated marker state). {@code PikeVMMatcher} itself handles group 0's two slots outside {@code
+ * addThread}/{@code updateCaptures} entirely: slot 0 is seeded directly by the caller when a thread
+ * is created (e.g. {@code initClist}'s {@code init[0] = pos}), and slot 1 is written directly by
+ * the search loop the moment an accept state is reached (e.g. {@code caps[1] = pos} in {@code
+ * runMatchResult}), never through a state's {@code enterGroup}/{@code exitGroup} field.
+ *
+ * <p>This class mirrors that split for tag numbering purposes: {@link #tagOfState} maps every real
+ * {@code enterGroup}/{@code exitGroup} marker state to its {@code 2*g}/{@code 2*g+1} tag, AND
+ * additionally maps every NFA accept state to tag {@code 1} (group 0's close) — the tag-numbering
+ * equivalent of "write slot 1 the moment an accept state is reached." Group 0's open (tag 0) has no
+ * per-state marker at all (by construction there is exactly one match attempt in an anchored
+ * closure, so tag 0 is seeded once at closure-start time by the caller, exactly as {@code
+ * initClist} seeds slot 0) — callers building an initial register file must set tag 0 themselves;
+ * this class does not (and structurally cannot) discover a "group 0 open" state to map.
+ */
+final class LaurikariTagNumbering {
+
+  private LaurikariTagNumbering() {}
+
+  /**
+   * @return {@code 2 * (groupCount + 1)}, the number of capture-tag registers for this pattern.
+   */
+  static int tagCount(int groupCount) {
+    return 2 * (groupCount + 1);
+  }
+
+  /**
+   * @return {@code tagOfState[id]}: the tag index ({@code 2*g} or {@code 2*g+1}) carried by NFA
+   *     state {@code id}, or {@code -1} if state {@code id} carries no tag. Accept states are
+   *     additionally mapped to tag {@code 1} (group 0's close) unless they already carry a real
+   *     {@code enterGroup}/{@code exitGroup} tag (not expected in practice per {@code
+   *     ThompsonBuilder}'s dedicated-marker-state construction, but resolved without overwriting a
+   *     real group tag if it ever occurs).
+   */
+  static int[] tagOfState(NFA nfa) {
+    int stateCount = nfa.getStates().size();
+    int[] tagOfState = new int[stateCount];
+    Arrays.fill(tagOfState, -1);
+    for (NFA.NFAState s : nfa.getStates()) {
+      if (s.enterGroup != null) {
+        tagOfState[s.id] = 2 * s.enterGroup;
+      }
+      if (s.exitGroup != null) {
+        tagOfState[s.id] = 2 * s.exitGroup + 1;
+      }
+    }
+    for (NFA.NFAState accept : nfa.getAcceptStates()) {
+      if (tagOfState[accept.id] < 0) {
+        tagOfState[accept.id] = 1; // group 0's close, the "caps[1] = pos at accept" equivalent
+      }
+    }
+    return tagOfState;
+  }
+}

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
@@ -1309,10 +1309,10 @@ public final class PikeVMMatcher extends ReggieMatcher {
   // -------------------------------------------------------------------------
 
   /**
-   * ASCII word-char predicate used by {@code \b}/{@code \B} — matches {@code CharSet.WORD}
-   * ({@code [A-Za-z0-9_]}), the same word-char definition {@code \w} and the generated {@code
-   * isWordChar} helpers use elsewhere in this codebase (unlike {@code Character.isLetterOrDigit},
-   * which admits Unicode letters/digits and excludes {@code '_'}).
+   * ASCII word-char predicate used by {@code \b}/{@code \B} — matches {@code CharSet.WORD} ({@code
+   * [A-Za-z0-9_]}), the same word-char definition {@code \w} and the generated {@code isWordChar}
+   * helpers use elsewhere in this codebase (unlike {@code Character.isLetterOrDigit}, which admits
+   * Unicode letters/digits and excludes {@code '_'}).
    */
   static boolean isWordChar(char c) {
     return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_';

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
@@ -1308,6 +1308,16 @@ public final class PikeVMMatcher extends ReggieMatcher {
   // Anchor checking
   // -------------------------------------------------------------------------
 
+  /**
+   * ASCII word-char predicate used by {@code \b}/{@code \B} — matches {@code CharSet.WORD}
+   * ({@code [A-Za-z0-9_]}), the same word-char definition {@code \w} and the generated {@code
+   * isWordChar} helpers use elsewhere in this codebase (unlike {@code Character.isLetterOrDigit},
+   * which admits Unicode letters/digits and excludes {@code '_'}).
+   */
+  static boolean isWordChar(char c) {
+    return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_';
+  }
+
   static boolean checkAnchor(
       NFA.AnchorType anchor, String input, int pos, int regionStart, int regionEnd) {
     switch (anchor) {
@@ -1338,14 +1348,14 @@ public final class PikeVMMatcher extends ReggieMatcher {
         return pos == regionEnd || (pos < regionEnd && input.charAt(pos) == '\n');
       case WORD_BOUNDARY:
         {
-          boolean beforeWord = pos > 0 && Character.isLetterOrDigit(input.charAt(pos - 1));
-          boolean afterWord = pos < regionEnd && Character.isLetterOrDigit(input.charAt(pos));
+          boolean beforeWord = pos > 0 && isWordChar(input.charAt(pos - 1));
+          boolean afterWord = pos < regionEnd && isWordChar(input.charAt(pos));
           return beforeWord != afterWord;
         }
       case NON_WORD_BOUNDARY:
         {
-          boolean beforeWord = pos > 0 && Character.isLetterOrDigit(input.charAt(pos - 1));
-          boolean afterWord = pos < regionEnd && Character.isLetterOrDigit(input.charAt(pos));
+          boolean beforeWord = pos > 0 && isWordChar(input.charAt(pos - 1));
+          boolean afterWord = pos < regionEnd && isWordChar(input.charAt(pos));
           return beforeWord == afterWord;
         }
       case RESET_MATCH:

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/PikeVMMatcher.java
@@ -1342,6 +1342,12 @@ public final class PikeVMMatcher extends ReggieMatcher {
           boolean afterWord = pos < regionEnd && Character.isLetterOrDigit(input.charAt(pos));
           return beforeWord != afterWord;
         }
+      case NON_WORD_BOUNDARY:
+        {
+          boolean beforeWord = pos > 0 && Character.isLetterOrDigit(input.charAt(pos - 1));
+          boolean afterWord = pos < regionEnd && Character.isLetterOrDigit(input.charAt(pos));
+          return beforeWord == afterWord;
+        }
       case RESET_MATCH:
         return true;
       default:

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/RuntimeCompiler.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/RuntimeCompiler.java
@@ -181,14 +181,21 @@ public class RuntimeCompiler {
   private static final class BitStateEntry {
     final NFA nfa;
     final Map<String, Integer> nameMap;
+    final boolean usePosixLastMatch;
 
-    BitStateEntry(NFA nfa, Map<String, Integer> nameMap) {
+    BitStateEntry(NFA nfa, Map<String, Integer> nameMap, boolean usePosixLastMatch) {
       this.nfa = nfa;
       this.nameMap = nameMap;
+      this.usePosixLastMatch = usePosixLastMatch;
     }
 
     ReggieMatcher newMatcher(String pattern) {
-      ReggieMatcher m = new BitStateMatcher(nfa, pattern);
+      // Phase 2 Task 2.1 (Option A, doc/2026-07-10-tdfa-capture-engine-impl-plan.md §4): try the
+      // TDFA capture engine before BitStateMatcher's own BUDGET_CELLS-overflow call falls all the
+      // way through to PikeVMMatcher. null when LaurikariEligibility rejects this pattern.
+      ReggieMatcher laurikari =
+          LaurikariDfaSupport.tryCreate(nfa, pattern, nfa.getGroupCount(), usePosixLastMatch);
+      ReggieMatcher m = new BitStateMatcher(nfa, pattern, laurikari);
       if (!nameMap.isEmpty()) {
         m.setNameToIndex(nameMap);
         if (!m.embedsNameMap()) {
@@ -574,7 +581,8 @@ public class RuntimeCompiler {
           return fallbackOrThrow(pattern, bitStateFallbackReason, nameMap, options);
         }
         NFA bitStateNfa = result.lazyNfa ? new ThompsonBuilder(true).build(ast, groupCount) : nfa;
-        BITSTATE_NFA_CACHE.putIfAbsent(cacheKey, new BitStateEntry(bitStateNfa, nameMap));
+        BITSTATE_NFA_CACHE.putIfAbsent(
+            cacheKey, new BitStateEntry(bitStateNfa, nameMap, result.usePosixLastMatch));
         return BITSTATE_NFA_CACHE.get(cacheKey).newMatcher(pattern);
       }
 

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/RuntimeCompiler.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/RuntimeCompiler.java
@@ -197,6 +197,9 @@ public class RuntimeCompiler {
           LaurikariDfaSupport.tryCreate(nfa, pattern, nfa.getGroupCount(), usePosixLastMatch);
       ReggieMatcher m = new BitStateMatcher(nfa, pattern, laurikari);
       if (!nameMap.isEmpty()) {
+        if (laurikari != null) {
+          laurikari.setNameToIndex(nameMap);
+        }
         m.setNameToIndex(nameMap);
         if (!m.embedsNameMap()) {
           m = new NameEnrichingMatcher(m);

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/RuntimeCompiler.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/RuntimeCompiler.java
@@ -1072,6 +1072,9 @@ public class RuntimeCompiler {
             (PatternAnalyzer.FixedSequenceInfo) result.patternInfo;
         FixedSequenceBytecodeGenerator fixedGen =
             new FixedSequenceBytecodeGenerator(fixedInfo, nfa.getGroupCount());
+        if (fixedGen.needsBoundaryHelpers()) {
+          fixedGen.generateBoundaryHelperMethods(cw, "com/datadoghq/reggie/runtime/" + className);
+        }
         fixedGen.generateMatchesMethod(cw, "com/datadoghq/reggie/runtime/" + className);
         fixedGen.generateFindMethod(cw, "com/datadoghq/reggie/runtime/" + className);
         fixedGen.generateFindFromMethod(cw, "com/datadoghq/reggie/runtime/" + className);

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/BackrefBacktrackMatcherTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/BackrefBacktrackMatcherTest.java
@@ -51,6 +51,9 @@ public class BackrefBacktrackMatcherTest {
     {"(ab)\\1", "abab"},
     {"(a)(b)\\2\\1", "abba"},
     {"(.)\\1", "zz"},
+    {"(a+)\\1\\B", "aaaab"},
+    {"(a+)\\1\\B", "aaaa"},
+    {"(a+)\\1\\b", "aaaa"},
   };
 
   @Test

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/BitStateMatcherTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/BitStateMatcherTest.java
@@ -435,6 +435,44 @@ class BitStateMatcherTest {
   }
 
   @Test
+  void matchesOversizedInputWithEligiblePatternRoutesToLaurikariNotPikeVm() throws Exception {
+    String pat = "(a)(b)*c";
+    BitStateMatcher bitState = buildWithLaurikari(pat);
+    String input = oversizedInput();
+
+    assertEquals(0L, bitState.laurikariCount());
+    assertTrue(bitState.matches(input));
+    assertEquals(1L, bitState.laurikariCount());
+    assertEquals(0L, bitState.fallbackCount());
+  }
+
+  @Test
+  void findFromOversizedInputWithEligiblePatternRoutesToLaurikariNotPikeVm() throws Exception {
+    String pat = "(a)(b)*c";
+    BitStateMatcher bitState = buildWithLaurikari(pat);
+    String input = oversizedInput();
+
+    assertEquals(0L, bitState.laurikariCount());
+    assertEquals(0, bitState.findFrom(input, 0));
+    assertEquals(1L, bitState.laurikariCount());
+    assertEquals(0L, bitState.fallbackCount());
+  }
+
+  @Test
+  void findMatchFromOversizedInputWithEligiblePatternRoutesToLaurikariNotPikeVm() throws Exception {
+    String pat = "(a)(b)*c";
+    BitStateMatcher bitState = buildWithLaurikari(pat);
+    String input = oversizedInput();
+
+    assertEquals(0L, bitState.laurikariCount());
+    MatchResult result = bitState.findMatchFrom(input, 0);
+    assertNotNull(result);
+    assertEquals(0, result.start(0));
+    assertEquals(1L, bitState.laurikariCount());
+    assertEquals(0L, bitState.fallbackCount());
+  }
+
+  @Test
   void nullLaurikariPreservesExistingFallbackBehavior() throws Exception {
     // The 2-arg constructor (used by every pre-Phase-2 call site) must behave identically to
     // before: laurikari is always null, so BUDGET_CELLS overflow always goes straight to

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/BitStateMatcherTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/BitStateMatcherTest.java
@@ -388,6 +388,67 @@ class BitStateMatcherTest {
     assertEquals(1L, bitState.fallbackCount());
   }
 
+  // -------------------------------------------------------------------------
+  // Laurikari wiring (Phase 2 Task 2.1, Option A, doc/2026-07-10-tdfa-capture-engine-impl-plan.md)
+  // -------------------------------------------------------------------------
+
+  private static BitStateMatcher buildWithLaurikari(String pat) throws Exception {
+    RegexParser parser = new RegexParser();
+    RegexNode ast = parser.parse(pat);
+    ThompsonBuilder builder = new ThompsonBuilder();
+    NFA nfa = builder.build(ast, countGroups(pat));
+    ReggieMatcher laurikari =
+        LaurikariDfaSupport.tryCreate(nfa, pat, countGroups(pat), /* usePosixLastMatch= */ false);
+    assertNotNull(laurikari, pat + " expected to be LaurikariEligibility-eligible");
+    return new BitStateMatcher(nfa, pat, laurikari);
+  }
+
+  @Test
+  void oversizedSearchWithEligiblePatternRoutesToLaurikariNotPikeVm() throws Exception {
+    String pat = "(a)(b)*c";
+    BitStateMatcher bitState = buildWithLaurikari(pat);
+    java.util.regex.Matcher oracle = jdkMatch(pat, oversizedInput());
+
+    assertEquals(0L, bitState.laurikariCount());
+    assertEquals(0L, bitState.fallbackCount());
+    MatchResult actual = bitState.match(oversizedInput());
+    assertNotNull(oracle);
+    assertNotNull(actual);
+    assertEquals(oracle.start(0), actual.start(0));
+    assertEquals(oracle.end(0), actual.end(0));
+    assertEquals(1L, bitState.laurikariCount());
+    assertEquals(0L, bitState.fallbackCount());
+  }
+
+  @Test
+  void findOversizedInputWithEligiblePatternRoutesToLaurikariNotPikeVm() throws Exception {
+    String pat = "(a)(b)*c";
+    BitStateMatcher bitState = buildWithLaurikari(pat);
+    String input = oversizedInput();
+
+    assertEquals(0L, bitState.laurikariCount());
+    assertTrue(bitState.find(input));
+    assertEquals(1L, bitState.laurikariCount());
+    assertEquals(0L, bitState.fallbackCount());
+  }
+
+  @Test
+  void nullLaurikariPreservesExistingFallbackBehavior() throws Exception {
+    // The 2-arg constructor (used by every pre-Phase-2 call site) must behave identically to
+    // before: laurikari is always null, so BUDGET_CELLS overflow always goes straight to
+    // PikeVMMatcher, never LaurikariDfaMatcher.
+    RegexParser parser = new RegexParser();
+    String pat = "(a)(b)*c";
+    RegexNode ast = parser.parse(pat);
+    ThompsonBuilder builder = new ThompsonBuilder();
+    NFA nfa = builder.build(ast, countGroups(pat));
+    BitStateMatcher bitState = new BitStateMatcher(nfa, pat);
+
+    assertTrue(bitState.find(oversizedInput()));
+    assertEquals(0L, bitState.laurikariCount());
+    assertEquals(1L, bitState.fallbackCount());
+  }
+
   @Test
   void matchesBoundedOversizedRegionDelegatesToPikeVmAndIncrementsFallbackCounter()
       throws Exception {

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/BitStateMatcherTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/BitStateMatcherTest.java
@@ -17,10 +17,12 @@ package com.datadoghq.reggie.runtime;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.datadoghq.reggie.ReggieOptions;
 import com.datadoghq.reggie.codegen.ast.RegexNode;
 import com.datadoghq.reggie.codegen.automaton.NFA;
 import com.datadoghq.reggie.codegen.automaton.ThompsonBuilder;
 import com.datadoghq.reggie.codegen.parsing.RegexParser;
+import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -447,6 +449,62 @@ class BitStateMatcherTest {
     assertTrue(bitState.find(oversizedInput()));
     assertEquals(0L, bitState.laurikariCount());
     assertEquals(1L, bitState.fallbackCount());
+  }
+
+  // -------------------------------------------------------------------------
+  // Named-group resolution across the fallback/laurikari paths (issue #106)
+  // -------------------------------------------------------------------------
+
+  @Test
+  void oversizedMatchWithNamedGroupResolvesGroupNameViaPikeVmFallback() throws Exception {
+    RegexParser parser = new RegexParser();
+    String pat = "(?<num>a)(b)*c";
+    RegexNode ast = parser.parse(pat);
+    ThompsonBuilder builder = new ThompsonBuilder();
+    NFA nfa = builder.build(ast, countGroups(pat));
+    BitStateMatcher bitState = new BitStateMatcher(nfa, pat);
+    bitState.setNameToIndex(Collections.singletonMap("num", 1));
+
+    assertEquals(0L, bitState.fallbackCount());
+    MatchResult result = bitState.match(oversizedInput());
+    assertNotNull(result);
+    assertEquals(1L, bitState.fallbackCount());
+    assertEquals(0, result.start("num"));
+    assertEquals(1, result.end("num"));
+  }
+
+  @Test
+  void oversizedMatchWithNamedGroupResolvesGroupNameViaLaurikari() throws Exception {
+    String pat = "(?<num>a)(b)*c";
+    RegexParser parser = new RegexParser();
+    RegexNode ast = parser.parse(pat);
+    ThompsonBuilder builder = new ThompsonBuilder();
+    NFA nfa = builder.build(ast, countGroups(pat));
+    ReggieMatcher laurikari =
+        LaurikariDfaSupport.tryCreate(nfa, pat, countGroups(pat), /* usePosixLastMatch= */ false);
+    assertNotNull(laurikari, pat + " expected to be LaurikariEligibility-eligible");
+    laurikari.setNameToIndex(Collections.singletonMap("num", 1));
+    BitStateMatcher bitState = new BitStateMatcher(nfa, pat, laurikari);
+    bitState.setNameToIndex(Collections.singletonMap("num", 1));
+
+    assertEquals(0L, bitState.laurikariCount());
+    MatchResult result = bitState.match(oversizedInput());
+    assertNotNull(result);
+    assertEquals(1L, bitState.laurikariCount());
+    assertEquals(0, result.start("num"));
+    assertEquals(1, result.end("num"));
+  }
+
+  @Test
+  void oversizedMatchWithNamedGroupResolvesGroupNameEndToEndViaRuntimeCompiler() throws Exception {
+    ReggieMatcher m =
+        (ReggieMatcher)
+            RuntimeCompiler.compile(
+                "(?<num>a)(b)*c", ReggieOptions.builder().allowJdkFallback().build());
+    MatchResult result = m.match(oversizedInput());
+    assertNotNull(result);
+    assertEquals(0, result.start("num"));
+    assertEquals(1, result.end("num"));
   }
 
   @Test

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariAnchorLookaheadFuzzTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariAnchorLookaheadFuzzTest.java
@@ -239,11 +239,8 @@ class LaurikariAnchorLookaheadFuzzTest {
 
   @Test
   void wordBoundaryDigits_variousPositions() throws Exception {
-    // Each input gets a FRESH matcher pair: reusing one findCache-backed LaurikariDfaMatcher
-    // across many distinct inputs runs into the separately-documented pre-existing within-call
-    // cache-pollution bug (see anchorCachePollutionWithinSingleFindCall_knownPreExistingBug
-    // below), which is orthogonal to what this test verifies -- correctness of the single-call
-    // anchor fan-out.
+    // Each input gets a FRESH matcher pair to isolate this test's target -- correctness of the
+    // single-call anchor fan-out -- from any cross-input cache-reuse effects.
     String pattern = "\\b\\d+";
     int groupCount = 0;
 
@@ -319,11 +316,7 @@ class LaurikariAnchorLookaheadFuzzTest {
     // regionEnd-2.
     String[] inputs = {
       "", "1", "12", "123", "a", "a1", "a12", "a123", "1a", // digit not at true end -> no match
-      "12a",
-      // NOTE: "a1a1" is deliberately excluded here -- it trips the pre-existing, unrelated
-      // within-call anchor-cache-pollution bug documented and reproduced in
-      // anchorCachePollutionWithinSingleFindCall_knownPreExistingBug() below, which is not a
-      // regression from the fan-out fix under test in this method.
+      "12a", "a1a1",
     };
     for (String input : inputs) {
       LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
@@ -450,42 +443,32 @@ class LaurikariAnchorLookaheadFuzzTest {
   }
 
   // ==============================================================================================
-  // KNOWN, PRE-EXISTING BUG (not introduced by the uncommitted lookahead-class fan-out fix; the
-  // caching-decision gate below is untouched by that diff and traces back to commit 274488d):
-  // position-scoped cache pollution in LaurikariDFACache's findCache.
+  // FIXED (issue #108): position-scoped cache pollution in LaurikariDFACache's findCache.
   //
-  // Root cause: LaurikariDFACache.isAnchorSensitive(int[] states) only checks whether an
-  // anchor-bearing NFA state is already a MEMBER of a DFA state's own subset. It does not check
-  // whether an anchor-bearing state becomes reachable one step later via a single consuming
-  // transition + epsilon-closure. So a transition out of a state that is NOT flagged
-  // anchorSensitive can, on its first evaluation, resolve through a live checkAnchor(...) call
-  // that is specific to that call's (pos, regionEnd) -- and LaurikariDFACache.lookupOrCompute's
-  // caching gate (`if (id != FALLBACK && !anchorSensitive[state]) cacheEntry(state, c, id);`)
-  // unconditionally memoizes that position-specific outcome, keyed only on (state, c).
+  // Root cause: LaurikariDFACache.lookupOrCompute's caching gate used to check only whether the
+  // SOURCE state of a transition was anchorSensitive. It did not check whether the transition's
+  // DESTINATION subset newly touches an anchor-bearing state one step later via a single
+  // consuming transition + epsilon-closure. So a transition out of a state that was NOT flagged
+  // anchorSensitive could, on its first evaluation, resolve through a live checkAnchor(...) call
+  // that is specific to that call's (pos, regionEnd) -- and the caching gate unconditionally
+  // memoized that position-specific outcome, keyed only on (state, c).
   //
-  // This is more severe than "reuse the matcher across two find() calls": LaurikariDfaMatcher's
-  // self-anchoring find() ALREADY sweeps every start position within ONE call, reinjecting start
+  // This was more severe than "reuse the matcher across two find() calls": LaurikariDfaMatcher's
+  // self-anchoring find() already sweeps every start position within ONE call, reinjecting start
   // threads into the SAME findCache instance at each position. So a single find() call over a
-  // multi-character input can self-pollute: an anchor outcome computed live at an early position
-  // gets cached under (state, c) and then wrongly reused at a later position with a different
-  // pos/regionEnd, even though no second find() call or matcher reuse was involved.
+  // multi-character input could self-pollute: an anchor outcome computed live at an early
+  // position got cached under (state, c) and then wrongly reused at a later position with a
+  // different pos/regionEnd, even though no second find() call or matcher reuse was involved.
   //
-  // Minimal repro (single find() call, brand-new matcher, no reuse across calls): pattern
-  // "\d+$", input "a1a1". Oracle (PikeVMMatcher, and java.util.regex) correctly finds a match --
-  // the trailing "1" at index 3 satisfies \d+$. A fresh LaurikariDfaMatcher's find("a1a1")
-  // incorrectly returns false, because computing the earlier "1" at index 1 (followed by "a",
-  // which fails the END anchor) caches an outcome that gets wrongly reused when the scan later
-  // reaches the trailing "1" at index 3.
-  //
-  // This predates today's fix and is orthogonal to it -- every other test in this file
-  // deliberately uses a fresh LaurikariDfaMatcher per input, but that only isolates ACROSS calls;
-  // it cannot isolate the within-a-single-call self-pollution this repro demonstrates. Per task
-  // instructions this bug is described here, not fixed; LaurikariDFACache.java is not modified by
-  // this change.
+  // Fix: lookupOrCompute's caching gate additionally checks anchorSensitive[id] (the destination
+  // state), not just anchorSensitive[state] (the source) -- see LaurikariDFACache.lookupOrCompute
+  // and the anchorSensitive field javadoc for the correctness argument (addClosure adds an
+  // anchor-bearing NFA state to a closure unconditionally the moment it becomes epsilon-reachable,
+  // so this is a purely structural, position-independent check).
   // ==============================================================================================
 
   @Test
-  void anchorCachePollutionWithinSingleFindCall_knownPreExistingBug() throws Exception {
+  void anchorCachePollutionWithinSingleFindCall() throws Exception {
     String pattern = "\\d+$";
     int groupCount = 0;
     LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
@@ -495,16 +478,9 @@ class LaurikariAnchorLookaheadFuzzTest {
     // oracle correctly matches the trailing digit "1" at index 3.
     assertTrue(oracle.find("a1a1"), "sanity: oracle must find \\d+$ in \"a1a1\" (trailing '1')");
 
-    // Documents today's ACTUAL (buggy) behavior: the Laurikari engine wrongly reports no match,
-    // because the live END-anchor check performed while scanning position 1 ("1" followed by
-    // "a") gets cached under (state, 'a') and is wrongly replayed when the scan reaches position
-    // 3 ("1" followed by end-of-input). If this assertion ever starts failing because the bug
-    // got fixed, update/remove this test rather than reintroducing the workaround.
-    assertEquals(
-        false,
+    assertTrue(
         laurikari.find("a1a1"),
-        "documents current buggy behavior: single find() call wrongly misses the trailing digit"
-            + " match in \"a1a1\" due to within-call anchor-cache pollution (oracle-correct"
-            + " answer is true)");
+        "single find() call must find the trailing digit match in \"a1a1\" (issue #108"
+            + " regression)");
   }
 }

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariAnchorLookaheadFuzzTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariAnchorLookaheadFuzzTest.java
@@ -366,9 +366,9 @@ class LaurikariAnchorLookaheadFuzzTest {
       "a1\nb2\nc3",
       "a1\r\nb2\r\nc3",
       "a1\rb2\rc3",
-      "1 ", // LINE SEPARATOR
-      "1 ", // PARAGRAPH SEPARATOR
-      "1", // NEL
+      "1\u2028", // LINE SEPARATOR
+      "1\u2029", // PARAGRAPH SEPARATOR
+      "1\u0085", // NEL
     };
     for (String input : inputs) {
       LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariAnchorLookaheadFuzzTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariAnchorLookaheadFuzzTest.java
@@ -1,0 +1,510 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datadoghq.reggie.codegen.ast.RegexNode;
+import com.datadoghq.reggie.codegen.automaton.NFA;
+import com.datadoghq.reggie.codegen.automaton.ThompsonBuilder;
+import com.datadoghq.reggie.codegen.parsing.RegexParser;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Differential-fuzz verification for the uncommitted "lookahead-class fan-out" fix in {@link
+ * LaurikariDFACache} (doc/2026-07-14-laurikari-anchor-caching-fix-design.md), which restores {@code
+ * find()}-mode caching for the 5 anchor types {@code LaurikariEligibility} admits ({@code END},
+ * {@code STRING_END}, {@code STRING_END_ABSOLUTE}, {@code END_MULTILINE}, {@code WORD_BOUNDARY}).
+ *
+ * <p>Motivation: a JMH re-run after the fix landed showed the Laurikari {@code find()} path on the
+ * three SQL-tokenizer benchmark patterns running far faster than its pre-Phase-2 baseline (~15-16x
+ * RE2J vs. the historical ~0.83-0.86x) — implausible enough to warrant checking whether the fan-out
+ * is silently skipping real work rather than genuinely caching it. This test asserts exact
+ * agreement between {@link LaurikariDfaMatcher} and the {@link PikeVMMatcher} oracle for:
+ *
+ * <ul>
+ *   <li>the exact SQL_ANSI/SQL_MYSQL/SQL_POSTGRESQL patterns from {@code IastRegexpBenchmark}, at
+ *       both the benchmark's LONG-scale match and no-match inputs;
+ *   <li>hand-crafted adversarial shapes covering {@code \b\d+}, {@code (?m)...--.*$}, boundary
+ *       positions within {@code ANCHOR_LOOKAHEAD_LIVE_MARGIN} (2 chars) of the region end, and
+ *       {@code \r}/{@code \n}/{@code \r\n} combinations near end-of-input and {@code (?m)$}.
+ * </ul>
+ */
+class LaurikariAnchorLookaheadFuzzTest {
+
+  // --- exact benchmark pattern strings, copied verbatim from IastRegexpBenchmark --------------
+
+  private static final String SQL_ANSI =
+      "(?i)(?m)[-+]?(?:x'[0-9a-f]+'|0x[0-9a-f]+|b'[0-9a-f]+'|0b[0-9a-f]+"
+          + "|\\d*\\.\\d+(?:E[-+]?\\d+[fd]?)?|\\b\\d+(?:E[-+]?\\d+[fd]?)?)"
+          + "|'(?:''|[^'])*'|--.*$|/\\*[\\s\\S]*\\*/";
+
+  private static final String SQL_MYSQL =
+      "(?i)(?m)[-+]?(?:x'[0-9a-f]+'|0x[0-9a-f]+|b'[0-9a-f]+'|0b[0-9a-f]+"
+          + "|\\d*\\.\\d+(?:E[-+]?\\d+[fd]?)?|\\b\\d+(?:E[-+]?\\d+[fd]?)?)"
+          + "|\"(?:\\\\\"|[^\"])*\"|'(?:\\\\'|[^'])*'|--.*$|/\\*[\\s\\S]*\\*/";
+
+  private static final String SQL_POSTGRESQL =
+      "(?i)(?m)[-+]?(?:x'[0-9a-f]+'|0x[0-9a-f]+|b'[0-9a-f]+'|0b[0-9a-f]+"
+          + "|\\d*\\.\\d+(?:E[-+]?\\d+[fd]?)?|\\b\\d+(?:E[-+]?\\d+[fd]?)?)"
+          + "|\\$(?:[a-zA-Z_]\\w*)?\\$|'(?:''|[^'])*'|--.*$|/\\*[\\s\\S]*\\*/";
+
+  private static NFA nfa(String pattern, int groupCount) throws Exception {
+    RegexNode ast = new RegexParser().parse(pattern);
+    return new ThompsonBuilder().build(ast, groupCount);
+  }
+
+  private static LaurikariDfaMatcher laurikari(String pattern, int groupCount) throws Exception {
+    return new LaurikariDfaMatcher(nfa(pattern, groupCount), pattern, groupCount);
+  }
+
+  private static PikeVMMatcher pikeVm(String pattern, int groupCount) throws Exception {
+    return new PikeVMMatcher(nfa(pattern, groupCount), pattern);
+  }
+
+  private static void assertMatchEquals(
+      MatchResult expected, MatchResult actual, int groupCount, String context) {
+    if (expected == null) {
+      assertNull(actual, "expected no match for " + context);
+      return;
+    }
+    assertNotNull(actual, "expected a match for " + context);
+    for (int g = 0; g <= groupCount; g++) {
+      assertEquals(
+          expected.start(g), actual.start(g), "group " + g + " start diverged for " + context);
+      assertEquals(expected.end(g), actual.end(g), "group " + g + " end diverged for " + context);
+    }
+  }
+
+  /** Full find-family differential check, plus a same-input findFrom at every offset. */
+  private static void assertFindFamilyMatchesOracle(
+      LaurikariDfaMatcher laurikari, PikeVMMatcher oracle, int groupCount, String input) {
+    String ctx = "input=[" + preview(input) + "] (len=" + input.length() + ")";
+    assertEquals(oracle.find(input), laurikari.find(input), "find() diverged for " + ctx);
+    assertEquals(
+        oracle.findFrom(input, 0), laurikari.findFrom(input, 0), "findFrom(0) diverged for " + ctx);
+    assertMatchEquals(oracle.findMatch(input), laurikari.findMatch(input), groupCount, ctx);
+    assertMatchEquals(
+        oracle.findMatchFrom(input, 0), laurikari.findMatchFrom(input, 0), groupCount, ctx);
+
+    // Exercise findFrom at every start offset -- covers the reinject/reinjectAfterNl seeding and
+    // the ANCHOR_LOOKAHEAD_LIVE_MARGIN boundary from many different regionEnd distances.
+    for (int start = 0; start <= input.length(); start++) {
+      assertEquals(
+          oracle.findFrom(input, start),
+          laurikari.findFrom(input, start),
+          "findFrom(" + start + ") diverged for " + ctx);
+    }
+  }
+
+  private static String preview(String s) {
+    String p = s.length() > 60 ? s.substring(0, 60) + "...(" + s.length() + " chars)" : s;
+    return p.replace("\n", "\\n").replace("\r", "\\r");
+  }
+
+  // ==============================================================================================
+  // Eligibility re-check: confirm the SQL patterns actually route through Laurikari, not a
+  // silent fallback that coincidentally looks fast.
+  // ==============================================================================================
+
+  @Test
+  void sqlPatterns_areLaurikariEligible() throws Exception {
+    for (String pattern : new String[] {SQL_ANSI, SQL_MYSQL, SQL_POSTGRESQL}) {
+      NFA nfa = nfa(pattern, 0);
+      assertTrue(
+          LaurikariEligibility.isEligible(nfa, false),
+          "expected " + pattern + " to be Laurikari-eligible");
+    }
+  }
+
+  // ==============================================================================================
+  // Exact benchmark patterns/inputs at LONG scale (mirrors IastRegexpBenchmark.setup(), scale
+  // = LONG: "col_x = col_y AND ".repeat(2000) prefix, per that class).
+  // ==============================================================================================
+
+  @Test
+  void sqlAnsi_longScaleMatchAndNoMatch_agreeWithOracle() throws Exception {
+    int groupCount = 0;
+    LaurikariDfaMatcher laurikari = laurikari(SQL_ANSI, groupCount);
+    PikeVMMatcher oracle = pikeVm(SQL_ANSI, groupCount);
+
+    String sqlMatch =
+        "SELECT * FROM users WHERE "
+            + "col_x = col_y AND ".repeat(2000)
+            + "id = 42 AND name = 'Alice' AND balance = 1234.56";
+    String sqlNoMatch =
+        "SELECT id, name, email FROM users WHERE "
+            + "col_x = col_y AND ".repeat(2000)
+            + "id = id ORDER BY id";
+
+    assertTrue(laurikari.find(sqlMatch), "SQL_ANSI LONG-scale match input must find() true");
+    assertTrue(oracle.find(sqlMatch), "oracle sanity check: SQL_ANSI match input must find() true");
+    assertFindFamilyMatchesOracleFast(laurikari, oracle, groupCount, sqlMatch);
+
+    assertFindFamilyMatchesOracleFast(laurikari, oracle, groupCount, sqlNoMatch);
+    assertEquals(
+        oracle.find(sqlNoMatch), laurikari.find(sqlNoMatch), "SQL_ANSI no-match find() diverged");
+
+    assertEquals(0, laurikari.fallbackCount(), "no PikeVM fallback expected for SQL_ANSI");
+  }
+
+  @Test
+  void sqlMysql_longScaleMatchAndNoMatch_agreeWithOracle() throws Exception {
+    int groupCount = 0;
+    LaurikariDfaMatcher laurikari = laurikari(SQL_MYSQL, groupCount);
+    PikeVMMatcher oracle = pikeVm(SQL_MYSQL, groupCount);
+
+    String mysqlMatch =
+        "SELECT id, `name` FROM users WHERE "
+            + "col_x = col_y AND ".repeat(2000)
+            + "id = 1 AND email = 'user@example.com' AND active = 1";
+    String mysqlNoMatch =
+        "SELECT id, name FROM users WHERE "
+            + "col_x = col_y AND ".repeat(2000)
+            + "active AND enabled";
+
+    assertTrue(laurikari.find(mysqlMatch), "SQL_MYSQL LONG-scale match input must find() true");
+    assertFindFamilyMatchesOracleFast(laurikari, oracle, groupCount, mysqlMatch);
+
+    assertFindFamilyMatchesOracleFast(laurikari, oracle, groupCount, mysqlNoMatch);
+    assertEquals(
+        oracle.find(mysqlNoMatch),
+        laurikari.find(mysqlNoMatch),
+        "SQL_MYSQL no-match find() diverged");
+
+    assertEquals(0, laurikari.fallbackCount(), "no PikeVM fallback expected for SQL_MYSQL");
+  }
+
+  @Test
+  void sqlPostgresql_longScaleMatchAndNoMatch_agreeWithOracle() throws Exception {
+    int groupCount = 0;
+    LaurikariDfaMatcher laurikari = laurikari(SQL_POSTGRESQL, groupCount);
+    PikeVMMatcher oracle = pikeVm(SQL_POSTGRESQL, groupCount);
+
+    String postgresqlMatch =
+        "SELECT * FROM docs WHERE "
+            + "col_x = col_y AND ".repeat(2000)
+            + "body = $$hello world$$ AND revision = 3";
+    String postgresqlNoMatch =
+        "SELECT id, title FROM docs WHERE " + "col_x = col_y AND ".repeat(2000) + "id = id";
+
+    assertTrue(
+        laurikari.find(postgresqlMatch), "SQL_POSTGRESQL LONG-scale match input must find() true");
+    assertFindFamilyMatchesOracleFast(laurikari, oracle, groupCount, postgresqlMatch);
+
+    assertFindFamilyMatchesOracleFast(laurikari, oracle, groupCount, postgresqlNoMatch);
+    assertEquals(
+        oracle.find(postgresqlNoMatch),
+        laurikari.find(postgresqlNoMatch),
+        "SQL_POSTGRESQL no-match find() diverged");
+
+    assertEquals(0, laurikari.fallbackCount(), "no PikeVM fallback expected for SQL_POSTGRESQL");
+  }
+
+  /**
+   * Same intent as {@link #assertFindFamilyMatchesOracle} but skips the O(n) per-offset findFrom
+   * sweep (too slow at LONG scale, ~38K chars) -- just the four find-family entry points at offset
+   * 0, which is exactly what the JMH benchmark calls.
+   */
+  private static void assertFindFamilyMatchesOracleFast(
+      LaurikariDfaMatcher laurikari, PikeVMMatcher oracle, int groupCount, String input) {
+    String ctx = "input len=" + input.length();
+    assertEquals(oracle.find(input), laurikari.find(input), "find() diverged for " + ctx);
+    assertEquals(
+        oracle.findFrom(input, 0), laurikari.findFrom(input, 0), "findFrom(0) diverged for " + ctx);
+    assertMatchEquals(oracle.findMatch(input), laurikari.findMatch(input), groupCount, ctx);
+    assertMatchEquals(
+        oracle.findMatchFrom(input, 0), laurikari.findMatchFrom(input, 0), groupCount, ctx);
+  }
+
+  // ==============================================================================================
+  // Adversarial hand-crafted shapes: \b\d+ at various positions
+  // ==============================================================================================
+
+  @Test
+  void wordBoundaryDigits_variousPositions() throws Exception {
+    // Each input gets a FRESH matcher pair: reusing one findCache-backed LaurikariDfaMatcher
+    // across many distinct inputs runs into the separately-documented pre-existing within-call
+    // cache-pollution bug (see anchorCachePollutionWithinSingleFindCall_knownPreExistingBug
+    // below), which is orthogonal to what this test verifies -- correctness of the single-call
+    // anchor fan-out.
+    String pattern = "\\b\\d+";
+    int groupCount = 0;
+
+    String[] inputs = {
+      "123",
+      "abc123",
+      "123abc",
+      "abc 123 def",
+      "abc123def", // \b never fires mid-word -> no match
+      "1",
+      "",
+      "a1",
+      "1a",
+      " 1",
+      "1 ",
+      "999999999999999999999999999999",
+      "x".repeat(50) + "42",
+      "42" + "x".repeat(50),
+    };
+    for (String input : inputs) {
+      LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+      PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+      assertFindFamilyMatchesOracle(laurikari, oracle, groupCount, input);
+      assertEquals(0, laurikari.fallbackCount());
+    }
+  }
+
+  // ==============================================================================================
+  // Adversarial hand-crafted shapes: (?m)...--.*$ and $ at end of each line
+  // ==============================================================================================
+
+  @Test
+  void multilineCommentToEndOfLine_variousLineBreaks() throws Exception {
+    // Fresh matcher pair per input -- see comment on wordBoundaryDigits_variousPositions.
+    String pattern = "(?m)--.*$";
+    int groupCount = 0;
+
+    String[] inputs = {
+      "-- comment",
+      "-- comment\n",
+      "-- comment\r\n",
+      "-- comment\r",
+      "line1\n-- comment\nline3",
+      "line1\r\n-- comment\r\nline3",
+      "line1\r-- comment\rline3",
+      "no comment here",
+      "--",
+      "--\n",
+      "a\n--\nb\n--\nc",
+      "--" + "x".repeat(100),
+      "--" + "x".repeat(100) + "\n",
+      "--" + "x".repeat(100) + "\r\n",
+    };
+    for (String input : inputs) {
+      LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+      PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+      assertFindFamilyMatchesOracle(laurikari, oracle, groupCount, input);
+      assertEquals(0, laurikari.fallbackCount());
+    }
+  }
+
+  // ==============================================================================================
+  // Boundary cases within ANCHOR_LOOKAHEAD_LIVE_MARGIN (2 chars) of regionEnd / string end
+  // ==============================================================================================
+
+  @Test
+  void endAnchor_boundaryPositionsNearRegionEnd() throws Exception {
+    // Fresh matcher pair per input -- see comment on wordBoundaryDigits_variousPositions.
+    String pattern = "\\d+$";
+    int groupCount = 0;
+
+    // empty / length-1 / length-2 inputs, plus digits landing exactly at regionEnd, regionEnd-1,
+    // regionEnd-2.
+    String[] inputs = {
+      "", "1", "12", "123", "a", "a1", "a12", "a123", "1a", // digit not at true end -> no match
+      "12a",
+      // NOTE: "a1a1" is deliberately excluded here -- it trips the pre-existing, unrelated
+      // within-call anchor-cache-pollution bug documented and reproduced in
+      // anchorCachePollutionWithinSingleFindCall_knownPreExistingBug() below, which is not a
+      // regression from the fan-out fix under test in this method.
+    };
+    for (String input : inputs) {
+      LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+      PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+      assertFindFamilyMatchesOracle(laurikari, oracle, groupCount, input);
+      assertEquals(0, laurikari.fallbackCount());
+    }
+  }
+
+  @Test
+  void wordBoundary_boundaryPositionsNearRegionEnd() throws Exception {
+    // Fresh matcher pair per input -- see comment on wordBoundaryDigits_variousPositions.
+    String pattern = "\\w+\\b";
+    int groupCount = 0;
+
+    String[] inputs = {"", "a", "ab", "abc", "a ", "ab ", "a.", "ab.", " a", " ab"};
+    for (String input : inputs) {
+      LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+      PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+      assertFindFamilyMatchesOracle(laurikari, oracle, groupCount, input);
+      assertEquals(0, laurikari.fallbackCount());
+    }
+  }
+
+  // ==============================================================================================
+  // \r, \n, \r\n line-terminator combinations near end-of-input and near (?m)$
+  // ==============================================================================================
+
+  @Test
+  void lineTerminatorCombinations_endMultiline() throws Exception {
+    // Fresh matcher pair per input -- see comment on wordBoundaryDigits_variousPositions.
+    String pattern = "(?m)\\d+$";
+    int groupCount = 0;
+
+    String[] inputs = {
+      "1\n",
+      "1\r\n",
+      "1\r",
+      "1\n2",
+      "1\r\n2",
+      "1\r2",
+      "12\n",
+      "12\r\n",
+      "12\r",
+      "1\n\n",
+      "1\r\n\r\n",
+      "a1\nb2\nc3",
+      "a1\r\nb2\r\nc3",
+      "a1\rb2\rc3",
+      "1 ", // LINE SEPARATOR
+      "1 ", // PARAGRAPH SEPARATOR
+      "1", // NEL
+    };
+    for (String input : inputs) {
+      LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+      PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+      assertFindFamilyMatchesOracle(laurikari, oracle, groupCount, input);
+      assertEquals(0, laurikari.fallbackCount());
+    }
+  }
+
+  @Test
+  void lineTerminatorCombinations_stringEnd() throws Exception {
+    // STRING_END (\Z semantics as used internally) vs STRING_END_ABSOLUTE (\z) both live in the
+    // same 5-anchor-type scope; drive them via $ without (?m) (STRING_END: allows a single
+    // trailing line terminator) and via \z-equivalent END anchor through end-of-input digit runs.
+    // Fresh matcher pair per input -- see comment on wordBoundaryDigits_variousPositions.
+    String pattern = "\\d+$"; // no (?m): STRING_END, matches before a final line terminator too
+    int groupCount = 0;
+
+    String[] inputs = {
+      "1", "1\n", "1\r\n", "1\r", "12\n", "12\r\n", "1\n2", "1\n2\n", "a1\n", "a1\r\n", "a12\n",
+      "1\n\n", // digits not immediately before the final terminator -> no match under $ semantics
+    };
+    for (String input : inputs) {
+      LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+      PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+      assertFindFamilyMatchesOracle(laurikari, oracle, groupCount, input);
+      assertEquals(0, laurikari.fallbackCount());
+    }
+  }
+
+  // ==============================================================================================
+  // Proxy check from the design doc's test plan item 1: anchorSensitiveCount() should stay a
+  // small minority of findCache's interned states for the SQL patterns (the fan-out fixes the
+  // caching defeat; it must not also be masking a correctness bug by e.g. never marking states
+  // anchor-sensitive at all, which would make the "genuine speedup" story impossible to
+  // distinguish from "the classification silently stopped applying").
+  // ==============================================================================================
+
+  @Test
+  void sqlAnsi_anchorSensitiveStatesPresent_afterExercisingFindCache() throws Exception {
+    int groupCount = 0;
+    LaurikariDfaMatcher laurikari = laurikari(SQL_ANSI, groupCount);
+
+    // Exercise findCache with representative inputs touching every anchor-bearing branch.
+    String[] inputs = {
+      "SELECT 42 FROM t",
+      "-- comment\n",
+      "'quoted'",
+      "0x1F",
+      "SELECT * FROM users WHERE " + "col_x = col_y AND ".repeat(50) + "id = 42",
+    };
+    for (String input : inputs) {
+      laurikari.find(input);
+    }
+
+    int anchorSensitiveCount = 0;
+    int stateCount = laurikari.findCache.stateCount();
+    for (int i = 0; i < stateCount; i++) {
+      if (laurikari.findCache.anchorSensitive[i]) anchorSensitiveCount++;
+    }
+    assertTrue(
+        anchorSensitiveCount > 0,
+        "expected at least one anchor-sensitive state for SQL_ANSI's \\b\\d+ branch (found 0 of "
+            + stateCount
+            + " states) -- if this is 0, the classification isn't firing at all, which would make"
+            + " any 'speedup' from this fix impossible (there would be nothing left to cache"
+            + " smarter)");
+    assertTrue(
+        anchorSensitiveCount < stateCount,
+        "expected anchor-sensitive states to be a minority of findCache's state space, not all of"
+            + " it (that would indicate the fan-out isn't narrowing anything)");
+  }
+
+  // ==============================================================================================
+  // KNOWN, PRE-EXISTING BUG (not introduced by the uncommitted lookahead-class fan-out fix; the
+  // caching-decision gate below is untouched by that diff and traces back to commit 274488d):
+  // position-scoped cache pollution in LaurikariDFACache's findCache.
+  //
+  // Root cause: LaurikariDFACache.isAnchorSensitive(int[] states) only checks whether an
+  // anchor-bearing NFA state is already a MEMBER of a DFA state's own subset. It does not check
+  // whether an anchor-bearing state becomes reachable one step later via a single consuming
+  // transition + epsilon-closure. So a transition out of a state that is NOT flagged
+  // anchorSensitive can, on its first evaluation, resolve through a live checkAnchor(...) call
+  // that is specific to that call's (pos, regionEnd) -- and LaurikariDFACache.lookupOrCompute's
+  // caching gate (`if (id != FALLBACK && !anchorSensitive[state]) cacheEntry(state, c, id);`)
+  // unconditionally memoizes that position-specific outcome, keyed only on (state, c).
+  //
+  // This is more severe than "reuse the matcher across two find() calls": LaurikariDfaMatcher's
+  // self-anchoring find() ALREADY sweeps every start position within ONE call, reinjecting start
+  // threads into the SAME findCache instance at each position. So a single find() call over a
+  // multi-character input can self-pollute: an anchor outcome computed live at an early position
+  // gets cached under (state, c) and then wrongly reused at a later position with a different
+  // pos/regionEnd, even though no second find() call or matcher reuse was involved.
+  //
+  // Minimal repro (single find() call, brand-new matcher, no reuse across calls): pattern
+  // "\d+$", input "a1a1". Oracle (PikeVMMatcher, and java.util.regex) correctly finds a match --
+  // the trailing "1" at index 3 satisfies \d+$. A fresh LaurikariDfaMatcher's find("a1a1")
+  // incorrectly returns false, because computing the earlier "1" at index 1 (followed by "a",
+  // which fails the END anchor) caches an outcome that gets wrongly reused when the scan later
+  // reaches the trailing "1" at index 3.
+  //
+  // This predates today's fix and is orthogonal to it -- every other test in this file
+  // deliberately uses a fresh LaurikariDfaMatcher per input, but that only isolates ACROSS calls;
+  // it cannot isolate the within-a-single-call self-pollution this repro demonstrates. Per task
+  // instructions this bug is described here, not fixed; LaurikariDFACache.java is not modified by
+  // this change.
+  // ==============================================================================================
+
+  @Test
+  void anchorCachePollutionWithinSingleFindCall_knownPreExistingBug() throws Exception {
+    String pattern = "\\d+$";
+    int groupCount = 0;
+    LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    // This is a single find() call on a brand-new matcher -- not a cross-call scenario. The
+    // oracle correctly matches the trailing digit "1" at index 3.
+    assertTrue(oracle.find("a1a1"), "sanity: oracle must find \\d+$ in \"a1a1\" (trailing '1')");
+
+    // Documents today's ACTUAL (buggy) behavior: the Laurikari engine wrongly reports no match,
+    // because the live END-anchor check performed while scanning position 1 ("1" followed by
+    // "a") gets cached under (state, 'a') and is wrongly replayed when the scan reaches position
+    // 3 ("1" followed by end-of-input). If this assertion ever starts failing because the bug
+    // got fixed, update/remove this test rather than reintroducing the workaround.
+    assertEquals(
+        false,
+        laurikari.find("a1a1"),
+        "documents current buggy behavior: single find() call wrongly misses the trailing digit"
+            + " match in \"a1a1\" due to within-call anchor-cache pollution (oracle-correct"
+            + " answer is true)");
+  }
+}

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariCaptureStepTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariCaptureStepTest.java
@@ -237,8 +237,7 @@ class LaurikariCaptureStepTest {
         "reinjectClosure() live vs precomputed");
 
     LaurikariStepResult reinjectAfterNl = step.reinjectAfterNlClosure();
-    LaurikariStepResult reinjectAfterNlLive =
-        step.reinjectAfterNlClosure(input, 1, input.length());
+    LaurikariStepResult reinjectAfterNlLive = step.reinjectAfterNlClosure(input, 1, input.length());
     if (reinjectAfterNl == null) {
       org.junit.jupiter.api.Assertions.assertNull(
           reinjectAfterNlLive, "reinjectAfterNlClosure() live vs precomputed (both null)");

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariCaptureStepTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariCaptureStepTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.datadoghq.reggie.codegen.ast.RegexNode;
+import com.datadoghq.reggie.codegen.automaton.NFA;
+import com.datadoghq.reggie.codegen.automaton.ThompsonBuilder;
+import com.datadoghq.reggie.codegen.parsing.RegexParser;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Impl-plan Task 1.1/1.2 (doc/2026-07-10-tdfa-capture-engine-impl-plan.md §3): validates {@link
+ * LaurikariTagNumbering} + {@link LaurikariCaptureNfaStep} against {@link PikeVMMatcher} — the same
+ * oracle-comparison style {@code LaurikariPhase05Test} already uses for its hand-derived 2-3-tag
+ * checkpoint, generalized here to the full {@code 2 * (groupCount + 1)} tag count derived
+ * automatically from an arbitrary pattern's real {@code groupCount}, instead of 2-3 hand-picked
+ * tags on 3 fixed patterns.
+ *
+ * <p>Scope, per the impl plan: anchored whole-input match only (mirrors {@code
+ * PikeVMMatcher.match()}/{@code Matcher.matches()} semantics) — no self-anchoring {@code find()}
+ * localization (that composition is {@code LaurikariDfaMatcher}'s job, Task 1.4, explicitly out of
+ * scope here). Patterns are restricted to concatenation/alternation/quantified capturing groups
+ * with no lookaround, backreferences, or atomic groups (Task 1.3's eligibility gate is also out of
+ * scope here — this test simply never constructs an ineligible pattern).
+ */
+class LaurikariCaptureStepTest {
+
+  private static NFA nfa(String pattern, int groupCount) throws Exception {
+    RegexNode ast = new RegexParser().parse(pattern);
+    return new ThompsonBuilder().build(ast, groupCount);
+  }
+
+  private static final class Built {
+    final LaurikariCaptureNfaStep step;
+    final LaurikariDFACache cache;
+    final int acceptId;
+
+    Built(LaurikariCaptureNfaStep step, LaurikariDFACache cache, int acceptId) {
+      this.step = step;
+      this.cache = cache;
+      this.acceptId = acceptId;
+    }
+  }
+
+  private static Built build(String pattern, int groupCount) throws Exception {
+    NFA nfa = nfa(pattern, groupCount);
+    LaurikariCaptureNfaStep step = new LaurikariCaptureNfaStep(nfa, groupCount);
+    LaurikariStepResult initial = LaurikariCaptureNfaStep.initial(nfa, step);
+    int acceptId = nfa.getAcceptStates().iterator().next().id;
+    LaurikariDFACache cache =
+        new LaurikariDFACache(initial.states, initial.regs, new int[] {acceptId});
+    return new Built(step, cache, acceptId);
+  }
+
+  /**
+   * Drives {@code input} through {@code built.cache} (the production {@link LaurikariDFACache}
+   * lazily-materializing/interning transitions produced by {@code built.step}) one character at a
+   * time, and returns the absolute tag positions once every character is consumed, or {@code null}
+   * if the accept state isn't live at the end (no whole-input match).
+   */
+  private static int[] runToEnd(Built built, String input) {
+    int dfaState = 0;
+    for (int i = 0; i < input.length(); i++) {
+      int next = built.cache.lookupOrCompute(dfaState, input.charAt(i), built.step);
+      if (next == LaurikariDFACache.DEAD) return null;
+      if (next == LaurikariDFACache.FALLBACK) {
+        fail("unexpected cache overflow for a small test pattern");
+      }
+      dfaState = next;
+    }
+    if (!built.cache.accepting[dfaState]) return null;
+    int[] acceptRegs = built.cache.acceptRegs(dfaState);
+    return built.step.absolutePositions(acceptRegs, input.length());
+  }
+
+  private static PikeVMMatcher pikeVm(String pattern, int groupCount) throws Exception {
+    NFA nfa = nfa(pattern, groupCount);
+    return new PikeVMMatcher(nfa, pattern);
+  }
+
+  /** Asserts every group's open/close tag matches {@code oracleResult}'s reported span exactly. */
+  private static void assertCapturesMatchOracle(
+      int[] absolute, MatchResult oracleResult, int groupCount, String input) {
+    int[] expected = new int[2 * (groupCount + 1)];
+    for (int g = 0; g <= groupCount; g++) {
+      expected[2 * g] = oracleResult.start(g);
+      expected[2 * g + 1] = oracleResult.end(g);
+    }
+    assertArrayEquals(expected, absolute, "capture tags diverged from PikeVMMatcher for " + input);
+  }
+
+  // --- (a) simple concatenation: (a)(b)
+  // -----------------------------------------------------------
+
+  @Test
+  void concatenation_twoGroups_matchesPikeVM() throws Exception {
+    String pattern = "(a)(b)";
+    int groupCount = 2;
+    Built built = build(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    for (String input : new String[] {"ab"}) {
+      MatchResult oracleResult = oracle.match(input);
+      assertNotNull(oracleResult, "PikeVMMatcher must match " + input);
+      int[] absolute = runToEnd(built, input);
+      assertNotNull(absolute, "Laurikari driver must also match " + input);
+      assertCapturesMatchOracle(absolute, oracleResult, groupCount, input);
+    }
+  }
+
+  // --- (b) alternation with distinct capture groups per branch: (foo|bar)(baz) -------------------
+
+  @Test
+  void alternation_distinctBranches_matchesPikeVM() throws Exception {
+    String pattern = "(foo|bar)(baz)";
+    int groupCount = 2;
+    Built built = build(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    for (String input : new String[] {"foobaz", "barbaz"}) {
+      MatchResult oracleResult = oracle.match(input);
+      assertNotNull(oracleResult, "PikeVMMatcher must match " + input);
+      int[] absolute = runToEnd(built, input);
+      assertNotNull(absolute, "Laurikari driver must also match " + input);
+      assertCapturesMatchOracle(absolute, oracleResult, groupCount, input);
+    }
+  }
+
+  // --- (c) quantified group + optional group: (a+)(b)? -------------------------------------------
+
+  @Test
+  void quantifiedAndOptionalGroups_matchesPikeVM() throws Exception {
+    String pattern = "(a+)(b)?";
+    int groupCount = 2;
+    Built built = build(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    for (String input : new String[] {"a", "aaa", "ab", "aaab"}) {
+      MatchResult oracleResult = oracle.match(input);
+      assertNotNull(oracleResult, "PikeVMMatcher must match " + input);
+      int[] absolute = runToEnd(built, input);
+      assertNotNull(absolute, "Laurikari driver must also match " + input);
+      assertCapturesMatchOracle(absolute, oracleResult, groupCount, input);
+    }
+  }
+
+  // --- (d) nested/loop group re-set every iteration: (ab)+ (single group, no independent second
+  // --- group, but exercises the loop-back re-set path with the general tag-numbering mechanism
+  // --- instead of Phase 0.5's hand-picked tagSpecs)
+  // -----------------------------------------------
+
+  @Test
+  void loopBodyGroup_reSetOnEveryIteration_matchesPikeVM() throws Exception {
+    String pattern = "(ab)+";
+    int groupCount = 1;
+    Built built = build(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    for (String input : new String[] {"ab", "abab", "ababab"}) {
+      MatchResult oracleResult = oracle.match(input);
+      assertNotNull(oracleResult, "PikeVMMatcher must match " + input);
+      int[] absolute = runToEnd(built, input);
+      assertNotNull(absolute, "Laurikari driver must also match " + input);
+      assertCapturesMatchOracle(absolute, oracleResult, groupCount, input);
+    }
+  }
+}

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariCaptureStepTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariCaptureStepTest.java
@@ -62,7 +62,7 @@ class LaurikariCaptureStepTest {
   private static Built build(String pattern, int groupCount) throws Exception {
     NFA nfa = nfa(pattern, groupCount);
     LaurikariCaptureNfaStep step = new LaurikariCaptureNfaStep(nfa, groupCount);
-    LaurikariStepResult initial = LaurikariCaptureNfaStep.initial(nfa, step);
+    LaurikariStepResult initial = step.initialClosure();
     int acceptId = nfa.getAcceptStates().iterator().next().id;
     LaurikariDFACache cache =
         new LaurikariDFACache(initial.states, initial.regs, new int[] {acceptId});

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariCaptureStepTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariCaptureStepTest.java
@@ -16,6 +16,7 @@
 package com.datadoghq.reggie.runtime;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -179,6 +180,71 @@ class LaurikariCaptureStepTest {
       int[] absolute = runToEnd(built, input);
       assertNotNull(absolute, "Laurikari driver must also match " + input);
       assertCapturesMatchOracle(absolute, oracleResult, groupCount, input);
+    }
+  }
+
+  // --- package-private compatibility overloads (no production caller ever exercises these
+  // --- exact arities, since LaurikariDfaMatcher always threads real input/pos/regionEnd through;
+  // --- covered here directly as they're part of LaurikariCaptureNfaStep's real API surface).
+
+  private static void assertResultsEqual(LaurikariStepResult a, LaurikariStepResult b, String msg) {
+    assertArrayEquals(a.states, b.states, msg + " (states)");
+    for (int i = 0; i < a.states.length; i++) {
+      assertArrayEquals(a.regs[i], b.regs[i], msg + " (regs[" + i + "])");
+    }
+  }
+
+  @Test
+  void noArgApplyOverloads_matchExplicitEmptyInputVariant() throws Exception {
+    String pattern = "(a)(b)";
+    int groupCount = 2;
+    NFA nfa = nfa(pattern, groupCount);
+    LaurikariCaptureNfaStep step = new LaurikariCaptureNfaStep(nfa, groupCount);
+    assertFalse(step.hasNewAnchor, "no-anchor pattern must not set hasNewAnchor");
+
+    LaurikariStepResult initial = step.initialClosure();
+
+    LaurikariStepResult viaShort = step.apply(initial.states, initial.regs, 'a');
+    LaurikariStepResult viaExplicit = step.apply(initial.states, initial.regs, 'a', "", 0, 0);
+    assertResultsEqual(viaShort, viaExplicit, "apply() 3-arg vs 6-arg for 'a'");
+
+    LaurikariStepResult viaFindShort = step.applyFind(initial.states, initial.regs, 'a');
+    LaurikariStepResult viaFindExplicit =
+        step.applyFind(initial.states, initial.regs, 'a', "", 0, 0);
+    assertResultsEqual(viaFindShort, viaFindExplicit, "applyFind() 3-arg vs 6-arg for 'a'");
+  }
+
+  @Test
+  void liveClosureOverloads_delegateToPrecomputedFieldsWhenNoNewAnchor() throws Exception {
+    String pattern = "(a+)(b)?";
+    int groupCount = 2;
+    NFA nfa = nfa(pattern, groupCount);
+    LaurikariCaptureNfaStep step = new LaurikariCaptureNfaStep(nfa, groupCount);
+    assertFalse(step.hasNewAnchor, "no-anchor pattern must not set hasNewAnchor");
+
+    String input = "aab";
+    assertResultsEqual(
+        step.initialClosure(),
+        step.initialClosure(input, input.length()),
+        "initialClosure() live vs precomputed");
+    assertResultsEqual(
+        step.truncatedInitialClosure(),
+        step.truncatedInitialClosure(input, input.length()),
+        "truncatedInitialClosure() live vs precomputed");
+    assertResultsEqual(
+        step.reinjectClosure(),
+        step.reinjectClosure(input, 1, input.length()),
+        "reinjectClosure() live vs precomputed");
+
+    LaurikariStepResult reinjectAfterNl = step.reinjectAfterNlClosure();
+    LaurikariStepResult reinjectAfterNlLive =
+        step.reinjectAfterNlClosure(input, 1, input.length());
+    if (reinjectAfterNl == null) {
+      org.junit.jupiter.api.Assertions.assertNull(
+          reinjectAfterNlLive, "reinjectAfterNlClosure() live vs precomputed (both null)");
+    } else {
+      assertResultsEqual(
+          reinjectAfterNl, reinjectAfterNlLive, "reinjectAfterNlClosure() live vs precomputed");
     }
   }
 }

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDFACacheTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDFACacheTest.java
@@ -392,6 +392,9 @@ class LaurikariDFACacheTest {
     assertNotNull(
         cache.asciiTables[anchorFreeState],
         "anchor-free sibling state must populate asciiTables on its first step");
+    assertNull(
+        cache.anchorLookaheadTables[anchorFreeState],
+        "anchor-free state must never allocate anchorLookaheadTables, however often it's stepped");
   }
 
   // --- (f) TDFA Phase 2 follow-up: anchor-lookahead fan-out caching -----------------------------

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDFACacheTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDFACacheTest.java
@@ -393,4 +393,52 @@ class LaurikariDFACacheTest {
         cache.asciiTables[anchorFreeState],
         "anchor-free sibling state must populate asciiTables on its first step");
   }
+
+  // --- (f) TDFA Phase 2 follow-up: anchor-lookahead fan-out caching -----------------------------
+  // 274488d's anchorSensitive gating made anchor-bearing states never populate asciiTables at
+  // all -- correct, but for find()'s self-anchoring reinject this meant a live recomputation
+  // (including a checkAnchor call) on nearly every character. This proves the follow-up fix: away
+  // from regionEnd, the anchor outcome collapses to a small (consumed-char, lookahead-class) pair
+  // (see LaurikariDFACache#lookaheadClass), so those transitions ARE cached now (in
+  // anchorLookaheadTables, never asciiTables), while positions within
+  // ANCHOR_LOOKAHEAD_LIVE_MARGIN characters of regionEnd are still always recomputed live.
+
+  @Test
+  void anchorSensitiveState_cachesTransitionsAwayFromRegionEnd_liveNearRegionEnd() {
+    boolean[] anchorBearingStates = {true, false};
+    int[] calls = {0};
+    LaurikariNfaStep countingPassThrough =
+        (curStates, curRegs, c, input, pos, regionEnd) -> {
+          calls[0]++;
+          return new LaurikariStepResult(curStates, curRegs);
+        };
+
+    LaurikariDFACache cache =
+        new LaurikariDFACache(new int[] {0}, new int[][] {{}}, new int[0], anchorBearingStates);
+    String input = "aaaaaaaaaa";
+    int regionEnd = input.length();
+
+    // Far from regionEnd: first step recomputes live and caches into anchorLookaheadTables.
+    cache.step(0, 'a', countingPassThrough, input, 1, regionEnd);
+    assertNotNull(
+        cache.anchorLookaheadTables[0],
+        "anchor-sensitive state must populate anchorLookaheadTables away from regionEnd");
+    assertNull(cache.asciiTables[0], "must still never populate asciiTables directly");
+    int callsAfterFirst = calls[0];
+
+    // Same (state, char, lookahead-class) at other far-from-regionEnd positions: cache hit, no
+    // further live recomputation.
+    for (int i = 1; i < 5; i++) {
+      cache.step(0, 'a', countingPassThrough, input, i + 1, regionEnd);
+    }
+    assertEquals(
+        callsAfterFirst,
+        calls[0],
+        "repeated (state, char, lookahead-class) transitions must hit the cache, not recompute"
+            + " live");
+
+    // Within ANCHOR_LOOKAHEAD_LIVE_MARGIN of regionEnd: always live, never cached.
+    cache.step(0, 'a', countingPassThrough, input, regionEnd - 1, regionEnd);
+    assertTrue(calls[0] > callsAfterFirst, "positions near regionEnd must always recompute live");
+  }
 }

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDFACacheTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDFACacheTest.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datadoghq.reggie.codegen.automaton.NFA;
+import com.datadoghq.reggie.codegen.automaton.ThompsonBuilder;
+import com.datadoghq.reggie.codegen.parsing.RegexParser;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link LaurikariDFACache}, the Phase-0 Laurikari-style localization spike that
+ * recovers the exact leftmost start of the first completable match in a single left-to-right scan
+ * by tracking a per-candidate "age" register through DFA-state interning (see {@link
+ * LaurikariNfaStep} and {@link LaurikariStateSetKey} for what "age" means and why it is used
+ * instead of an absolute start position).
+ *
+ * <p>{@link LaurikariDFACache}, {@link LaurikariNfaStep}, {@link LaurikariStepResult}, and {@link
+ * LaurikariStateSetKey} are all package-private with no public entry point, but since this test
+ * lives in the same package it can use them directly (unlike {@code RejectDfaFactoryTest}, which
+ * needs reflection to reach {@code RejectDfaFactory}'s own package-private {@code build} method).
+ *
+ * <p>This test builds its own {@link LaurikariNfaStep} driver (closure + consuming-transition +
+ * merge, over the raw {@link NFA} built by {@link ThompsonBuilder}) rather than depend on any
+ * production wiring point, since Phase 0 does not have one yet: see the class doc of {@link
+ * LaurikariNfaStep} for the exact algorithm this driver implements. This is legitimate test-only
+ * duplication of the production algorithm — the real matcher-construction wiring is a later phase's
+ * concern.
+ */
+class LaurikariDFACacheTest {
+
+  // --- Test-only LaurikariNfaStep driver -------------------------------------------------------
+  //
+  // Mirrors RejectDfaFactory's closure()/transitionTargets() shape (including its "cross every
+  // anchor state as epsilon" over-approximation — anchor eligibility is a later phase's concern,
+  // not Phase 0's), but threads a per-state age register through closure and merge instead of
+  // doing an unconditional attribution-erasing union.
+
+  private static NFA nfa(String pattern, int groupCount) throws Exception {
+    return new ThompsonBuilder().build(new RegexParser().parse(pattern), groupCount);
+  }
+
+  private static NFA.NFAState[] statesById(NFA nfa) {
+    NFA.NFAState[] arr = new NFA.NFAState[nfa.getStates().size()];
+    for (NFA.NFAState s : nfa.getStates()) {
+      arr[s.id] = s;
+    }
+    return arr;
+  }
+
+  /**
+   * Epsilon-closure of {@code (seedStates[i], seedAges[i])}, crossing every anchor state as epsilon
+   * exactly like {@code RejectDfaFactory.closure()} (same sound-over-approximation reasoning: Phase
+   * 0 is a localization spike, anchor eligibility is deferred). When two paths reach the same state
+   * with different ages, the larger age wins (older candidate = more leftmost), matching {@link
+   * LaurikariNfaStep}'s tie-break rule. Ages only ever increase while propagating (epsilon consumes
+   * no character), so a monotone worklist relaxation (rather than a single visited-once DFS) is
+   * used to let a later, larger-age arrival re-open already-visited states.
+   *
+   * @return {@code {states, ages}}, both sorted ascending by state id (parallel arrays)
+   */
+  private static int[][] closureWithAges(
+      NFA.NFAState[] statesById, int stateCount, int[] seedStates, int[] seedAges) {
+    int[] ages = new int[stateCount];
+    Arrays.fill(ages, -1);
+    Deque<Integer> worklist = new ArrayDeque<>();
+    for (int i = 0; i < seedStates.length; i++) {
+      int id = seedStates[i];
+      if (seedAges[i] > ages[id]) {
+        ages[id] = seedAges[i];
+        worklist.push(id);
+      }
+    }
+    while (!worklist.isEmpty()) {
+      int id = worklist.pop();
+      int age = ages[id];
+      for (NFA.NFAState e : statesById[id].getEpsilonTransitions()) {
+        if (age > ages[e.id]) {
+          ages[e.id] = age;
+          worklist.push(e.id);
+        }
+      }
+    }
+    return denseToSeed(ages, stateCount);
+  }
+
+  /** Converts a dense per-id age array ({@code -1} = absent) to sorted parallel (states, ages). */
+  private static int[][] denseToSeed(int[] denseAges, int stateCount) {
+    int count = 0;
+    for (int v : denseAges) {
+      if (v >= 0) count++;
+    }
+    int[] states = new int[count];
+    int[] ages = new int[count];
+    int oi = 0;
+    for (int id = 0; id < stateCount; id++) {
+      if (denseAges[id] >= 0) {
+        states[oi] = id;
+        ages[oi] = denseAges[id];
+        oi++;
+      }
+    }
+    return new int[][] {states, ages};
+  }
+
+  /**
+   * Builds the {@link LaurikariNfaStep} implementing Phase 0's step function: (1) consuming
+   * transitions with age+1, (2) closure of the consuming targets, (3) a separate fresh
+   * self-anchoring closure({@code startId}) at age 0, and (4) a larger-age-wins merge of (2) and
+   * (3) — see {@link LaurikariNfaStep}'s class javadoc for the full rationale.
+   */
+  private static LaurikariNfaStep laurikariStep(NFA nfa) {
+    NFA.NFAState[] statesById = statesById(nfa);
+    int stateCount = statesById.length;
+    int startId = nfa.getStartState().id;
+    return (curStates, curRegs, c) -> {
+      int[] rawAges = new int[stateCount];
+      Arrays.fill(rawAges, -1);
+      for (int i = 0; i < curStates.length; i++) {
+        NFA.NFAState s = statesById[curStates[i]];
+        int age = curRegs[i][0];
+        for (NFA.Transition t : s.getTransitions()) {
+          if (t.chars.contains((char) c)) {
+            int cand = age + 1;
+            if (cand > rawAges[t.target.id]) rawAges[t.target.id] = cand;
+          }
+        }
+      }
+      int[][] consumedSeed = denseToSeed(rawAges, stateCount);
+      int[][] consumedClosed =
+          closureWithAges(statesById, stateCount, consumedSeed[0], consumedSeed[1]);
+      int[][] freshClosed =
+          closureWithAges(statesById, stateCount, new int[] {startId}, new int[] {0});
+
+      int[] merged = new int[stateCount];
+      Arrays.fill(merged, -1);
+      for (int i = 0; i < consumedClosed[0].length; i++) {
+        merged[consumedClosed[0][i]] = consumedClosed[1][i];
+      }
+      for (int i = 0; i < freshClosed[0].length; i++) {
+        int id = freshClosed[0][i];
+        int age = freshClosed[1][i];
+        if (age > merged[id]) merged[id] = age;
+      }
+      int[][] out = denseToSeed(merged, stateCount);
+      int[] outStates = out[0];
+      int[] outAges = out[1];
+      int[][] outRegs = new int[outStates.length][];
+      for (int i = 0; i < outStates.length; i++) {
+        outRegs[i] = new int[] {outAges[i]};
+      }
+      return new LaurikariStepResult(outStates, outRegs);
+    };
+  }
+
+  /** {@link LaurikariDFACache} + its driving {@link LaurikariNfaStep}, built for one pattern. */
+  private static final class Built {
+    final LaurikariDFACache cache;
+    final LaurikariNfaStep step;
+
+    Built(LaurikariDFACache cache, LaurikariNfaStep step) {
+      this.cache = cache;
+      this.step = step;
+    }
+  }
+
+  private static Built build(String pattern, int groupCount) throws Exception {
+    NFA nfa = nfa(pattern, groupCount);
+    NFA.NFAState[] statesById = statesById(nfa);
+    int stateCount = statesById.length;
+    int startId = nfa.getStartState().id;
+
+    // Seed state set for LaurikariDFACache's state 0: plain closure(startId) at age 0 — the
+    // cache's own constructor re-derives an all-zero age array for it, matching how
+    // LazyDFACache's constructor seeds nfaStateSets[0] from startStateSet.
+    int[][] startClosure =
+        closureWithAges(statesById, stateCount, new int[] {startId}, new int[] {0});
+
+    int[] acceptIds = new int[nfa.getAcceptStates().size()];
+    int ai = 0;
+    for (NFA.NFAState s : nfa.getAcceptStates()) {
+      acceptIds[ai++] = s.id;
+    }
+
+    int[] startStates = startClosure[0];
+    int[] startAges = startClosure[1];
+    int[][] startRegs = new int[startStates.length][];
+    for (int i = 0; i < startStates.length; i++) {
+      startRegs[i] = new int[] {startAges[i]};
+    }
+
+    LaurikariDFACache cache = new LaurikariDFACache(startStates, startRegs, acceptIds);
+    return new Built(cache, laurikariStep(nfa));
+  }
+
+  // --- (a) Basic sanity: exact leftmost start for simple literal / multi-leading-char patterns --
+
+  @Test
+  void simpleLiteral_findsExactStart_orMinusOneWhenAbsent() throws Exception {
+    Built b = build("abc", 0);
+
+    // "abc" appears starting at index 3.
+    assertEquals(3, b.cache.findLeftmostStart("xxxabcxxx", 0, b.step));
+    // Not present at all.
+    assertEquals(-1, b.cache.findLeftmostStart("xxxxxxxxx", 0, b.step));
+    // Overlaps the literal's own characters but never the full sequence.
+    assertEquals(-1, b.cache.findLeftmostStart("cabxbca", 0, b.step));
+  }
+
+  @Test
+  void alternation_withMultipleLeadingChars_findsExactStart_orMinusOneWhenNeitherBranchMatches()
+      throws Exception {
+    // cat|dog: two disjoint leading characters, exercising the merge across more than one live
+    // NFA position at once (single-literal "abc" above only ever tracks one lineage).
+    Built b = build("cat|dog", 0);
+
+    assertEquals(3, b.cache.findLeftmostStart("xxxcatxxx", 0, b.step));
+    assertEquals(3, b.cache.findLeftmostStart("xxxdogxxx", 0, b.step));
+    assertEquals(-1, b.cache.findLeftmostStart("xxxxxxxxx", 0, b.step));
+    // "cad" shares a prefix with "cat" and a suffix with "dog" but is neither.
+    assertEquals(-1, b.cache.findLeftmostStart("xxxcadxxx", 0, b.step));
+  }
+
+  // --- (b) Adversarial unbounded-width case: localization across content wider than any fixed --
+  // --- window could handle, exercising the FALLBACK/frozen path once the cache hits DEFAULT_CAP --
+
+  @Test
+  void quotedString_unboundedWidthBody_findsExactOpeningQuote() throws Exception {
+    // '(?:''|[^'])*' : a SQL-style quoted string (simplified standalone version of SQL_ANSI's
+    // quoted-string branch) whose body is unbounded width. Once the opening quote at index 3 is
+    // consumed, the single surviving candidate's age grows by 1 on every subsequent 'a' — so
+    // after enough characters this genuinely defeats the "same (subset, age-vector) pair recurs"
+    // boundedness LaurikariNfaStep's class javadoc describes for typical bounded-loop patterns:
+    // here the interned state space *does* grow with input length, DEFAULT_CAP (4096) is hit
+    // partway through the run of 'a's, and LaurikariDFACache.findLeftmostStart must fall through
+    // to nfaFallbackFindLeftmostStart to finish the scan. This test's whole point is to prove that
+    // fallback path is exactly as correct as the cached path, not merely that the cached path
+    // works for short inputs.
+    Built b = build("'(?:''|[^'])*'", 0);
+
+    String input = "xxx'" + "a".repeat(5000) + "'yyy";
+    assertEquals(3, b.cache.findLeftmostStart(input, 0, b.step));
+  }
+
+  // --- (c) Genuine merge-tie case ------------------------------------------------------------
+
+  @Test
+  void repetition_selfAnchoringRestart_neverOverridesOlderSurvivingCandidate() throws Exception {
+    // a+b built by ThompsonBuilder (traced and verified, not assumed) has exactly these states:
+    //   0 --'a'--> 1 --eps--> {0, 2}
+    //   2 --'b'--> 3 --eps--> 4 (accept)
+    // i.e. state 1's epsilon fans out to BOTH state 0 (loop back for another 'a') and state 2
+    // (proceed to try 'b'), and state 0 is *also* the pattern's start state, so it is always
+    // re-seeded at age 0 by step 3's fresh self-anchoring closure(startId).
+    //
+    // Scanning "aaab" from position 0:
+    //   pos0 'a': dfa1 = {0,1,2}@{1,1,1}   (closure of consuming-target 1@1 reaches 0@1 and 2@1)
+    //   pos1 'a': dfa2 = {0,1,2}@{2,2,2}
+    //   pos2 'a': dfa3 = {0,1,2}@{3,3,3}
+    //   pos3 'b': dfa4 = {0,3,4}@{0,4,4}  -- accepting (state 4), winning age 4 -> start = 0
+    //
+    // At every one of those first three steps, state 0 is reached by TWO different-aged
+    // candidates in the same LaurikariNfaStep.apply call: the loop-back copy carried through
+    // closure of the consuming step (age k, k = pos+1: the original candidate that started
+    // consuming 'a' at position 0 and has survived k steps) AND the fresh self-anchoring
+    // re-injection of closure(startId) at age 0 (a brand-new candidate about to attempt starting
+    // its own match at the next position). This is the genuine collision: same target NFA state
+    // (id 0), reached via two different paths with two different ages in a single merge. The
+    // "keep the larger age" rule (k > 0 for k >= 1) means the fresh restart never overwrites the
+    // older, more-leftmost lineage's age at state 0 — which is exactly what preserves the correct
+    // start-position bookkeeping all the way to the eventual accept at position 3, where the
+    // winning age (4) recovers start = (3+1)-4 = 0, not some later restart's (wrong) start.
+    //
+    // Fresher restarts injected at positions 1, 2, or 3 are genuinely dead ends for reaching the
+    // 'b'-consuming state 2: they would need to consume an 'a' first (state0 --'a'--> state1), but
+    // by the time any of them could reach state1 and loop to state2, the input's only 'b' (at
+    // position 3) has already been consumed by the original, older lineage — so state 2/3/4 are
+    // never subject to the same double-arrival collision state 0 sees; only state 0 is contested,
+    // and only because it is simultaneously the loop-back epsilon target and the start state.
+    Built b = build("a+b", 0);
+
+    assertEquals(0, b.cache.findLeftmostStart("aaab", 0, b.step));
+  }
+
+  // --- (d) Genuine combinatorial stress: many candidates of different ages colliding under -----
+  // --- branchy input, as distinct from (b)'s single-lineage monotonic-age growth. Measured -----
+  // --- growth (via a throwaway sweep, not asserted here): stateCount ~= 2*cycleUnits - 1, i.e. ---
+  // --- LINEAR in input length, reaching DEFAULT_CAP (4096) at ~2050 cycle units -- confirming ---
+  // --- that Phase 0's age-based cache does NOT generally bound state growth by NFA structure ---
+  // --- alone; it only stays small on inputs like SQL_ANSI/LONG's benign filler because that ----
+  // --- filler keeps almost nothing alive. This test documents the real failure mode rather than -
+  // --- pretending it doesn't happen: FALLBACK is expected and exercised, and the assertion is ---
+  // --- that the fallback path still localizes correctly despite it, not that the cap is avoided.
+
+  @Test
+  void denseAlternation_manyOverlappingCandidateAges_hitsCapButFallbackStaysCorrect()
+      throws Exception {
+    // Six disjoint 3-char branches over a 2-letter alphabet, looped, requiring a trailing 'z' to
+    // accept. Every position in an a/b run is a fresh self-anchoring restart (step 3 of
+    // LaurikariNfaStep's merge), so scanning a long a/b string keeps many candidates that started
+    // at different offsets simultaneously alive at different ages as they race through the shared
+    // alternation -- unlike quotedString_unboundedWidthBody's test above, where only ONE lineage
+    // ever survives past the opening quote, here many *different* (subset, age-vector) combinations
+    // are live across the scan, and the growth is driven by that diversity, not one candidate's
+    // age.
+    Built b = build("(?:aab|aba|baa|abb|bab|bba)*z", 0);
+
+    // 3000 cycle units (well past the ~2050-unit point where the sweep above hits DEFAULT_CAP),
+    // then a single trailing 'z' so the only way to reach it is through
+    // nfaFallbackFindLeftmostStart
+    // once the cache has frozen.
+    StringBuilder sb = new StringBuilder();
+    String[] cycle = {"a", "b", "ab", "ba", "aab", "bba"};
+    for (int i = 0; i < 3000; i++) {
+      sb.append(cycle[i % cycle.length]);
+    }
+    sb.append('z');
+    String denseInput = sb.toString();
+
+    java.util.regex.Matcher oracle =
+        java.util.regex.Pattern.compile("(?:aab|aba|baa|abb|bab|bba)*z").matcher(denseInput);
+    assertTrue(oracle.find(), "JDK oracle must find a match (the trailing 'z' alone always does)");
+    int expectedStart = oracle.start();
+
+    assertEquals(expectedStart, b.cache.findLeftmostStart(denseInput, 0, b.step));
+
+    int stateCount = b.cache.stateCount();
+    assertEquals(
+        LaurikariDFACache.DEFAULT_CAP,
+        stateCount,
+        "expected this dense branchy input to hit DEFAULT_CAP (confirming real, input-length-driven"
+            + " growth, not a fixed NFA-structure bound) -- if this fails because stateCount is now"
+            + " LOWER, that's a genuine improvement worth re-deriving this test's sweep for; if"
+            + " it's HIGHER, the cache silently grew past its own advertised cap.");
+  }
+}

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDFACacheTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDFACacheTest.java
@@ -16,6 +16,8 @@
 package com.datadoghq.reggie.runtime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.datadoghq.reggie.codegen.automaton.NFA;
@@ -131,7 +133,7 @@ class LaurikariDFACacheTest {
     NFA.NFAState[] statesById = statesById(nfa);
     int stateCount = statesById.length;
     int startId = nfa.getStartState().id;
-    return (curStates, curRegs, c) -> {
+    return (curStates, curRegs, c, input, pos, regionEnd) -> {
       int[] rawAges = new int[stateCount];
       Arrays.fill(rawAges, -1);
       for (int i = 0; i < curStates.length; i++) {
@@ -350,5 +352,45 @@ class LaurikariDFACacheTest {
             + " growth, not a fixed NFA-structure bound) -- if this fails because stateCount is now"
             + " LOWER, that's a genuine improvement worth re-deriving this test's sweep for; if"
             + " it's HIGHER, the cache silently grew past its own advertised cap.");
+  }
+
+  // --- (e) TDFA Phase 2 anchorSensitive/asciiTables gating -------------------------------------
+  // Hand-rolled DFA-state graph (no real NFA involved -- LaurikariDFACache treats "NFA state ids"
+  // as opaque ints, only using anchorBearingStates[id] to decide anchor-sensitivity) with one
+  // anchor-bearing "NFA state" (id 0) and one anchor-free sibling (id 1), self-looping under a
+  // pass-through LaurikariNfaStep, both interned in the SAME cache instance. Proves the design
+  // doc's "zero risk to existing patterns" claim holds even within one shared cache: the
+  // anchor-sensitive DFA state's asciiTables entry is never populated no matter how many times it
+  // is stepped, while the anchor-free sibling's entry gets populated on its first step.
+
+  @Test
+  void anchorSensitiveState_neverPopulatesAsciiTable_siblingAnchorFreeStateDoes() {
+    boolean[] anchorBearingStates = {true, false}; // NFA state 0 is anchor-bearing, 1 is not
+    LaurikariNfaStep passThrough =
+        (curStates, curRegs, c, input, pos, regionEnd) ->
+            new LaurikariStepResult(curStates, curRegs);
+
+    LaurikariDFACache cache =
+        new LaurikariDFACache(new int[] {0}, new int[][] {{}}, new int[0], anchorBearingStates);
+    // Seed a second, anchor-free DFA state (subset {1}) in the SAME cache instance.
+    int anchorFreeState = cache.intern(new int[] {1}, new int[][] {{}});
+
+    assertTrue(
+        cache.anchorSensitive[0], "DFA state 0's subset touches the anchor-bearing NFA state");
+    assertTrue(
+        !cache.anchorSensitive[anchorFreeState],
+        "DFA state built from subset {1} touches no anchor-bearing NFA state");
+
+    for (int i = 0; i < 5; i++) {
+      cache.step(0, 'a', passThrough, "aaaaa", i + 1, 5);
+    }
+    assertNull(
+        cache.asciiTables[0],
+        "anchor-sensitive DFA state must never populate asciiTables, however often it's stepped");
+
+    cache.step(anchorFreeState, 'a', passThrough, "aaaaa", 1, 5);
+    assertNotNull(
+        cache.asciiTables[anchorFreeState],
+        "anchor-free sibling state must populate asciiTables on its first step");
   }
 }

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDFACacheTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDFACacheTest.java
@@ -354,6 +354,28 @@ class LaurikariDFACacheTest {
             + " it's HIGHER, the cache silently grew past its own advertised cap.");
   }
 
+  @Test
+  void denseAlternation_hitsCapAndFallbackScanExhaustsInputWithoutMatch() throws Exception {
+    // Same dense-branchy setup as the test above, but WITHOUT the trailing 'z' that lets the
+    // fallback scan accept: this drives nfaFallbackFindLeftmostStart's fallback loop all the way
+    // to the end of input with no accept ever reached, exercising its final `return -1` (as
+    // opposed to the sibling test above, which only exercises its mid-scan accept branch).
+    Built b = build("(?:aab|aba|baa|abb|bab|bba)*z", 0);
+
+    StringBuilder sb = new StringBuilder();
+    String[] cycle = {"a", "b", "ab", "ba", "aab", "bba"};
+    for (int i = 0; i < 3000; i++) {
+      sb.append(cycle[i % cycle.length]);
+    }
+    String denseInputNoZ = sb.toString();
+
+    assertEquals(-1, b.cache.findLeftmostStart(denseInputNoZ, 0, b.step));
+    assertEquals(
+        LaurikariDFACache.DEFAULT_CAP,
+        b.cache.stateCount(),
+        "expected the same dense growth (minus the final 'z' consumption) to still hit the cap");
+  }
+
   // --- (e) TDFA Phase 2 anchorSensitive/asciiTables gating -------------------------------------
   // Hand-rolled DFA-state graph (no real NFA involved -- LaurikariDFACache treats "NFA state ids"
   // as opaque ints, only using anchorBearingStates[id] to decide anchor-sensitivity) with one

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcherTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcherTest.java
@@ -312,4 +312,211 @@ class LaurikariDfaMatcherTest {
           "matches() diverged for " + input);
     }
   }
+
+  // --- FALLBACK-sentinel find() regression (Phase 2 discovery) -------------------------------
+  // runFind's DFA-cache-overflow branch used to restart PikeVMMatcher from the frozen scan
+  // position instead of the scan's original start, silently losing any already-consumed prefix
+  // of a still-in-progress match (see LaurikariDfaMatcher.runFind's FALLBACK branch). Only
+  // observable once findCache's 4096-state cap is exceeded, which requires a long, high-variety
+  // input -- Phase 1's fuzz coverage never drove find()-family calls this long.
+
+  @Test
+  void findSurvivesDfaCacheOverflowMidMatch() throws Exception {
+    String pattern = "(a)(b)*c";
+    LaurikariDfaMatcher m = laurikari(pattern, 2);
+    PikeVMMatcher oracle = pikeVm(pattern, 2);
+
+    StringBuilder sb = new StringBuilder("a");
+    for (int i = 0; i < 10_000; i++) sb.append('b');
+    sb.append('c');
+    String input = sb.toString();
+
+    assertTrue(oracle.find(input), "oracle sanity check");
+    assertTrue(m.find(input), "find() must not lose the match's prefix on cache overflow");
+    assertTrue(m.fallbackCount() > 0, "this input is expected to overflow findCache's state cap");
+    assertMatchEquals(oracle.findMatch(input), m.findMatch(input), 2, input);
+  }
+
+  // --- TDFA Phase 2 end-anchor/\b extension: the 5 new anchor types --------------------------
+  // Direct-construction differential coverage against the PikeVMMatcher oracle, mirroring the
+  // existing anchor-boundary section above but for END/STRING_END/STRING_END_ABSOLUTE/
+  // END_MULTILINE/WORD_BOUNDARY instead of the START-family.
+
+  @Test
+  void wordBoundary_leadingAndTrailing_matchesOracle() throws Exception {
+    String pattern = "\\b(\\w+)\\b";
+    int groupCount = 1;
+    LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    for (String input : new String[] {"foo", " foo ", "foo bar", "123", "", " ", "a1_2"}) {
+      assertAllApisMatchOracle(laurikari, oracle, groupCount, input);
+    }
+    assertEquals(0, laurikari.fallbackCount());
+  }
+
+  @Test
+  void endAnchor_trailingWithLineTerminators_matchesOracle() throws Exception {
+    String pattern = "(a+)$";
+    int groupCount = 1;
+    LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    for (String input :
+        new String[] {"aaa", "aaa\n", "aaa\r", "aaa\r\n", "aaa\n\n", "aaab", "", "aaa ", "aaa"}) {
+      assertAllApisMatchOracle(laurikari, oracle, groupCount, input);
+    }
+    assertEquals(0, laurikari.fallbackCount());
+  }
+
+  @Test
+  void stringEndAnchor_matchesOracle() throws Exception {
+    String pattern = "(a+)\\Z";
+    int groupCount = 1;
+    LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    for (String input : new String[] {"aaa", "aaa\n", "aaa\r\n", "aaab", ""}) {
+      assertAllApisMatchOracle(laurikari, oracle, groupCount, input);
+    }
+    assertEquals(0, laurikari.fallbackCount());
+  }
+
+  @Test
+  void stringEndAbsoluteAnchor_matchesOracle() throws Exception {
+    String pattern = "(a+)\\z";
+    int groupCount = 1;
+    LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    for (String input : new String[] {"aaa", "aaa\n", "aaa\r\n", "aaab", ""}) {
+      assertAllApisMatchOracle(laurikari, oracle, groupCount, input);
+    }
+    assertEquals(0, laurikari.fallbackCount());
+  }
+
+  @Test
+  void endMultilineAnchor_matchesOracleAcrossLines() throws Exception {
+    String pattern = "(?m)(a+)$";
+    int groupCount = 1;
+    LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    for (String input : new String[] {"aaa", "aaa\nbbb", "xxx\naaa\nyyy", "aaa\r\naaa", ""}) {
+      assertAllApisMatchOracle(laurikari, oracle, groupCount, input);
+    }
+    assertEquals(0, laurikari.fallbackCount());
+  }
+
+  @Test
+  void endAnchorInsideNonTailBranch_matchesOracle() throws Exception {
+    // Adversarial shape from the TDFA Phase 2 plan: the end anchor sits inside one alternation
+    // branch, with more pattern content (the 'c') following. No structural "leading/trailing-
+    // only" restriction is needed here -- checkAnchor is evaluated live per-occurrence.
+    String pattern = "(a$|b)c";
+    int groupCount = 1;
+    LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    for (String input : new String[] {"bc", "ac", "bcx", ""}) {
+      assertAllApisMatchOracle(laurikari, oracle, groupCount, input);
+    }
+    assertEquals(0, laurikari.fallbackCount());
+  }
+
+  @Test
+  void wordBoundary_findFromNonZeroOffset_matchesOracle() throws Exception {
+    // Cache-soundness regression (design doc's top-named risk): drives the SAME
+    // LaurikariDfaMatcher instance/caches across multiple findFrom offsets on the same input, so
+    // the same (subset, char) transition recurs at different absolute positions -- if \b's
+    // outcome were ever memoized instead of recomputed live, this would surface the divergence.
+    String pattern = "\\b(\\w+)\\b";
+    int groupCount = 1;
+    LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    String input = "foo bar baz";
+    for (int start = 0; start <= input.length(); start++) {
+      assertEquals(
+          oracle.findFrom(input, start),
+          laurikari.findFrom(input, start),
+          "findFrom(" + start + ") diverged");
+      assertMatchEquals(
+          oracle.findMatchFrom(input, start),
+          laurikari.findMatchFrom(input, start),
+          groupCount,
+          input + "@" + start);
+    }
+    assertEquals(0, laurikari.fallbackCount());
+  }
+
+  @Test
+  void endAnchor_sameSubsetRecursAtDifferentPositions_matchesOracle() throws Exception {
+    // Direct regression for the cache-soundness risk named in the design doc: a single instance
+    // is matched() against several inputs, some where the trailing 'a' run sits at true
+    // end-of-string and some where it doesn't -- if the DFA cache ever memoized an anchor-
+    // sensitive transition, a later call with a different regionEnd would read the wrong answer.
+    String pattern = "(a+)$";
+    int groupCount = 1;
+    LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    for (String input : new String[] {"aaa", "aaab", "aaa", "aa", "aaab", "aaa"}) {
+      assertAllApisMatchOracle(laurikari, oracle, groupCount, input);
+    }
+    assertEquals(0, laurikari.fallbackCount());
+  }
+
+  // --- SQL tokenizer regression (IastRegexpBenchmark) -----------------------------------------
+  // The three SQL dialect patterns whose \b\d+/(?m)...--.*$ anchors were the original motivation
+  // for this eligibility extension -- confirms they're now eligible and route through
+  // LaurikariDfaMatcher with zero fallbacks.
+
+  private static final String SQL_ANSI =
+      "(?i)(?m)[-+]?(?:x'[0-9a-f]+'|0x[0-9a-f]+|b'[0-9a-f]+'|0b[0-9a-f]+"
+          + "|\\d*\\.\\d+(?:E[-+]?\\d+[fd]?)?|\\b\\d+(?:E[-+]?\\d+[fd]?)?)"
+          + "|'(?:''|[^'])*'|--.*$|/\\*[\\s\\S]*\\*/";
+
+  private static final String SQL_MYSQL =
+      "(?i)(?m)[-+]?(?:x'[0-9a-f]+'|0x[0-9a-f]+|b'[0-9a-f]+'|0b[0-9a-f]+"
+          + "|\\d*\\.\\d+(?:E[-+]?\\d+[fd]?)?|\\b\\d+(?:E[-+]?\\d+[fd]?)?)"
+          + "|\"(?:\\\\\"|[^\"])*\"|'(?:\\\\'|[^'])*'|--.*$|/\\*[\\s\\S]*\\*/";
+
+  private static final String SQL_POSTGRESQL =
+      "(?i)(?m)[-+]?(?:x'[0-9a-f]+'|0x[0-9a-f]+|b'[0-9a-f]+'|0b[0-9a-f]+"
+          + "|\\d*\\.\\d+(?:E[-+]?\\d+[fd]?)?|\\b\\d+(?:E[-+]?\\d+[fd]?)?)"
+          + "|\\$(?:[a-zA-Z_]\\w*)?\\$|'(?:''|[^'])*'|--.*$|/\\*[\\s\\S]*\\*/";
+
+  private static final String SQL_INPUT =
+      "SELECT id, name FROM users -- fetch all users\nWHERE age > 0x1F AND salary = 1234.56\n"
+          + "/* block comment\n spanning lines */\n"
+          + "AND note = 'it''s fine' OR flag = b'101'";
+
+  private static void assertSqlRoutesThroughLaurikari(String pattern) throws Exception {
+    NFA nfa = nfa(pattern, 0);
+    assertTrue(
+        LaurikariEligibility.isEligible(nfa, false),
+        pattern + " must now be Laurikari-eligible (was rejected pre-Phase-2-extension)");
+
+    LaurikariDfaMatcher laurikari = laurikari(pattern, 0);
+    PikeVMMatcher oracle = pikeVm(pattern, 0);
+
+    assertAllApisMatchOracle(laurikari, oracle, 0, SQL_INPUT);
+    assertEquals(0, laurikari.fallbackCount(), pattern + " must not fall back to PikeVMMatcher");
+  }
+
+  @Test
+  void sqlAnsiTokenizer_routesThroughLaurikari() throws Exception {
+    assertSqlRoutesThroughLaurikari(SQL_ANSI);
+  }
+
+  @Test
+  void sqlMysqlTokenizer_routesThroughLaurikari() throws Exception {
+    assertSqlRoutesThroughLaurikari(SQL_MYSQL);
+  }
+
+  @Test
+  void sqlPostgresqlTokenizer_routesThroughLaurikari() throws Exception {
+    assertSqlRoutesThroughLaurikari(SQL_POSTGRESQL);
+  }
 }

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcherTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcherTest.java
@@ -41,8 +41,18 @@ class LaurikariDfaMatcherTest {
     return new ThompsonBuilder().build(ast, groupCount);
   }
 
+  private static NFA lazyAwareNfa(String pattern, int groupCount) throws Exception {
+    RegexNode ast = new RegexParser().parse(pattern);
+    return new ThompsonBuilder(true).build(ast, groupCount);
+  }
+
   private static LaurikariDfaMatcher laurikari(String pattern, int groupCount) throws Exception {
     return new LaurikariDfaMatcher(nfa(pattern, groupCount), pattern, groupCount);
+  }
+
+  private static LaurikariDfaMatcher laurikariLazyAware(String pattern, int groupCount)
+      throws Exception {
+    return new LaurikariDfaMatcher(lazyAwareNfa(pattern, groupCount), pattern, groupCount);
   }
 
   private static PikeVMMatcher pikeVm(String pattern, int groupCount) throws Exception {
@@ -232,5 +242,24 @@ class LaurikariDfaMatcherTest {
   @Test
   void fallbackCountStaysZero_acrossAllSmallPatterns() throws Exception {
     assertTrue(laurikari("(a+)(b+)", 2).fallbackCount() == 0);
+  }
+
+  // --- lazy-quantifier regressions surfaced by LaurikariAlgorithmicFuzzTest ------------------
+  // Reproduces residual JDK-oracle findings directly against LaurikariDfaMatcher (built with
+  // ThompsonBuilder(true), same as the fuzz harness) to determine whether they are a genuine
+  // engine bug or an artifact of the fuzz test's own NFA construction.
+
+  @Test
+  void lazyPlusQuantifier_matchesJdk() throws Exception {
+    String pattern = ".+?";
+    LaurikariDfaMatcher laurikari = laurikariLazyAware(pattern, 0);
+    java.util.regex.Pattern jdk = java.util.regex.Pattern.compile(pattern);
+
+    for (String input : new String[] {"0a011a-", "_111-bc", "10a", "bb0-"}) {
+      assertEquals(
+          jdk.matcher(input).matches(),
+          laurikari.matches(input),
+          "matches() diverged for " + input);
+    }
   }
 }

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcherTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcherTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datadoghq.reggie.codegen.ast.RegexNode;
+import com.datadoghq.reggie.codegen.automaton.NFA;
+import com.datadoghq.reggie.codegen.automaton.ThompsonBuilder;
+import com.datadoghq.reggie.codegen.parsing.RegexParser;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Impl-plan Task 1.5 (doc/2026-07-10-tdfa-capture-engine-impl-plan.md §3): direct-construction
+ * correctness tests for {@link LaurikariDfaMatcher} against a {@link PikeVMMatcher} oracle over the
+ * same NFA — models {@code PikeVMMatcherTest}'s direct-construction pattern (no {@code
+ * Reggie.compile()}).
+ */
+class LaurikariDfaMatcherTest {
+
+  private static NFA nfa(String pattern, int groupCount) throws Exception {
+    RegexNode ast = new RegexParser().parse(pattern);
+    return new ThompsonBuilder().build(ast, groupCount);
+  }
+
+  private static LaurikariDfaMatcher laurikari(String pattern, int groupCount) throws Exception {
+    return new LaurikariDfaMatcher(nfa(pattern, groupCount), pattern, groupCount);
+  }
+
+  private static PikeVMMatcher pikeVm(String pattern, int groupCount) throws Exception {
+    return new PikeVMMatcher(nfa(pattern, groupCount), pattern);
+  }
+
+  private static void assertMatchEquals(
+      MatchResult expected, MatchResult actual, int groupCount, String input) {
+    if (expected == null) {
+      assertNull(actual, "expected no match for " + input);
+      return;
+    }
+    assertNotNull(actual, "expected a match for " + input);
+    for (int g = 0; g <= groupCount; g++) {
+      assertEquals(
+          expected.start(g), actual.start(g), "group " + g + " start diverged for " + input);
+      assertEquals(expected.end(g), actual.end(g), "group " + g + " end diverged for " + input);
+    }
+  }
+
+  /**
+   * Runs the full matches/match/find/findFrom/findMatch/findMatchFrom surface against the oracle.
+   */
+  private static void assertAllApisMatchOracle(
+      LaurikariDfaMatcher laurikari, PikeVMMatcher oracle, int groupCount, String input) {
+    assertEquals(
+        oracle.matches(input), laurikari.matches(input), "matches() diverged for " + input);
+    assertMatchEquals(oracle.match(input), laurikari.match(input), groupCount, input);
+
+    assertEquals(oracle.find(input), laurikari.find(input), "find() diverged for " + input);
+    assertEquals(
+        oracle.findFrom(input, 0),
+        laurikari.findFrom(input, 0),
+        "findFrom(0) diverged for " + input);
+    assertMatchEquals(oracle.findMatch(input), laurikari.findMatch(input), groupCount, input);
+    assertMatchEquals(
+        oracle.findMatchFrom(input, 0), laurikari.findMatchFrom(input, 0), groupCount, input);
+  }
+
+  // --- Phase 0.5 adversarial set -------------------------------------------------------------
+
+  @Test
+  void twoIndependentGroups_matchesOracle() throws Exception {
+    String pattern = "(a+)(b+)";
+    int groupCount = 2;
+    LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    for (String input : new String[] {"ab", "aaabbb", "aaaaaaaabb", "a", "xab", "abx"}) {
+      assertAllApisMatchOracle(laurikari, oracle, groupCount, input);
+    }
+    assertEquals(0, laurikari.fallbackCount(), "no fallback expected for small patterns/inputs");
+  }
+
+  @Test
+  void loopBodyGroup_matchesOracle() throws Exception {
+    String pattern = "(ab)+";
+    int groupCount = 1;
+    LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    for (String input : new String[] {"ab", "abab", "ababab", "x", "ababx"}) {
+      assertAllApisMatchOracle(laurikari, oracle, groupCount, input);
+    }
+    assertEquals(0, laurikari.fallbackCount());
+  }
+
+  @Test
+  void nestedNullableGroups_matchesOracle() throws Exception {
+    String pattern = "((a)|())*";
+    int groupCount = 3;
+    LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    for (String input : new String[] {"", "a", "aa", "aaa"}) {
+      assertAllApisMatchOracle(laurikari, oracle, groupCount, input);
+    }
+    assertEquals(0, laurikari.fallbackCount());
+  }
+
+  // --- shared-prefix alternation with distinct capture groups per branch ---------------------
+
+  @Test
+  void sharedPrefixAlternation_matchesOracle() throws Exception {
+    String pattern = "(foobar)|(foobaz)";
+    int groupCount = 2;
+    LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    for (String input : new String[] {"foobar", "foobaz", "fooba", "xfoobar"}) {
+      assertAllApisMatchOracle(laurikari, oracle, groupCount, input);
+    }
+    assertEquals(0, laurikari.fallbackCount());
+  }
+
+  // --- unrolled-quantifier / multi-anchor style pattern ---------------------------------------
+
+  @Test
+  void quantifiedAlternation_matchesOracle() throws Exception {
+    String pattern = "(a|b){2,4}(c)";
+    int groupCount = 2;
+    LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    for (String input : new String[] {"aac", "abbac", "bbbbc", "ac", "aaaac", "xabc"}) {
+      assertAllApisMatchOracle(laurikari, oracle, groupCount, input);
+    }
+    assertEquals(0, laurikari.fallbackCount());
+  }
+
+  // --- no-match and zero-length-match cases, anchored and find-family -------------------------
+
+  @Test
+  void noMatch_bothAnchoredAndFind() throws Exception {
+    String pattern = "(a+)(b+)";
+    int groupCount = 2;
+    LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    String input = "xyz";
+    assertFalse(laurikari.matches(input));
+    assertNull(laurikari.match(input));
+    assertFalse(laurikari.find(input));
+    assertEquals(-1, laurikari.findFrom(input, 0));
+    assertNull(laurikari.findMatch(input));
+    assertAllApisMatchOracle(laurikari, oracle, groupCount, input);
+    assertEquals(0, laurikari.fallbackCount());
+  }
+
+  @Test
+  void zeroLengthMatch_anchoredAndFind() throws Exception {
+    String pattern = "(a*)";
+    int groupCount = 1;
+    LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    for (String input : new String[] {"", "b", "a", "aaa"}) {
+      assertAllApisMatchOracle(laurikari, oracle, groupCount, input);
+    }
+    assertEquals(0, laurikari.fallbackCount());
+  }
+
+  // --- findFrom at a non-zero offset, and full capture-span pinning ---------------------------
+
+  @Test
+  void findFromNonZeroOffset_matchesOracleCaptures() throws Exception {
+    String pattern = "(a+)(b+)";
+    int groupCount = 2;
+    LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    String input = "xxxaabbxxxaaabbb";
+    for (int start : new int[] {0, 1, 3, 8, 11, input.length()}) {
+      assertEquals(
+          oracle.findFrom(input, start),
+          laurikari.findFrom(input, start),
+          "findFrom(" + start + ") diverged");
+      MatchResult expected = oracle.findMatchFrom(input, start);
+      MatchResult actual = laurikari.findMatchFrom(input, start);
+      assertMatchEquals(expected, actual, groupCount, input + "@" + start);
+    }
+    assertEquals(0, laurikari.fallbackCount());
+  }
+
+  @Test
+  void captureSpans_pinnedAgainstOracleExactly() throws Exception {
+    String pattern = "(a+)(b+)";
+    int groupCount = 2;
+    LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    String input = "aaabbb";
+    MatchResult expected = oracle.match(input);
+    MatchResult actual = laurikari.match(input);
+    int[] expectedSpans = new int[2 * (groupCount + 1)];
+    int[] actualSpans = new int[2 * (groupCount + 1)];
+    for (int g = 0; g <= groupCount; g++) {
+      expectedSpans[2 * g] = expected.start(g);
+      expectedSpans[2 * g + 1] = expected.end(g);
+      actualSpans[2 * g] = actual.start(g);
+      actualSpans[2 * g + 1] = actual.end(g);
+    }
+    assertArrayEquals(expectedSpans, actualSpans);
+    assertEquals(0, laurikari.fallbackCount());
+  }
+
+  @Test
+  void fallbackCountStaysZero_acrossAllSmallPatterns() throws Exception {
+    assertTrue(laurikari("(a+)(b+)", 2).fallbackCount() == 0);
+  }
+}

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcherTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcherTest.java
@@ -579,10 +579,13 @@ class LaurikariDfaMatcherTest {
   // --- hasNewAnchor cache-overflow FALLBACK at the *seed* (as opposed to
   // --- findSurvivesDfaCacheOverflowMidMatch's mid-scan FALLBACK): runAnchored/runFind's
   // --- hasNewAnchor branches recompute their seed live via anchoredCache.intern/findCache.intern
-  // --- on every call (see LaurikariDfaMatcher's class javadoc on why -- the constructor-precomputed
-  // --- seeds are just placeholders for hasNewAnchor patterns). Once a prior call has already frozen
+  // --- on every call (see LaurikariDfaMatcher's class javadoc on why -- the
+  // constructor-precomputed
+  // --- seeds are just placeholders for hasNewAnchor patterns). Once a prior call has already
+  // frozen
   // --- the cache, a *later* call whose live seed key was never interned before must itself return
-  // --- FALLBACK, delegating the whole call to PikeVMMatcher -- exercised here for both the anchored
+  // --- FALLBACK, delegating the whole call to PikeVMMatcher -- exercised here for both the
+  // anchored
   // --- (matches()/match()) and self-anchoring (find()/findFrom()) drivers, and for both a
   // --- fallback-still-matches and a fallback-finds-nothing outcome.
 
@@ -641,12 +644,16 @@ class LaurikariDfaMatcherTest {
   // --- runFind's FALLBACK-mid-scan ternary's "best != null" branch: unlike
   // --- findSurvivesDfaCacheOverflowMidMatch (whose pattern can't accept before the mandatory
   // --- trailing 'c', so `best` is always still null when FALLBACK hits), this pattern's trailing
-  // --- 'c' is optional, so every prefix "a", "ab", "abb", ... is already a valid (shorter) match --
+  // --- 'c' is optional, so every prefix "a", "ab", "abb", ... is already a valid (shorter) match
+  // --
   // --- `best` is non-null well before the cache overflows deep into the 'b' run. Per runFind's own
-  // --- javadoc (LaurikariDfaMatcher.java:279-283), a mid-scan FALLBACK with a non-null `best` returns
+  // --- javadoc (LaurikariDfaMatcher.java:279-283), a mid-scan FALLBACK with a non-null `best`
+  // returns
   // --- that already-recorded (possibly non-maximal) match as-is rather than delegating to the
-  // --- fallback engine to keep extending -- a deliberate whole-call-delegation-or-nothing trade-off,
-  // --- not a bug -- so this test checks self-consistency against the pattern, not equality with the
+  // --- fallback engine to keep extending -- a deliberate whole-call-delegation-or-nothing
+  // trade-off,
+  // --- not a bug -- so this test checks self-consistency against the pattern, not equality with
+  // the
   // --- oracle's true greedy (longest) match.
 
   @Test

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcherTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcherTest.java
@@ -363,7 +363,7 @@ class LaurikariDfaMatcherTest {
     PikeVMMatcher oracle = pikeVm(pattern, groupCount);
 
     for (String input :
-        new String[] {"aaa", "aaa\n", "aaa\r", "aaa\r\n", "aaa\n\n", "aaab", "", "aaa ", "aaa"}) {
+        new String[] {"aaa", "aaa\n", "aaa\r", "aaa\r\n", "aaa\n\n", "aaab", "", "aaa\u2028", "aaa\u0085"}) {
       assertAllApisMatchOracle(laurikari, oracle, groupCount, input);
     }
     assertEquals(0, laurikari.fallbackCount());

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcherTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcherTest.java
@@ -217,6 +217,56 @@ class LaurikariDfaMatcherTest {
     assertEquals(0, laurikari.fallbackCount());
   }
 
+  // --- anchor-boundary cases: regionEnd/scan-bound separation for start anchors --------------
+  // (design doc §"Task 1.5": the same bug class already fixed once in BitStateMatcher.search --
+  // confusing where a scan is allowed to *start* re-checking an anchor with where the scan's
+  // *content window* begins/ends. LaurikariDfaMatcher's analog is startDfaStateFor/
+  // reinjectDfaState/reinjectAfterNlDfaState: ^ must only ever fire at absolute position 0, and
+  // (?m)^ only at absolute 0 or immediately after a '\n', regardless of what offset findFrom is
+  // called with -- pinned here across multiple offsets against the PikeVMMatcher oracle.
+
+  @Test
+  void leadingStartAnchor_findFromOffsets_matchesOracle() throws Exception {
+    String pattern = "^(a+)";
+    int groupCount = 1;
+    LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    String input = "aaa\naaa";
+    for (int start : new int[] {0, 1, 3, 4, 6, input.length()}) {
+      assertEquals(
+          oracle.findFrom(input, start),
+          laurikari.findFrom(input, start),
+          "findFrom(" + start + ") diverged");
+      MatchResult expected = oracle.findMatchFrom(input, start);
+      MatchResult actual = laurikari.findMatchFrom(input, start);
+      assertMatchEquals(expected, actual, groupCount, input + "@" + start);
+    }
+    assertEquals(0, laurikari.fallbackCount());
+  }
+
+  @Test
+  void multilineStartAnchor_findFromAcrossNewlines_matchesOracle() throws Exception {
+    String pattern = "(?m)^(a+)";
+    int groupCount = 1;
+    LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    // '\n' at indices 2 and 6 -- (?m)^ is live at absolute 0 and immediately after each of those,
+    // i.e. positions 0, 3, 7; every other offset must have the anchor blocked.
+    String input = "xa\naaa\nxx";
+    for (int start : new int[] {0, 1, 2, 3, 4, 6, 7, 8, input.length()}) {
+      assertEquals(
+          oracle.findFrom(input, start),
+          laurikari.findFrom(input, start),
+          "findFrom(" + start + ") diverged");
+      MatchResult expected = oracle.findMatchFrom(input, start);
+      MatchResult actual = laurikari.findMatchFrom(input, start);
+      assertMatchEquals(expected, actual, groupCount, input + "@" + start);
+    }
+    assertEquals(0, laurikari.fallbackCount());
+  }
+
   @Test
   void captureSpans_pinnedAgainstOracleExactly() throws Exception {
     String pattern = "(a+)(b+)";

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcherTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcherTest.java
@@ -363,7 +363,9 @@ class LaurikariDfaMatcherTest {
     PikeVMMatcher oracle = pikeVm(pattern, groupCount);
 
     for (String input :
-        new String[] {"aaa", "aaa\n", "aaa\r", "aaa\r\n", "aaa\n\n", "aaab", "", "aaa\u2028", "aaa\u0085"}) {
+        new String[] {
+          "aaa", "aaa\n", "aaa\r", "aaa\r\n", "aaa\n\n", "aaab", "", "aaa\u2028", "aaa\u0085"
+        }) {
       assertAllApisMatchOracle(laurikari, oracle, groupCount, input);
     }
     assertEquals(0, laurikari.fallbackCount());

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcherTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariDfaMatcherTest.java
@@ -451,6 +451,33 @@ class LaurikariDfaMatcherTest {
   }
 
   @Test
+  void multilineStartAnchorCombinedWithWordBoundary_findAcrossNewlines_matchesOracle()
+      throws Exception {
+    // Combines a START_MULTILINE reinject ((?m)^) with a WORD_BOUNDARY (hasNewAnchor): the
+    // find()-family reinject path must recompute the after-'\n' seed closure live via
+    // reinjectAfterNlClosure(input, pos, regionEnd) at each '\n' crossing, not the precomputed
+    // reinjectAfterNlStates field (which predates the input string and can't evaluate \b).
+    String pattern = "(?m)^\\w+\\b";
+    int groupCount = 0;
+    LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    String input = "xx\nfoo bar\nx\nbaz9 qux";
+    for (int start = 0; start <= input.length(); start++) {
+      assertEquals(
+          oracle.findFrom(input, start),
+          laurikari.findFrom(input, start),
+          "findFrom(" + start + ") diverged");
+      assertMatchEquals(
+          oracle.findMatchFrom(input, start),
+          laurikari.findMatchFrom(input, start),
+          groupCount,
+          input + "@" + start);
+    }
+    assertEquals(0, laurikari.fallbackCount());
+  }
+
+  @Test
   void endAnchor_sameSubsetRecursAtDifferentPositions_matchesOracle() throws Exception {
     // Direct regression for the cache-soundness risk named in the design doc: a single instance
     // is matched() against several inputs, some where the trailing 'a' run sits at true
@@ -518,5 +545,140 @@ class LaurikariDfaMatcherTest {
   @Test
   void sqlPostgresqlTokenizer_routesThroughLaurikari() throws Exception {
     assertSqlRoutesThroughLaurikari(SQL_POSTGRESQL);
+  }
+
+  // --- embedsNameMap: RuntimeCompiler consults this to decide whether to wrap the matcher in a
+  // --- NameEnrichingMatcher for named groups -- exercised directly here since this test suite
+  // --- constructs LaurikariDfaMatcher without going through RuntimeCompiler/Reggie.compile().
+
+  @Test
+  void embedsNameMap_returnsTrue() throws Exception {
+    LaurikariDfaMatcher m = laurikari("(a)(b)", 2);
+    assertTrue(m.embedsNameMap());
+  }
+
+  // --- findFrom(start > input.length()): runFind's own out-of-range guard, distinct from
+  // --- PikeVMMatcher's identical clamp (see class javadoc's comparison to BitStateMatcher.search).
+
+  @Test
+  void findFromStartBeyondInputLength_returnsNoMatch() throws Exception {
+    String pattern = "(a+)(b+)";
+    int groupCount = 2;
+    LaurikariDfaMatcher laurikari = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    String input = "aabb";
+    int start = input.length() + 5;
+    assertEquals(oracle.findFrom(input, start), laurikari.findFrom(input, start));
+    assertNull(laurikari.findMatchFrom(input, start));
+    assertEquals(0, laurikari.fallbackCount());
+  }
+
+  // --- hasNewAnchor cache-overflow FALLBACK at the *seed* (as opposed to
+  // --- findSurvivesDfaCacheOverflowMidMatch's mid-scan FALLBACK): runAnchored/runFind's
+  // --- hasNewAnchor branches recompute their seed live via anchoredCache.intern/findCache.intern
+  // --- on every call (see LaurikariDfaMatcher's class javadoc on why -- the constructor-precomputed
+  // --- seeds are just placeholders for hasNewAnchor patterns). Once a prior call has already frozen
+  // --- the cache, a *later* call whose live seed key was never interned before must itself return
+  // --- FALLBACK, delegating the whole call to PikeVMMatcher -- exercised here for both the anchored
+  // --- (matches()/match()) and self-anchoring (find()/findFrom()) drivers, and for both a
+  // --- fallback-still-matches and a fallback-finds-nothing outcome.
+
+  @Test
+  void hasNewAnchor_seedFallbackAfterAnchoredCacheOverflow() throws Exception {
+    String pattern = "\\b(a)(b)*c";
+    int groupCount = 2;
+    LaurikariDfaMatcher m = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    StringBuilder sb = new StringBuilder("a");
+    for (int i = 0; i < 10_000; i++) sb.append('b');
+    sb.append('c');
+    String overflowInput = sb.toString();
+    // Word-initial: satisfies the leading \b, so this call's live initial-closure seed is the
+    // "anchor satisfied" variant -- drives anchoredCache past DEFAULT_CAP via (b)*'s per-position
+    // register growth, exactly like findSurvivesDfaCacheOverflowMidMatch but for matches().
+    assertEquals(oracle.matches(overflowInput), m.matches(overflowInput));
+    assertTrue(m.fallbackCount() > 0, "overflowInput must overflow anchoredCache mid-scan");
+
+    // Non-word-initial: \b fails at position 0, so this call's live seed is the anchor-*blocked*
+    // variant -- a key anchoredCache never interned before it froze -- forcing intern() to return
+    // FALLBACK directly from the seed check (runAnchored's hasNewAnchor branch), not mid-scan.
+    String blockedInput = " " + overflowInput;
+    assertNull(oracle.match(blockedInput), "oracle sanity check: leading \\b must fail here");
+    assertEquals(oracle.matches(blockedInput), m.matches(blockedInput));
+    assertNull(m.match(blockedInput));
+  }
+
+  @Test
+  void hasNewAnchor_seedFallbackAfterFindCacheOverflow() throws Exception {
+    String pattern = "\\b(a)(b)*c";
+    int groupCount = 2;
+    LaurikariDfaMatcher m = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    StringBuilder sb = new StringBuilder("a");
+    for (int i = 0; i < 10_000; i++) sb.append('b');
+    sb.append('c');
+    String overflowInput = sb.toString();
+    assertTrue(oracle.find(overflowInput), "oracle sanity check");
+    assertTrue(m.find(overflowInput), "find() must not lose the match's prefix on cache overflow");
+    assertTrue(m.fallbackCount() > 0, "overflowInput must overflow findCache mid-scan");
+
+    // A short, unrelated input scanned from a non-zero offset: findCache is already frozen, and
+    // this call's live reinject-seed key (startDfaStateFor's hasNewAnchor branch) was never
+    // interned before -- forcing FALLBACK directly at the seed, before any per-character stepping.
+    // No 'c' anywhere after the offset, so the delegated PikeVMMatcher scan also finds nothing.
+    String shortInput = "xx bbbbb";
+    int start = 3;
+    assertNull(oracle.findMatchFrom(shortInput, start), "oracle sanity check: no 'c' after offset");
+    assertEquals(oracle.findFrom(shortInput, start), m.findFrom(shortInput, start));
+    assertNull(m.findMatchFrom(shortInput, start));
+  }
+
+  // --- runFind's FALLBACK-mid-scan ternary's "best != null" branch: unlike
+  // --- findSurvivesDfaCacheOverflowMidMatch (whose pattern can't accept before the mandatory
+  // --- trailing 'c', so `best` is always still null when FALLBACK hits), this pattern's trailing
+  // --- 'c' is optional, so every prefix "a", "ab", "abb", ... is already a valid (shorter) match --
+  // --- `best` is non-null well before the cache overflows deep into the 'b' run. Per runFind's own
+  // --- javadoc (LaurikariDfaMatcher.java:279-283), a mid-scan FALLBACK with a non-null `best` returns
+  // --- that already-recorded (possibly non-maximal) match as-is rather than delegating to the
+  // --- fallback engine to keep extending -- a deliberate whole-call-delegation-or-nothing trade-off,
+  // --- not a bug -- so this test checks self-consistency against the pattern, not equality with the
+  // --- oracle's true greedy (longest) match.
+
+  @Test
+  void findSurvivesDfaCacheOverflow_withAlreadyRecordedBest() throws Exception {
+    String pattern = "\\b(a)(b)*c?";
+    int groupCount = 2;
+    LaurikariDfaMatcher m = laurikari(pattern, groupCount);
+    PikeVMMatcher oracle = pikeVm(pattern, groupCount);
+
+    StringBuilder sb = new StringBuilder("a");
+    for (int i = 0; i < 10_000; i++) sb.append('b');
+    String input = sb.toString();
+
+    assertTrue(oracle.find(input), "oracle sanity check");
+    assertTrue(m.find(input), "find() must keep the already-recorded best match on cache overflow");
+    assertTrue(m.fallbackCount() > 0, "input must overflow findCache mid-scan");
+
+    MatchResult oracleResult = oracle.findMatch(input);
+    MatchResult actual = m.findMatch(input);
+    assertNotNull(actual, "the already-recorded best match must survive the overflow");
+    assertEquals(0, actual.start(0), "group 0 start diverged");
+    assertEquals(0, actual.start(1), "group 1 start diverged");
+    assertEquals(1, actual.end(1), "group 1 ('a') must end right after position 0");
+    assertTrue(
+        actual.end(0) >= 1 && actual.end(0) <= oracleResult.end(0),
+        "the recorded best is truncated by the overflow, so its span must be a proper prefix of "
+            + "the oracle's true greedy match: expected 1 <= "
+            + actual.end(0)
+            + " <= "
+            + oracleResult.end(0));
+    assertTrue(
+        java.util.regex.Pattern.compile(pattern)
+            .matcher(input.substring(0, actual.end(0)))
+            .matches(),
+        "the recorded best span itself must be a valid, self-consistent match of the pattern");
   }
 }

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariEligibilityTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariEligibilityTest.java
@@ -63,16 +63,6 @@ class LaurikariEligibilityTest {
   }
 
   @Test
-  void wordBoundary_rejected() throws Exception {
-    assertFalse(eligible("\\bfoo", 0));
-  }
-
-  @Test
-  void endAnchor_rejected() throws Exception {
-    assertFalse(eligible("foo$", 0));
-  }
-
-  @Test
   void anchorInsideLoop_rejected() throws Exception {
     // Start anchor reachable after consuming a character -> not "leading-only".
     assertFalse(eligible("(^a|b)+", 0));
@@ -118,6 +108,49 @@ class LaurikariEligibilityTest {
   @Test
   void multilineStartAnchor_eligible() throws Exception {
     assertTrue(eligible("(?m)^(a+)", 1));
+  }
+
+  @Test
+  void wordBoundary_leading_eligible() throws Exception {
+    assertTrue(eligible("\\b(a+)", 1));
+  }
+
+  @Test
+  void wordBoundary_trailing_eligible() throws Exception {
+    assertTrue(eligible("(a+)\\b", 1));
+  }
+
+  @Test
+  void wordBoundary_midPattern_eligible() throws Exception {
+    assertTrue(eligible("(a+)\\b(b+)", 2));
+  }
+
+  @Test
+  void endAnchor_trailing_eligible() throws Exception {
+    assertTrue(eligible("(a+)$", 1));
+  }
+
+  @Test
+  void stringEndAnchor_eligible() throws Exception {
+    assertTrue(eligible("(a+)\\Z", 1));
+  }
+
+  @Test
+  void stringEndAbsoluteAnchor_eligible() throws Exception {
+    assertTrue(eligible("(a+)\\z", 1));
+  }
+
+  @Test
+  void endMultilineAnchor_eligible() throws Exception {
+    assertTrue(eligible("(?m)(a+)$", 1));
+  }
+
+  @Test
+  void endAnchorInsideNonTailLoop_eligible() throws Exception {
+    // Unlike the START-family, the 5 new anchor types are checked live per-occurrence (not baked
+    // into a build-time-precomputed closure), so no "leading/trailing-only" structural restriction
+    // is needed even when the anchor sits inside a repeating construct followed by more content.
+    assertTrue(eligible("(a$|b)c", 0));
   }
 
   @Test

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariEligibilityTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariEligibilityTest.java
@@ -84,6 +84,15 @@ class LaurikariEligibilityTest {
     assertFalse(LaurikariEligibility.isEligible(n, true));
   }
 
+  @Test
+  void allOptionalLoopBodyFollowedByMoreContent_rejected() throws Exception {
+    // Bug class: a quantified capturing group whose body can match zero-width, looped via an
+    // epsilon-only cycle, followed by more pattern content -- LaurikariCaptureNfaStep.addClosure's
+    // visited-on-first-arrival DFS can't propagate the fresher register vector from an extra
+    // zero-width loop iteration to that downstream content (see LaurikariEligibility javadoc).
+    assertFalse(eligible("([b1-ba]?.*0??)+1", 1));
+  }
+
   // --- positive cases --------------------------------------------------------------------------
 
   @Test

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariEligibilityTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariEligibilityTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datadoghq.reggie.codegen.ast.RegexNode;
+import com.datadoghq.reggie.codegen.automaton.NFA;
+import com.datadoghq.reggie.codegen.automaton.ThompsonBuilder;
+import com.datadoghq.reggie.codegen.parsing.RegexParser;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Impl-plan Task 1.3 (doc/2026-07-10-tdfa-capture-engine-impl-plan.md §3): one rejecting case per
+ * {@link LaurikariEligibility} exclusion reason, plus positive cases confirming ordinary capturing
+ * patterns pass.
+ */
+class LaurikariEligibilityTest {
+
+  private static NFA nfa(String pattern, int groupCount) throws Exception {
+    RegexNode ast = new RegexParser().parse(pattern);
+    return new ThompsonBuilder().build(ast, groupCount);
+  }
+
+  private static boolean eligible(String pattern, int groupCount) throws Exception {
+    return LaurikariEligibility.isEligible(nfa(pattern, groupCount), false);
+  }
+
+  // --- rejecting cases -----------------------------------------------------------------------
+
+  @Test
+  void lookahead_rejected() throws Exception {
+    assertFalse(eligible("a(?=b)", 0));
+  }
+
+  @Test
+  void negativeLookahead_rejected() throws Exception {
+    assertFalse(eligible("a(?!b)", 0));
+  }
+
+  @Test
+  void backreference_rejected() throws Exception {
+    assertFalse(eligible("(a)\\1", 1));
+  }
+
+  @Test
+  void atomicGroup_rejected() throws Exception {
+    assertFalse(eligible("(?>a+)b", 0));
+  }
+
+  @Test
+  void wordBoundary_rejected() throws Exception {
+    assertFalse(eligible("\\bfoo", 0));
+  }
+
+  @Test
+  void endAnchor_rejected() throws Exception {
+    assertFalse(eligible("foo$", 0));
+  }
+
+  @Test
+  void anchorInsideLoop_rejected() throws Exception {
+    // Start anchor reachable after consuming a character -> not "leading-only".
+    assertFalse(eligible("(^a|b)+", 0));
+  }
+
+  @Test
+  void usePosixLastMatch_rejected() throws Exception {
+    NFA n = nfa("(a|a)+", 1);
+    assertFalse(LaurikariEligibility.isEligible(n, true));
+  }
+
+  // --- positive cases --------------------------------------------------------------------------
+
+  @Test
+  void ordinaryTwoGroupConcatenation_eligible() throws Exception {
+    assertTrue(eligible("(a+)(b+)", 2));
+  }
+
+  @Test
+  void loopBodyGroup_eligible() throws Exception {
+    assertTrue(eligible("(ab)+", 1));
+  }
+
+  @Test
+  void nestedGroups_eligible() throws Exception {
+    assertTrue(eligible("((a)|())*", 2));
+  }
+
+  @Test
+  void leadingStartAnchor_eligible() throws Exception {
+    assertTrue(eligible("^(a+)(b+)", 2));
+  }
+
+  @Test
+  void multilineStartAnchor_eligible() throws Exception {
+    assertTrue(eligible("(?m)^(a+)", 1));
+  }
+
+  @Test
+  void usePosixLastMatchFalse_ordinaryPattern_eligible() throws Exception {
+    NFA n = nfa("(a+)(b+)", 2);
+    assertTrue(LaurikariEligibility.isEligible(n, false));
+  }
+}

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariHybridDisjointnessTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariHybridDisjointnessTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datadoghq.reggie.codegen.analysis.PatternAnalyzer;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Phase 2 Task 2.1a (doc/2026-07-10-tdfa-capture-engine-impl-plan.md): confirms that patterns
+ * routed to {@link HybridMatcher} via {@code usePosixLastMatch} never end up served by the
+ * Laurikari TDFA matcher instead.
+ *
+ * <p>{@code (^)(a)+b} is the reachable case: {@code routeBitState} rewrites its {@code
+ * PIKEVM_CAPTURE} result to {@code BITSTATE_CAPTURE} (the anchor-only capturing group {@code (^)}
+ * qualifies it), but {@code usePosixLastMatch} stays {@code true} (a capturing group, {@code (a)},
+ * sits inside a repeating quantifier). {@code RuntimeCompiler#compileInternal} returns from its
+ * {@code BITSTATE_CAPTURE} early-return branch before ever reaching the {@code shouldUseHybrid}
+ * check, so this pattern is actually compiled via {@code BitStateEntry}, not {@code HybridMatcher}
+ * -- disjointness holds by control flow, not by this pattern being routed elsewhere. {@code
+ * LaurikariEligibility.isEligible} independently rejects {@code usePosixLastMatch} patterns, so no
+ * Laurikari matcher gets attached to it either.
+ */
+public class LaurikariHybridDisjointnessTest {
+
+  @Test
+  void anchorOnlyGroupWithPosixQuantifiedGroup_routesToBitStateCapture() throws Exception {
+    assertEquals(
+        PatternAnalyzer.MatchingStrategy.BITSTATE_CAPTURE,
+        StrategyCorrectnessMetaTest.routeOf("(^)(a)+b"),
+        "(^)(a)+b must route to BITSTATE_CAPTURE, not HybridMatcher");
+  }
+
+  @Test
+  void anchorOnlyGroupWithPosixQuantifiedGroup_compilesToBitStateMatcherNotHybrid() {
+    ReggieMatcher m = RuntimeCompiler.compile("(^)(a)+b");
+    assertTrue(
+        m instanceof BitStateMatcher,
+        "(^)(a)+b must compile to BitStateMatcher, not " + m.getClass().getSimpleName());
+  }
+
+  @Test
+  void anchorOnlyGroupWithPosixQuantifiedGroup_matchesJdk() {
+    String pattern = "(^)(a)+b";
+    Pattern jdk = Pattern.compile(pattern);
+    ReggieMatcher reggie = RuntimeCompiler.compile(pattern);
+
+    assertEquals(jdk.matcher("aab").matches(), reggie.matches("aab"));
+    assertEquals(jdk.matcher("ab").matches(), reggie.matches("ab"));
+    assertEquals(jdk.matcher("b").matches(), reggie.matches("b"));
+  }
+}

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariPhase05Test.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariPhase05Test.java
@@ -148,7 +148,7 @@ class LaurikariPhase05Test {
   private static LaurikariNfaStep laurikariStep(NFA nfa, int[] tagOfState) {
     NFA.NFAState[] statesById = statesById(nfa);
     int stateCount = statesById.length;
-    return (curStates, curRegs, c) -> {
+    return (curStates, curRegs, c, input, pos, regionEnd) -> {
       boolean[] seenTarget = new boolean[stateCount];
       List<Integer> seedIds = new ArrayList<>();
       List<int[]> seedRegs = new ArrayList<>();
@@ -237,7 +237,8 @@ class LaurikariPhase05Test {
     int consumed = 0;
     for (int i = 0; i < input.length(); i++) {
       if (curStates.length == 0) return null;
-      LaurikariStepResult r = built.step.apply(curStates, curRegs, input.charAt(i));
+      LaurikariStepResult r =
+          built.step.apply(curStates, curRegs, input.charAt(i), input, i + 1, input.length());
       curStates = r.states;
       curRegs = r.regs;
       consumed++;

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariPhase05Test.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariPhase05Test.java
@@ -1,0 +1,406 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.datadoghq.reggie.codegen.ast.RegexNode;
+import com.datadoghq.reggie.codegen.automaton.NFA;
+import com.datadoghq.reggie.codegen.automaton.ThompsonBuilder;
+import com.datadoghq.reggie.codegen.parsing.RegexParser;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Phase 0.5 checkpoint (impl plan §2, doc/2026-07-10-tdfa-capture-engine-impl-plan.md): 2-3
+ * independent capture tags, exercising cross-tag merge conflicts that Phase 0's single
+ * total-ordered "age" tag ({@link LaurikariDFACacheTest}) cannot reach at all.
+ *
+ * <p><b>Tie-break discipline</b> (design §4, "whole-mapping priority discard"): unlike Phase 0's
+ * value-based "larger age wins," this driver tracks genuine priority order — a DFS through epsilon
+ * transitions in {@code curStates}' array order (index 0 = highest priority), first-visit wins,
+ * mirroring {@code PikeVMMatcher.addThread} exactly (see that method for the reference semantics
+ * this driver replicates). {@code curStates}' order is therefore load-bearing and never
+ * canonicalized/sorted, unlike Phase 0's driver.
+ *
+ * <p><b>Register encoding</b>: each of the {@code tagCount} registers stores an "age" (characters
+ * consumed since that tag was last set), exactly generalizing Phase 0's single age register to N
+ * independent ages instead of one — not "set to absolute position" (design/Task 1.2's eventual real
+ * mechanism, which needs runtime-substituted register *operations* to stay cache-friendly under an
+ * unbounded scan). Consuming a character ages every currently-set register by 1; closure resets a
+ * specific tag's age to 0 the moment it passes through that tag's {@code enterGroup}/ {@code
+ * exitGroup} marker state. The absolute tag position is recovered only once, at the end, as {@code
+ * consumed - age} — same formula Phase 0's {@code acceptAge} uses for its one tag. Choosing this
+ * encoding (over literal positions) is itself part of what Task 0.5.3 measures: if ages stay small
+ * in practice for these patterns, {@link LaurikariStateSetKey}'s value-based caching stays viable
+ * at this register shape; if they do not, that is precisely the state-space blowup signal this
+ * checkpoint exists to surface before Phase 1 commits to the real tag count.
+ *
+ * <p><b>Task 0.5.1a's hand-derivation</b> is confined to each pattern's small {@code tagSpecs}
+ * table below ({@code {groupNumber, isEnter}} pairs) — the closure/step driver itself is shared,
+ * generic machinery (not per-pattern hardcoded), reading {@link NFA.NFAState#enterGroup}/{@link
+ * NFA.NFAState#exitGroup} to resolve each spec to the concrete NFA state id(s) that carry it. This
+ * is legitimate: what's hand-picked is *which* 2-3 group boundaries matter for this checkpoint, not
+ * *how* a boundary maps to a state id (Phase 1's Task 1.1/1.2 generalizes this same lookup to
+ * literally every group instead of 2-3 hand-picked ones — the mechanism doesn't change, only the
+ * number of tags fed into it does).
+ *
+ * <p>Scope: this driver assumes an anchored whole-input match (mirrors {@code Matcher.matches()}
+ * semantics) — it accepts only if the NFA's accept state is live after consuming every input
+ * character, not the leftmost-find-localization semantics {@code LaurikariDFACacheTest} covers.
+ * That split (locate the match span, then extract its captures) matches how Phase 1's eventual
+ * capture engine is expected to compose with Phase 0's boolean/localization DFA (design §7) — this
+ * checkpoint only needs to validate the extraction half.
+ */
+class LaurikariPhase05Test {
+
+  // --- NFA plumbing, shared with LaurikariDFACacheTest's test-only driver -----------------------
+
+  private static NFA nfa(String pattern, int groupCount) throws Exception {
+    RegexNode ast = new RegexParser().parse(pattern);
+    return new ThompsonBuilder().build(ast, groupCount);
+  }
+
+  private static NFA.NFAState[] statesById(NFA nfa) {
+    NFA.NFAState[] arr = new NFA.NFAState[nfa.getStates().size()];
+    for (NFA.NFAState s : nfa.getStates()) {
+      arr[s.id] = s;
+    }
+    return arr;
+  }
+
+  /**
+   * Resolves each {@code tagSpecs[t] = {groupNumber, isEnter (1/0)}} entry to the NFA state id(s)
+   * that carry it: {@code tagOfState[id] = t} for every state matching tag {@code t}'s spec (see
+   * class javadoc's "Task 0.5.1a's hand-derivation" note — more than one state id can map to the
+   * same tag, e.g. {@code ((a)|())*}'s outer-close, reached via either alternation branch).
+   */
+  private static int[] tagOfState(NFA nfa, int stateCount, int[][] tagSpecs) {
+    int[] tagOfState = new int[stateCount];
+    Arrays.fill(tagOfState, -1);
+    for (NFA.NFAState s : nfa.getStates()) {
+      for (int t = 0; t < tagSpecs.length; t++) {
+        int group = tagSpecs[t][0];
+        boolean enter = tagSpecs[t][1] == 1;
+        if (enter
+            ? (s.enterGroup != null && s.enterGroup == group)
+            : (s.exitGroup != null && s.exitGroup == group)) {
+          tagOfState[s.id] = t;
+        }
+      }
+    }
+    return tagOfState;
+  }
+
+  private static int[] ageAll(int[] regs) {
+    int[] out = new int[regs.length];
+    for (int i = 0; i < regs.length; i++) {
+      out[i] = regs[i] < 0 ? -1 : regs[i] + 1;
+    }
+    return out;
+  }
+
+  /**
+   * Priority-ordered epsilon-closure DFS (first-visit wins per {@code visited}, mirroring {@code
+   * PikeVMMatcher.addThread}), resetting {@code tagOfState[id]}'s age to 0 at each tag boundary
+   * crossed and propagating every other tag's age unchanged.
+   */
+  private static void addClosure(
+      NFA.NFAState[] statesById,
+      boolean[] visited,
+      List<Integer> outIds,
+      List<int[]> outRegs,
+      int[] tagOfState,
+      int id,
+      int[] regs) {
+    if (visited[id]) return;
+    visited[id] = true;
+    int tag = tagOfState[id];
+    int[] r = regs;
+    if (tag >= 0) {
+      r = regs.clone();
+      r[tag] = 0;
+    }
+    outIds.add(id);
+    outRegs.add(r);
+    for (NFA.NFAState e : statesById[id].getEpsilonTransitions()) {
+      addClosure(statesById, visited, outIds, outRegs, tagOfState, e.id, r);
+    }
+  }
+
+  /** {@link LaurikariNfaStep} implementing the whole-mapping priority-discard rule (design §4). */
+  private static LaurikariNfaStep laurikariStep(NFA nfa, int[] tagOfState) {
+    NFA.NFAState[] statesById = statesById(nfa);
+    int stateCount = statesById.length;
+    return (curStates, curRegs, c) -> {
+      boolean[] seenTarget = new boolean[stateCount];
+      List<Integer> seedIds = new ArrayList<>();
+      List<int[]> seedRegs = new ArrayList<>();
+      for (int i = 0; i < curStates.length; i++) {
+        NFA.NFAState s = statesById[curStates[i]];
+        for (NFA.Transition t : s.getTransitions()) {
+          if (t.chars.contains((char) c)) {
+            int tid = t.target.id;
+            if (!seenTarget[tid]) {
+              seenTarget[tid] = true;
+              seedIds.add(tid);
+              seedRegs.add(ageAll(curRegs[i]));
+            }
+          }
+        }
+      }
+      boolean[] visited = new boolean[stateCount];
+      List<Integer> outIds = new ArrayList<>();
+      List<int[]> outRegs = new ArrayList<>();
+      for (int i = 0; i < seedIds.size(); i++) {
+        addClosure(
+            statesById, visited, outIds, outRegs, tagOfState, seedIds.get(i), seedRegs.get(i));
+      }
+      int[] states = new int[outIds.size()];
+      for (int i = 0; i < states.length; i++) states[i] = outIds.get(i);
+      int[][] regs = outRegs.toArray(new int[0][]);
+      return new LaurikariStepResult(states, regs);
+    };
+  }
+
+  private static final class Built {
+    final NFA nfa;
+    final int[] initStates;
+    final int[][] initRegs;
+    final LaurikariNfaStep step;
+    final int acceptId;
+    final int tagCount;
+
+    Built(
+        NFA nfa,
+        int[] initStates,
+        int[][] initRegs,
+        LaurikariNfaStep step,
+        int acceptId,
+        int tagCount) {
+      this.nfa = nfa;
+      this.initStates = initStates;
+      this.initRegs = initRegs;
+      this.step = step;
+      this.acceptId = acceptId;
+      this.tagCount = tagCount;
+    }
+  }
+
+  private static Built build(String pattern, int groupCount, int[][] tagSpecs) throws Exception {
+    NFA nfa = nfa(pattern, groupCount);
+    NFA.NFAState[] statesById = statesById(nfa);
+    int stateCount = statesById.length;
+    int startId = nfa.getStartState().id;
+    int tagCount = tagSpecs.length;
+    int[] tagOfState = tagOfState(nfa, stateCount, tagSpecs);
+
+    int[] allUnset = new int[tagCount];
+    Arrays.fill(allUnset, -1);
+    boolean[] visited = new boolean[stateCount];
+    List<Integer> outIds = new ArrayList<>();
+    List<int[]> outRegs = new ArrayList<>();
+    addClosure(statesById, visited, outIds, outRegs, tagOfState, startId, allUnset);
+    int[] initStates = new int[outIds.size()];
+    for (int i = 0; i < initStates.length; i++) initStates[i] = outIds.get(i);
+    int[][] initRegs = outRegs.toArray(new int[0][]);
+
+    int acceptId = nfa.getAcceptStates().iterator().next().id;
+    return new Built(nfa, initStates, initRegs, laurikariStep(nfa, tagOfState), acceptId, tagCount);
+  }
+
+  /**
+   * Runs the whole {@code input} through {@code built}'s step function (uncached — this is a
+   * correctness driver, not the growth-measurement one below) and returns the absolute tag
+   * positions at the accept state once every character is consumed, or {@code null} if the accept
+   * state isn't live at the end (no whole-input match).
+   */
+  private static int[] runToEnd(Built built, String input) {
+    int[] curStates = built.initStates;
+    int[][] curRegs = built.initRegs;
+    int consumed = 0;
+    for (int i = 0; i < input.length(); i++) {
+      if (curStates.length == 0) return null;
+      LaurikariStepResult r = built.step.apply(curStates, curRegs, input.charAt(i));
+      curStates = r.states;
+      curRegs = r.regs;
+      consumed++;
+    }
+    int idx = -1;
+    for (int i = 0; i < curStates.length; i++) {
+      if (curStates[i] == built.acceptId) {
+        idx = i;
+        break;
+      }
+    }
+    if (idx < 0) return null;
+    int[] ages = curRegs[idx];
+    int[] absolute = new int[built.tagCount];
+    for (int t = 0; t < built.tagCount; t++) {
+      absolute[t] = ages[t] < 0 ? -1 : consumed - ages[t];
+    }
+    return absolute;
+  }
+
+  private static PikeVMMatcher pikeVm(String pattern, int groupCount) throws Exception {
+    NFA nfa = nfa(pattern, groupCount);
+    return new PikeVMMatcher(nfa, pattern);
+  }
+
+  // --- (a) (a+)(b+): 2 tags, group1's close + group2's open --------------------------------------
+
+  @Test
+  void twoIndependentGroups_greedyBoundaries_matchPikeVM() throws Exception {
+    int[][] tagSpecs = {{1, 0}, {2, 1}}; // tag0 = group1 exit, tag1 = group2 enter
+    Built built = build("(a+)(b+)", 2, tagSpecs);
+    PikeVMMatcher oracle = pikeVm("(a+)(b+)", 2);
+
+    for (String input : new String[] {"ab", "aaabbb", "aaaaaaaabb", "ab" /* min case */}) {
+      MatchResult oracleResult = oracle.match(input);
+      assertNotNull(oracleResult, "PikeVMMatcher must match " + input);
+
+      int[] absolute = runToEnd(built, input);
+      assertNotNull(absolute, "Laurikari driver must also match " + input);
+
+      // tag0 = group1's exit = oracle.end(1); tag1 = group2's enter = oracle.start(2)
+      assertArrayEquals(
+          new int[] {oracleResult.end(1), oracleResult.start(2)},
+          absolute,
+          "capture boundaries diverged from PikeVMMatcher for input " + input);
+    }
+  }
+
+  // --- (b) (ab)+: 2 tags, single group's open+close, re-set every loop iteration
+  // ------------------
+
+  @Test
+  void loopBodyGroup_reSetOnEveryIteration_matchesPikeVM() throws Exception {
+    int[][] tagSpecs = {{1, 1}, {1, 0}}; // tag0 = group1 enter, tag1 = group1 exit
+    Built built = build("(ab)+", 1, tagSpecs);
+    PikeVMMatcher oracle = pikeVm("(ab)+", 1);
+
+    for (String input : new String[] {"ab", "abab", "ababab", "abababababab"}) {
+      MatchResult oracleResult = oracle.match(input);
+      assertNotNull(oracleResult, "PikeVMMatcher must match " + input);
+
+      int[] absolute = runToEnd(built, input);
+      assertNotNull(absolute, "Laurikari driver must also match " + input);
+
+      // Perl/greedy semantics: group 1's final captured span is its LAST iteration, i.e. the
+      // input's
+      // trailing "ab" — exactly what oracle.start(1)/end(1) already report.
+      assertArrayEquals(
+          new int[] {oracleResult.start(1), oracleResult.end(1)},
+          absolute,
+          "loop-back re-set boundaries diverged from PikeVMMatcher for input " + input);
+    }
+  }
+
+  // --- (c) ((a)|())*: 3 tags, outer open/close + inner group's open (nullable-branch case) -------
+
+  @Test
+  void nestedGroupsWithNullableBranch_matchesPikeVM() throws Exception {
+    // tag0 = outer group1 enter, tag1 = outer group1 exit, tag2 = inner group2 (the "(a)" branch)
+    // enter. Group3 (the "()" branch) and group2's exit are deliberately untracked (design's
+    // "3 tags" scope, see class/plan doc).
+    int[][] tagSpecs = {{1, 1}, {1, 0}, {2, 1}};
+    Built built = build("((a)|())*", 3, tagSpecs);
+    PikeVMMatcher oracle = pikeVm("((a)|())*", 3);
+
+    // "a" then "" then "a": last iteration is the empty branch, so tag2 (inner group2's open) must
+    // reflect the LAST time group2 participated (an earlier iteration), not this run's final
+    // iteration — the exact nullable-branch subtlety this pattern is chosen to exercise.
+    for (String input : new String[] {"", "a", "aa", "aaa"}) {
+      MatchResult oracleResult = oracle.match(input);
+      assertNotNull(oracleResult, "PikeVMMatcher must match " + input);
+
+      int[] absolute = runToEnd(built, input);
+      assertNotNull(absolute, "Laurikari driver must also match " + input);
+
+      int expectedGroup2Start = oracleResult.start(2); // -1 if group 2 never participated
+      assertArrayEquals(
+          new int[] {oracleResult.start(1), oracleResult.end(1), expectedGroup2Start},
+          absolute,
+          "nested/nullable-branch boundaries diverged from PikeVMMatcher for input " + input);
+    }
+  }
+
+  // --- Task 0.5.3: state-count growth from N=2 (two patterns) to N=3, via the generalized
+  // ---------
+  // --- LaurikariDFACache caching layer (Task 0.5.1's actual production interning path, not the ---
+  // --- uncached driver above) over an adversarial input designed to keep several live candidate --
+  // --- register-age vectors distinct at once, the same shape as LaurikariDFACacheTest's own
+  // -------
+  // --- denseAlternation stress case.
+  //
+  // Report (printed, not asserted — this is a measurement, not a pass/fail check per Task 0.5.3):
+  // distinct DFA states materialized for each of the three patterns, to compare against Phase 0's
+  // already-reported single-tag numbers and each other.
+
+  @Test
+  void stateCountGrowth_twoAndThreeTags_reportedForPhase05ExitCriteria() throws Exception {
+    // Scale sweep per pattern (not a single data point) so the growth *rate* — not just one
+    // sample — is visible for the exit-criteria report. (a+)(b+)'s tag0 (group1's close) never
+    // resets once set, so its age grows for as long as the b+ tail keeps consuming — the same
+    // already-accepted-and-mitigated growth mode Phase 0's own quotedString adversarial test
+    // exercises (cap-and-fallback, not a new failure class). (ab)+/((a)|())*'s tags reset every
+    // loop iteration, so their ages stay small regardless of scale — the interesting comparison
+    // for "does tag COUNT itself drive blowup" (2 tags vs 3, both loop-reset).
+    for (int n : new int[] {100, 400, 1600}) {
+      report("(a+)(b+)", 2, new int[][] {{1, 0}, {2, 1}}, "a".repeat(n) + "b".repeat(n));
+    }
+    for (int n : new int[] {100, 400, 1600}) {
+      report("(ab)+", 1, new int[][] {{1, 1}, {1, 0}}, "ab".repeat(n));
+    }
+    for (int n : new int[] {100, 400, 1600}) {
+      report("((a)|())*", 3, new int[][] {{1, 1}, {1, 0}, {2, 1}}, "a".repeat(n));
+    }
+  }
+
+  private static void report(String pattern, int groupCount, int[][] tagSpecs, String input)
+      throws Exception {
+    Built built = build(pattern, groupCount, tagSpecs);
+    int[] acceptIds = {built.acceptId};
+    LaurikariDFACache cache = new LaurikariDFACache(built.initStates, built.initRegs, acceptIds);
+
+    int dfaState = 0;
+    int[] curStates = built.initStates;
+    int[][] curRegs = built.initRegs;
+    boolean fellBack = false;
+    for (int i = 0; i < input.length() && !fellBack; i++) {
+      int next = cache.lookupOrCompute(dfaState, input.charAt(i), built.step);
+      if (next == LaurikariDFACache.DEAD) break;
+      if (next == LaurikariDFACache.FALLBACK) {
+        fellBack = true;
+        break;
+      }
+      dfaState = next;
+    }
+    System.out.println(
+        "=== Phase 0.5 growth report: "
+            + pattern
+            + " (tagCount="
+            + tagSpecs.length
+            + ", inputLen="
+            + input.length()
+            + ") ===");
+    System.out.println("    distinct DFA states materialized: " + cache.stateCount());
+    System.out.println("    hit cap/fell back to uncached stepping: " + fellBack);
+  }
+}

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariPhase0SpikeTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariPhase0SpikeTest.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datadoghq.reggie.codegen.automaton.NFA;
+import com.datadoghq.reggie.codegen.automaton.ThompsonBuilder;
+import com.datadoghq.reggie.codegen.parsing.RegexParser;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Phase-0 exit-criteria evidence (impl plan Task 0.3,
+ * doc/2026-07-10-tdfa-capture-engine-impl-plan.md §1): builds a {@link LaurikariDFACache} over the
+ * real {@code SQL_ANSI} tokenizer pattern (mirrored from {@code IastRegexpBenchmark.SQL_ANSI}) and
+ * runs it over that benchmark's LONG-scale scan-prefix inputs — the exact shape that exceeds {@code
+ * BitStateMatcher.BUDGET_CELLS} and today gets punted all the way to {@code PikeVMMatcher}'s full
+ * thread simulation.
+ *
+ * <p>This is a throwaway measurement harness, not a correctness/regression suite: it exists purely
+ * to produce the three numbers Task 0.3 asks for (exact localization, materialized state count,
+ * rough wall-clock signal vs. the JDK oracle) for the Phase 0 exit-criteria report. The
+ * closure/step-function driver duplicates {@code LaurikariDFACacheTest}'s test-only driver verbatim
+ * (same legitimate test-only duplication rationale documented there) rather than sharing code
+ * across test classes, since both are disposable Phase-0 scaffolding.
+ */
+class LaurikariPhase0SpikeTest {
+
+  // --- SQL_ANSI, mirrored from IastRegexpBenchmark.java:101-104 --------------------------------
+  private static final String SQL_ANSI =
+      "(?i)(?m)[-+]?(?:x'[0-9a-f]+'|0x[0-9a-f]+|b'[0-9a-f]+'|0b[0-9a-f]+"
+          + "|\\d*\\.\\d+(?:E[-+]?\\d+[fd]?)?|\\b\\d+(?:E[-+]?\\d+[fd]?)?)"
+          + "|'(?:''|[^'])*'|--.*$|/\\*[\\s\\S]*\\*/";
+
+  // --- LONG-scale sqlMatch/sqlNoMatch, mirrored from IastRegexpBenchmark.java:241-260 (the third
+  // --- `pick(scale, ...)` argument, since IastRegexpBenchmark.pick() returns longV by default for
+  // --- any scale other than SHORT/MEDIUM, i.e. LONG). "col_x = col_y AND ".repeat(2000) is benign
+  // --- scan-prefix filler (no digits/quotes/comment markers) that BitStateMatcher's bounded budget
+  // --- cannot get through without falling all the way to PikeVMMatcher.
+  private static final String SQL_MATCH_LONG =
+      "SELECT * FROM users WHERE "
+          + "col_x = col_y AND ".repeat(2000)
+          + "id = 42 AND name = 'Alice' AND balance = 1234.56";
+  private static final String SQL_NO_MATCH_LONG =
+      "SELECT id, name, email FROM users WHERE "
+          + "col_x = col_y AND ".repeat(2000)
+          + "id = id ORDER BY id";
+
+  // --- Test-only LaurikariNfaStep driver, duplicated verbatim from LaurikariDFACacheTest ---------
+
+  private static NFA nfa(String pattern, int groupCount) throws Exception {
+    return new ThompsonBuilder().build(new RegexParser().parse(pattern), groupCount);
+  }
+
+  private static NFA.NFAState[] statesById(NFA nfa) {
+    NFA.NFAState[] arr = new NFA.NFAState[nfa.getStates().size()];
+    for (NFA.NFAState s : nfa.getStates()) {
+      arr[s.id] = s;
+    }
+    return arr;
+  }
+
+  private static int[][] closureWithAges(
+      NFA.NFAState[] statesById, int stateCount, int[] seedStates, int[] seedAges) {
+    int[] ages = new int[stateCount];
+    Arrays.fill(ages, -1);
+    Deque<Integer> worklist = new ArrayDeque<>();
+    for (int i = 0; i < seedStates.length; i++) {
+      int id = seedStates[i];
+      if (seedAges[i] > ages[id]) {
+        ages[id] = seedAges[i];
+        worklist.push(id);
+      }
+    }
+    while (!worklist.isEmpty()) {
+      int id = worklist.pop();
+      int age = ages[id];
+      for (NFA.NFAState e : statesById[id].getEpsilonTransitions()) {
+        if (age > ages[e.id]) {
+          ages[e.id] = age;
+          worklist.push(e.id);
+        }
+      }
+    }
+    return denseToSeed(ages, stateCount);
+  }
+
+  private static int[][] denseToSeed(int[] denseAges, int stateCount) {
+    int count = 0;
+    for (int v : denseAges) {
+      if (v >= 0) count++;
+    }
+    int[] states = new int[count];
+    int[] ages = new int[count];
+    int oi = 0;
+    for (int id = 0; id < stateCount; id++) {
+      if (denseAges[id] >= 0) {
+        states[oi] = id;
+        ages[oi] = denseAges[id];
+        oi++;
+      }
+    }
+    return new int[][] {states, ages};
+  }
+
+  private static LaurikariNfaStep laurikariStep(NFA nfa) {
+    NFA.NFAState[] statesById = statesById(nfa);
+    int stateCount = statesById.length;
+    int startId = nfa.getStartState().id;
+    return (curStates, curRegs, c) -> {
+      int[] rawAges = new int[stateCount];
+      Arrays.fill(rawAges, -1);
+      for (int i = 0; i < curStates.length; i++) {
+        NFA.NFAState s = statesById[curStates[i]];
+        int age = curRegs[i][0];
+        for (NFA.Transition t : s.getTransitions()) {
+          if (t.chars.contains((char) c)) {
+            int cand = age + 1;
+            if (cand > rawAges[t.target.id]) rawAges[t.target.id] = cand;
+          }
+        }
+      }
+      int[][] consumedSeed = denseToSeed(rawAges, stateCount);
+      int[][] consumedClosed =
+          closureWithAges(statesById, stateCount, consumedSeed[0], consumedSeed[1]);
+      int[][] freshClosed =
+          closureWithAges(statesById, stateCount, new int[] {startId}, new int[] {0});
+
+      int[] merged = new int[stateCount];
+      Arrays.fill(merged, -1);
+      for (int i = 0; i < consumedClosed[0].length; i++) {
+        merged[consumedClosed[0][i]] = consumedClosed[1][i];
+      }
+      for (int i = 0; i < freshClosed[0].length; i++) {
+        int id = freshClosed[0][i];
+        int age = freshClosed[1][i];
+        if (age > merged[id]) merged[id] = age;
+      }
+      int[][] out = denseToSeed(merged, stateCount);
+      int[] outStates = out[0];
+      int[] outAges = out[1];
+      int[][] outRegs = new int[outStates.length][];
+      for (int i = 0; i < outStates.length; i++) {
+        outRegs[i] = new int[] {outAges[i]};
+      }
+      return new LaurikariStepResult(outStates, outRegs);
+    };
+  }
+
+  private static final class Built {
+    final LaurikariDFACache cache;
+    final LaurikariNfaStep step;
+
+    Built(LaurikariDFACache cache, LaurikariNfaStep step) {
+      this.cache = cache;
+      this.step = step;
+    }
+  }
+
+  private static Built build(String pattern, int groupCount) throws Exception {
+    NFA nfa = nfa(pattern, groupCount);
+    NFA.NFAState[] statesById = statesById(nfa);
+    int stateCount = statesById.length;
+    int startId = nfa.getStartState().id;
+
+    int[][] startClosure =
+        closureWithAges(statesById, stateCount, new int[] {startId}, new int[] {0});
+
+    int[] acceptIds = new int[nfa.getAcceptStates().size()];
+    int ai = 0;
+    for (NFA.NFAState s : nfa.getAcceptStates()) {
+      acceptIds[ai++] = s.id;
+    }
+
+    int[] startStates = startClosure[0];
+    int[] startAges = startClosure[1];
+    int[][] startRegs = new int[startStates.length][];
+    for (int i = 0; i < startStates.length; i++) {
+      startRegs[i] = new int[] {startAges[i]};
+    }
+
+    LaurikariDFACache cache = new LaurikariDFACache(startStates, startRegs, acceptIds);
+    return new Built(cache, laurikariStep(nfa));
+  }
+
+  // --- Timing harness: NOT JMH-rigorous, explicitly a throwaway directional signal per the plan --
+
+  private static final int WARMUP_ITERS = 5;
+  private static final int MEASURED_ITERS = 5;
+
+  private static long medianNanos(long[] samples) {
+    long[] sorted = samples.clone();
+    Arrays.sort(sorted);
+    return sorted[sorted.length / 2];
+  }
+
+  @Test
+  void sqlAnsiLongScale_exactLocalization_stateCount_andRoughTiming() throws Exception {
+    // SQL_ANSI has no capturing groups (every parenthesis in it is (?i)/(?m)/(?:...)), so
+    // groupCount = 0, same convention LaurikariDFACacheTest uses for its own group-less patterns.
+    Built built = build(SQL_ANSI, 0);
+
+    // --- (3) Correctness on sqlMatch, oracle-derived (java.util.regex.Pattern is the oracle; the
+    // --- expected start is computed here, not hardcoded) -----------------------------------------
+    Pattern oracle = Pattern.compile(SQL_ANSI);
+    Matcher oracleMatcher = oracle.matcher(SQL_MATCH_LONG);
+    assertTrue(oracleMatcher.find(), "JDK oracle must find a match in SQL_MATCH_LONG");
+    int expectedStart = oracleMatcher.start();
+
+    int laurikariStart = built.cache.findLeftmostStart(SQL_MATCH_LONG, 0, built.step);
+    boolean exactLocalization = laurikariStart == expectedStart;
+    assertEquals(
+        expectedStart,
+        laurikariStart,
+        "LaurikariDFACache localized start must exactly match the JDK oracle's match start");
+
+    // --- (4) sqlNoMatch must return -1
+    // -------------------------------------------------------------
+    Matcher noMatchOracle = Pattern.compile(SQL_ANSI).matcher(SQL_NO_MATCH_LONG);
+    assertTrue(
+        !noMatchOracle.find(), "JDK oracle must NOT find a match in SQL_NO_MATCH_LONG (sanity)");
+    int laurikariNoMatch = built.cache.findLeftmostStart(SQL_NO_MATCH_LONG, 0, built.step);
+    assertEquals(-1, laurikariNoMatch, "LaurikariDFACache must report -1 on SQL_NO_MATCH_LONG");
+
+    // --- (b) total distinct DFA states materialized (package-private test-only accessor already
+    // --- present on LaurikariDFACache: stateCount())
+    // ----------------------------------------------
+    int stateCount = built.cache.stateCount();
+
+    // --- (c) rough wall-clock: LaurikariDFACache.findLeftmostStart vs Pattern.matcher().find(),
+    // --- same input (SQL_MATCH_LONG), 5 warmup + 5 measured iterations each, report the median of
+    // --- the measured set. Both sides reuse an already-"warm" object (the cache and the compiled
+    // --- Pattern respectively) across iterations, matching how each would actually be used
+    // --- repeatedly in production (one-time build cost amortized away) -- this is explicitly NOT
+    // --- JMH-quality, just a directional signal per the plan's own framing.
+    Pattern timingPattern = Pattern.compile(SQL_ANSI);
+
+    for (int i = 0; i < WARMUP_ITERS; i++) {
+      built.cache.findLeftmostStart(SQL_MATCH_LONG, 0, built.step);
+      timingPattern.matcher(SQL_MATCH_LONG).find();
+    }
+
+    long[] laurikariNanos = new long[MEASURED_ITERS];
+    for (int i = 0; i < MEASURED_ITERS; i++) {
+      long t0 = System.nanoTime();
+      built.cache.findLeftmostStart(SQL_MATCH_LONG, 0, built.step);
+      laurikariNanos[i] = System.nanoTime() - t0;
+    }
+
+    long[] jdkNanos = new long[MEASURED_ITERS];
+    for (int i = 0; i < MEASURED_ITERS; i++) {
+      long t0 = System.nanoTime();
+      timingPattern.matcher(SQL_MATCH_LONG).find();
+      jdkNanos[i] = System.nanoTime() - t0;
+    }
+
+    long laurikariMedianNanos = medianNanos(laurikariNanos);
+    long jdkMedianNanos = medianNanos(jdkNanos);
+
+    System.out.println("=== LaurikariPhase0SpikeTest / Phase 0 Task 0.3 measurements ===");
+    System.out.println("(a) exact localization vs JDK oracle: " + exactLocalization);
+    System.out.println(
+        "    expectedStart(JDK oracle)=" + expectedStart + " laurikariStart=" + laurikariStart);
+    System.out.println("(b) distinct DFA states materialized: " + stateCount);
+    System.out.println(
+        "(c) LaurikariDFACache.findLeftmostStart median nanos ("
+            + MEASURED_ITERS
+            + " measured, "
+            + WARMUP_ITERS
+            + " warmup): "
+            + laurikariMedianNanos
+            + " ns, all samples="
+            + Arrays.toString(laurikariNanos));
+    System.out.println(
+        "    Pattern.matcher(...).find() median nanos ("
+            + MEASURED_ITERS
+            + " measured, "
+            + WARMUP_ITERS
+            + " warmup): "
+            + jdkMedianNanos
+            + " ns, all samples="
+            + Arrays.toString(jdkNanos));
+    System.out.println(
+        "    ratio (JDK / Laurikari): "
+            + (jdkMedianNanos == 0 ? "n/a" : (double) jdkMedianNanos / laurikariMedianNanos));
+    System.out.println("==================================================================");
+  }
+}

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariPhase0SpikeTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LaurikariPhase0SpikeTest.java
@@ -126,7 +126,7 @@ class LaurikariPhase0SpikeTest {
     NFA.NFAState[] statesById = statesById(nfa);
     int stateCount = statesById.length;
     int startId = nfa.getStartState().id;
-    return (curStates, curRegs, c) -> {
+    return (curStates, curRegs, c, input, pos, regionEnd) -> {
       int[] rawAges = new int[stateCount];
       Arrays.fill(rawAges, -1);
       for (int i = 0; i < curStates.length; i++) {

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/NonWordBoundaryTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/NonWordBoundaryTest.java
@@ -91,6 +91,37 @@ class NonWordBoundaryTest {
   }
 
   @Test
+  void wordCharIncludesUnderscore() {
+    // '_' is a word char ([A-Za-z0-9_]), so there is no boundary between it and an adjacent
+    // letter/digit -- matches both Reggie's own \w and JDK's default (non-UNICODE_CHARACTER_CLASS)
+    // \b semantics.
+    // find() must skip position 0 (there IS a boundary before '_' at the very start of input)
+    // and match starting at position 1 (no boundary between '_' and 'a').
+    expectFindMatch("\\B\\w+", "_a", 1, 2);
+    expectFindMatch("\\bfoo_bar\\b", "foo_bar baz", 0, 7);
+    expectFindNone("foo\\b", "foo_bar");
+
+    String[] inputs = {"_", "_a", "a_", "_1", "1_", "__", "a_b", "_ a", "a _"};
+    for (String input : inputs) {
+      assertFindFamilyMatchesJdk("\\b\\w+\\b", input);
+      assertFindFamilyMatchesJdk("\\B\\w+", input);
+      assertFindFamilyMatchesJdk("\\w+\\B", input);
+    }
+  }
+
+  @Test
+  void wordCharExcludesNonAsciiLettersAndDigits() {
+    // Character.isLetterOrDigit would (incorrectly) treat Cyrillic letters as word chars; the
+    // ASCII-only definition must not, matching JDK's default (non-UNICODE_CHARACTER_CLASS) \b.
+    String[] inputs = {"д", "aд", "дa", " д ", "дд"};
+    for (String input : inputs) {
+      assertFindFamilyMatchesJdk("\\b\\w+\\b", input);
+      assertFindFamilyMatchesJdk("\\B", input);
+      assertFindFamilyMatchesJdk("\\b", input);
+    }
+  }
+
+  @Test
   void combinedWithBackreference() {
     // Linear pattern with a backreference plus a boundary anchor: routes through the
     // LINEAR_BACKREFERENCE strategy (LinearPatternAnalyzer/BackrefBacktrackMatcher), a

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/NonWordBoundaryTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/NonWordBoundaryTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datadoghq.reggie.Reggie;
+import com.datadoghq.reggie.ReggieOptions;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for issue #107: {@code \B} (non-word-boundary) used to be silently parsed as the
+ * literal character {@code 'B'} by {@code RegexParser.parseEscape}'s {@code default} branch.
+ */
+class NonWordBoundaryTest {
+
+  private static final ReggieOptions WITH_FALLBACK =
+      ReggieOptions.builder().allowJdkFallback().build();
+
+  @BeforeEach
+  void clearCache() {
+    RuntimeCompiler.clearCache();
+  }
+
+  @Test
+  void notParsedAsLiteralB() {
+    // If \B were still the literal 'B', "\\Bfoo" would require a literal "Bfoo" substring
+    // starting at index 0; the real non-word-boundary semantics match "foo" at [1,4) instead.
+    expectFindMatch("\\Bfoo", "Bfoo", 1, 4);
+  }
+
+  @Test
+  void basicNonWordBoundarySemantics() {
+    expectFindMatch("\\Bfoo", "xfoo", 1, 4);
+    expectFindNone("\\Bfoo", "foo");
+    expectFindNone("\\Bfoo", " foo");
+  }
+
+  @Test
+  void trailingNonWordBoundary() {
+    expectFindMatch("foo\\B", "foox", 0, 3);
+    expectFindNone("foo\\B", "foo");
+    expectFindNone("foo\\B", "foo ");
+  }
+
+  @Test
+  void midWordAndEmptyInput() {
+    expectFindMatch("\\B", "ab", 1, 1);
+    expectFindMatch("\\B", "", 0, 0);
+    expectFindNone("\\B", "a");
+  }
+
+  @Test
+  void combinedWithWordBoundaryAlternation() {
+    String[] inputs = {"", "a", "ab", "a b", " a ", "a1b2", "  ", "foo bar", "foobar"};
+    for (String input : inputs) {
+      assertFindFamilyMatchesJdk("\\b\\w+\\B", input);
+      assertFindFamilyMatchesJdk("\\B\\w+\\b", input);
+      assertFindFamilyMatchesJdk("(a\\B|b\\b)+", input);
+    }
+  }
+
+  @Test
+  void quantifiedAndAnchoredShapes() {
+    String[] inputs = {"", "x", "xx", "xxx", "1x1", " x ", "x\n", "\nx"};
+    for (String input : inputs) {
+      assertFindFamilyMatchesJdk("\\Bx+", input);
+      assertFindFamilyMatchesJdk("x+\\B", input);
+      assertFindFamilyMatchesJdk("^\\Bx", input);
+      assertFindFamilyMatchesJdk("x\\B$", input);
+      assertFindFamilyMatchesJdk("(?m)^x\\B", input);
+    }
+  }
+
+  private static void assertFindFamilyMatchesJdk(String regex, String input) {
+    Pattern jdk = Pattern.compile(regex);
+    Matcher jm = jdk.matcher(input);
+    boolean jdkMatched = jm.find();
+
+    ReggieMatcher m = Reggie.compile(regex, WITH_FALLBACK);
+    MatchResult mr = m.findMatch(input);
+
+    if (!jdkMatched) {
+      assertNull(
+          mr, () -> "Reggie found a match for /" + regex + "/ on \"" + input + "\", JDK did not");
+      return;
+    }
+    assertTrue(
+        mr != null && mr.start() == jm.start() && mr.end() == jm.end(),
+        () ->
+            "Reggie/JDK diverge for /"
+                + regex
+                + "/ on \""
+                + input
+                + "\": reggie="
+                + mr
+                + " jdk=["
+                + jm.start()
+                + ","
+                + jm.end()
+                + ")");
+  }
+
+  private static void expectFindMatch(String regex, String input, int start, int end) {
+    Pattern jdk = Pattern.compile(regex);
+    Matcher jm = jdk.matcher(input);
+    boolean jdkMatched = jm.find();
+    if (!(jdkMatched && jm.start() == start && jm.end() == end)) {
+      throw new IllegalArgumentException(
+          "Test premise wrong: JDK did not match pattern '"
+              + regex
+              + "' on '"
+              + input
+              + "' as ["
+              + start
+              + ","
+              + end
+              + ")");
+    }
+    ReggieMatcher m = Reggie.compile(regex, WITH_FALLBACK);
+    MatchResult mr = m.findMatch(input);
+    assertTrue(mr != null, () -> "Reggie find('" + input + "') for /" + regex + "/ should match");
+    assertEquals(start, mr.start());
+    assertEquals(end, mr.end());
+  }
+
+  private static void expectFindNone(String regex, String input) {
+    Pattern jdk = Pattern.compile(regex);
+    if (jdk.matcher(input).find()) {
+      throw new IllegalArgumentException(
+          "Test premise wrong: JDK matched pattern '" + regex + "' on '" + input + "'");
+    }
+    ReggieMatcher m = Reggie.compile(regex, WITH_FALLBACK);
+    MatchResult mr = m.findMatch(input);
+    assertNull(mr, () -> "Reggie find('" + input + "') for /" + regex + "/ should not match");
+  }
+}

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/NonWordBoundaryTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/NonWordBoundaryTest.java
@@ -90,6 +90,25 @@ class NonWordBoundaryTest {
     }
   }
 
+  @Test
+  void combinedWithBackreference() {
+    // Linear pattern with a backreference plus a boundary anchor: routes through the
+    // LINEAR_BACKREFERENCE strategy (LinearPatternAnalyzer/BackrefBacktrackMatcher), a
+    // different code path than the plain-anchor cases above (which route through BITSTATE_CAPTURE).
+    expectFindMatch("(a)\\1\\B", "aab", 0, 2);
+    expectFindNone("(a)\\1\\B", "aa");
+    expectFindNone("(a)\\1\\B", "aa ");
+
+    expectFindMatch("(a)\\1\\b", "aa", 0, 2);
+    expectFindNone("(a)\\1\\b", "aab");
+
+    String[] inputs = {"", "a", "aa", "aab", "aa ", "aaa", " aa "};
+    for (String input : inputs) {
+      assertFindFamilyMatchesJdk("(a)\\1\\B", input);
+      assertFindFamilyMatchesJdk("(a)\\1\\b", input);
+    }
+  }
+
   private static void assertFindFamilyMatchesJdk(String regex, String input) {
     Pattern jdk = Pattern.compile(regex);
     Matcher jm = jdk.matcher(input);

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/WordBoundaryFixedSequenceTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/WordBoundaryFixedSequenceTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datadoghq.reggie.codegen.analysis.PatternAnalyzer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Bare \b/\B + literal patterns (e.g. \bfoo, foo\b, \bfoo\b) route to SPECIALIZED_FIXED_SEQUENCE
+ * instead of the slower PIKEVM_CAPTURE fallback - see PatternAnalyzer.detectFixedSequence's
+ * leading/trailing boundary stripping and FixedSequenceBytecodeGenerator's isBoundary check.
+ */
+class WordBoundaryFixedSequenceTest {
+
+  @BeforeEach
+  void clearCache() {
+    RuntimeCompiler.clearCache();
+  }
+
+  @Test
+  void routesToSpecializedFixedSequence() throws Exception {
+    for (String regex :
+        new String[] {"\\bfoo", "foo\\b", "\\bfoo\\b", "\\Bfoo", "foo\\B", "\\Bfoo\\B"}) {
+      assertEquals(
+          PatternAnalyzer.MatchingStrategy.SPECIALIZED_FIXED_SEQUENCE,
+          StrategyCorrectnessMetaTest.routeOf(regex),
+          () -> "/" + regex + "/ should route to SPECIALIZED_FIXED_SEQUENCE");
+    }
+  }
+
+  @Test
+  void leadingWordBoundary() {
+    assertFindFamilyMatchesJdk("\\bfoo", "foo");
+    assertFindFamilyMatchesJdk("\\bfoo", "xfoo");
+    assertFindFamilyMatchesJdk("\\bfoo", " foo");
+    assertFindFamilyMatchesJdk("\\bfoo", "foobar");
+    assertFindFamilyMatchesJdk("\\bfoo", "");
+    assertFindFamilyMatchesJdk("\\bfoo", "fo");
+  }
+
+  @Test
+  void trailingWordBoundary() {
+    assertFindFamilyMatchesJdk("foo\\b", "foo");
+    assertFindFamilyMatchesJdk("foo\\b", "foox");
+    assertFindFamilyMatchesJdk("foo\\b", "foo ");
+    assertFindFamilyMatchesJdk("foo\\b", "xfoo");
+    assertFindFamilyMatchesJdk("foo\\b", "");
+  }
+
+  @Test
+  void bothWordBoundaries() {
+    assertFindFamilyMatchesJdk("\\bfoo\\b", "foo");
+    assertFindFamilyMatchesJdk("\\bfoo\\b", "foo bar");
+    assertFindFamilyMatchesJdk("\\bfoo\\b", "xfoo");
+    assertFindFamilyMatchesJdk("\\bfoo\\b", "foox");
+    assertFindFamilyMatchesJdk("\\bfoo\\b", "xfoox");
+    assertFindFamilyMatchesJdk("\\bfoo\\b", "");
+  }
+
+  @Test
+  void nonWordBoundaryVariants() {
+    assertFindFamilyMatchesJdk("\\Bfoo", "foo");
+    assertFindFamilyMatchesJdk("\\Bfoo", "xfoo");
+    assertFindFamilyMatchesJdk("foo\\B", "foo");
+    assertFindFamilyMatchesJdk("foo\\B", "foox");
+    assertFindFamilyMatchesJdk("\\Bfoo\\B", "foo");
+    assertFindFamilyMatchesJdk("\\Bfoo\\B", "xfoox");
+    assertFindFamilyMatchesJdk("\\Bfoo\\B", "xfoo");
+    assertFindFamilyMatchesJdk("\\Bfoo\\B", "foox");
+  }
+
+  private static void assertFindFamilyMatchesJdk(String regex, String input) {
+    Pattern jdk = Pattern.compile(regex);
+    Matcher jm = jdk.matcher(input);
+    boolean jdkMatched = jm.find();
+
+    ReggieMatcher m = RuntimeCompiler.compile(regex);
+    MatchResult mr = m.findMatch(input);
+
+    if (!jdkMatched) {
+      assertNull(
+          mr, () -> "Reggie found a match for /" + regex + "/ on \"" + input + "\", JDK did not");
+      return;
+    }
+    assertTrue(
+        mr != null && mr.start() == jm.start() && mr.end() == jm.end(),
+        () ->
+            "Reggie/JDK diverge for /"
+                + regex
+                + "/ on \""
+                + input
+                + "\": reggie="
+                + mr
+                + " jdk=["
+                + jm.start()
+                + ","
+                + jm.end()
+                + ")");
+
+    // matches() must agree with JDK's matches() (whole-string match), independent of find().
+    boolean jdkWholeMatch = jdk.matcher(input).matches();
+    assertEquals(
+        jdkWholeMatch,
+        m.matches(input),
+        () -> "matches() diverges from JDK for /" + regex + "/ on \"" + input + "\"");
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Introduces a Laurikari register-vector DFA (TDFA) as a capture-tracking fast path wired into `BitStateMatcher` ahead of the `PikeVM` fallback, extends its anchor eligibility to end-anchors and `\b`/`\B`, and adds a `SPECIALIZED_FIXED_SEQUENCE` bytecode fast path for bare word-boundary + literal patterns (e.g. `\bfoo`, `foo\b`, `\bfoo\b`) that previously fell back to the slower `PIKEVM_CAPTURE` strategy.

Also fixes `\B` being silently mis-parsed as the literal character `B`, and pins `com.diffplug.spotless` to `8.2.1` (`8.4.0`'s `googleJavaFormat` worker throws `NoClassDefFoundError` on `com.sun.tools.javac.tree.JCTree$JCAnyPattern` on this toolchain).

### Motivation

`\b`/`\B`-anchored and end-anchored patterns were categorically excluded from the DFA-native paths, forcing them onto the much slower NFA simulation. SQL-injection detection patterns (`\b\d+`, `--.*$` under `(?m)`) are a concrete example that benefited: SQL Find benchmarks moved from ~0.83-0.85x RE2J to a clear win, and the bare `\bfoo` benchmark went from losing to JDK/RE2J to 4.4-5.4x faster than JDK and ~13-15x faster than RE2J.

### Related Issue(s)

<!-- Link to related issues, e.g., Fixes #123, Implements RFC #456 -->

### Change Type

- [ ] Bug fix
- [x] New feature
- [x] Performance improvement
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [x] Test improvement
- [ ] Build/CI change

### Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] All existing tests pass (`./gradlew build`)
- [x] I have added tests for my changes
- [ ] I have updated documentation (if applicable)
- [x] My commits are signed

### Performance Impact

`IastRegexpBenchmark`'s `BARE_WORD_BOUNDARY` (`\bfoo`) benchmark: Reggie went from losing to JDK/RE2J at all scales to winning 4.4-5.4x vs JDK and ~13-15x vs RE2J. SQL Find benchmarks (`\b\d+`, multiline `--.*$`) improved from ~0.83-0.85x RE2J baseline.

### Additional Notes

`build.gradle`'s spotless plugin pin (8.2.1) is a workaround for a toolchain-local regression in 8.4.0, unrelated to the feature work, included here to unblock `spotlessApply` for this PR's own files.