### PR TITLE
feat: add Reggie runtime compile flags

### DIFF
--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
@@ -246,19 +246,7 @@ public class RegexParser {
       throw new ParseException("Unexpected metacharacter '" + ch + "' at position " + pos);
     } else {
       consume();
-      // Apply case-insensitive modifier if active
-      if (currentModifiers.isCaseInsensitive() && Character.isLetter(ch)) {
-        // Convert to character class [aA]
-        char lower = Character.toLowerCase(ch);
-        char upper = Character.toUpperCase(ch);
-        if (lower != upper) {
-          List<CharSet.Range> ranges = new ArrayList<>();
-          ranges.add(new CharSet.Range(lower, lower));
-          ranges.add(new CharSet.Range(upper, upper));
-          return new CharClassNode(CharSet.fromRanges(ranges), false);
-        }
-      }
-      return new LiteralNode(ch);
+      return literalNode(ch);
     }
   }
 
@@ -638,7 +626,7 @@ public class RegexParser {
 
           // First digit is 8 or 9 and no valid backref: treat as literal character '8' or '9'.
           pos = posBeforeFirst + 1; // restore to position just after the first digit
-          return new LiteralNode((char) ('0' + firstDigit));
+          return literalNode((char) ('0' + firstDigit));
         }
       case 'k':
         // Named backreference: \k<name> or \k'name'
@@ -655,7 +643,7 @@ public class RegexParser {
         return parseUnicodeProperty(true);
       default:
         // Escaped literal (e.g., \., \*, \+)
-        return new LiteralNode(ch);
+        return literalNode(ch);
     }
   }
 
@@ -707,7 +695,8 @@ public class RegexParser {
    * character represented by the hex value.
    */
   private RegexNode parseHexEscape() throws ParseException {
-    return parseHexEscapeInternal();
+    RegexNode node = parseHexEscapeInternal();
+    return node instanceof LiteralNode ? literalNode(((LiteralNode) node).ch) : node;
   }
 
   /** Internal implementation of hex escape parsing. Handles both \xhh and \x{NNNN} forms. */
@@ -774,7 +763,8 @@ public class RegexParser {
    * octal: - If result <= 99 and within group count, it's a backreference - Otherwise, it's octal
    */
   private RegexNode parseOctalEscape() throws ParseException {
-    return parseOctalEscapeInternal();
+    RegexNode node = parseOctalEscapeInternal();
+    return node instanceof LiteralNode ? literalNode(((LiteralNode) node).ch) : node;
   }
 
   /** Internal implementation of octal escape parsing. */
@@ -910,7 +900,7 @@ public class RegexParser {
         consume(); // consume 'E'
         break;
       }
-      parts.add(new LiteralNode(ch));
+      parts.add(literalNode(ch));
     }
 
     if (parts.isEmpty()) {
@@ -930,6 +920,20 @@ public class RegexParser {
     } else {
       throw new ParseException("Unexpected anchor: " + ch);
     }
+  }
+
+  private RegexNode literalNode(char ch) {
+    if (currentModifiers.isCaseInsensitive() && Character.isLetter(ch)) {
+      char lower = Character.toLowerCase(ch);
+      char upper = Character.toUpperCase(ch);
+      if (lower != upper) {
+        List<CharSet.Range> ranges = new ArrayList<>();
+        ranges.add(new CharSet.Range(lower, lower));
+        ranges.add(new CharSet.Range(upper, upper));
+        return new CharClassNode(CharSet.fromRanges(ranges), false);
+      }
+    }
+    return new LiteralNode(ch);
   }
 
   private RegexNode parseLookahead() throws ParseException {
@@ -1515,7 +1519,15 @@ public class RegexParser {
     int len = pat.length();
     while (i < len) {
       char c = pat.charAt(i);
-      if (c == '\\') {
+      if (c == '\\' && i + 1 < len && pat.charAt(i + 1) == 'Q') {
+        i += 2;
+        while (i + 1 < len && !(pat.charAt(i) == '\\' && pat.charAt(i + 1) == 'E')) {
+          i++;
+        }
+        if (i + 1 < len) {
+          i += 2;
+        }
+      } else if (c == '\\') {
         i += 2; // skip escaped character
       } else if (c == '[') {
         // skip character class

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
@@ -1525,7 +1525,10 @@ public class RegexParser {
           i++;
         }
         if (i + 1 < len) {
-          i += 2;
+          i += 2; // skip \E
+        } else {
+          // Unterminated \Q...: quote extends to end of pattern (PCRE semantics).
+          i = len;
         }
       } else if (c == '\\') {
         i += 2; // skip escaped character

--- a/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/parsing/RegexParserTest.java
+++ b/reggie-codegen/src/test/java/com/datadoghq/reggie/codegen/parsing/RegexParserTest.java
@@ -164,4 +164,29 @@ class RegexParserTest {
   void atomicGroup_digitPlusWithSuffix_throwsUnsupported() {
     assertDoesNotThrow(() -> parse("(?>\\d+)abc"), "(?>\\d+)abc must parse successfully");
   }
+
+  // ==================== Unterminated \Q...\E must not be counted as capturing ====================
+
+  /**
+   * An unterminated {@code \Q} quotes every remaining character, including any {@code (}, as a
+   * literal (PCRE semantics). The parenthesis inside must not be counted as a capturing group by
+   * the {@code countCapturingGroups} pre-scan used for multi-digit backreference resolution.
+   *
+   * <p>With 9 real capturing groups followed by {@code \10} and a trailing unterminated {@code
+   * \Q(}: if the stray {@code (} were miscounted as a 10th group, {@code \10} would resolve to a
+   * backreference to that (non-existent) group. With the correct count of 9, {@code \10} must
+   * resolve to backreference \1 followed by the literal digit '0' (JDK-compatible semantics).
+   */
+  @Test
+  void unterminatedQuoteAfterNineGroups_doesNotInflateGroupCount()
+      throws RegexParser.ParseException {
+    RegexNode node = parse("(a)(a)(a)(a)(a)(a)(a)(a)(a)\\10\\Q(");
+    String rendered = node.toString();
+    assertTrue(
+        rendered.contains("Backref(\\1)"),
+        "\\10 with 9 real groups must resolve to Backref(\\1) + literal '0', got: " + rendered);
+    assertFalse(
+        rendered.contains("Backref(\\10)"),
+        "Unterminated \\Q( must not be counted as a capturing group, got: " + rendered);
+  }
 }

--- a/reggie-processor/src/main/java/com/datadoghq/reggie/processor/ReggieMatcherBytecodeGenerator.java
+++ b/reggie-processor/src/main/java/com/datadoghq/reggie/processor/ReggieMatcherBytecodeGenerator.java
@@ -805,6 +805,17 @@ public class ReggieMatcherBytecodeGenerator {
     boolean inEscape = false;
     for (int i = 0; i < pattern.length(); i++) {
       char ch = pattern.charAt(i);
+      if (ch == '\\' && i + 1 < pattern.length() && pattern.charAt(i + 1) == 'Q') {
+        i += 2;
+        while (i + 1 < pattern.length()
+            && !(pattern.charAt(i) == '\\' && pattern.charAt(i + 1) == 'E')) {
+          i++;
+        }
+        if (i + 1 < pattern.length()) {
+          i++;
+        }
+        continue;
+      }
       if (inEscape) {
         inEscape = false;
         continue;

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/Reggie.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/Reggie.java
@@ -114,6 +114,29 @@ public final class Reggie {
   }
 
   /**
+   * Compile a regex pattern using {@link ReggieFlags}.
+   *
+   * <p>Supports {@link ReggieFlags#CASE_INSENSITIVE}, {@link ReggieFlags#MULTILINE}, {@link
+   * ReggieFlags#DOTALL}, and {@link ReggieFlags#LITERAL}. JDK migrations can use {@link
+   * com.datadoghq.reggie.compat.JdkPatternCompatibility#toReggieFlags(int)} at their boundary.
+   *
+   * @param pattern the regex pattern string
+   * @param flags bitwise OR of supported {@code ReggieFlags} constants
+   * @return compiled matcher instance
+   * @throws IllegalArgumentException if {@code flags} includes an unsupported value
+   * @throws java.util.regex.PatternSyntaxException if pattern is invalid
+   * @throws UnsupportedPatternException if pattern uses an unsupported regex construct
+   */
+  public static ReggieMatcher compile(String pattern, int flags) {
+    return RuntimeCompiler.compile(pattern, flags);
+  }
+
+  /** Compile a regex pattern with Reggie semantic flags and engine compilation options. */
+  public static ReggieMatcher compile(String pattern, int flags, ReggieOptions options) {
+    return RuntimeCompiler.compile(pattern, flags, options);
+  }
+
+  /**
    * Compile a regex pattern at runtime with explicit options.
    *
    * @param pattern the regex pattern string

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/ReggieFlags.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/ReggieFlags.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie;
+
+/** Flags that control regex semantics for {@link Reggie#compile(String, int)}. */
+public final class ReggieFlags {
+  // Keep these separate from java.util.regex.Pattern's values so an accidental JDK flag is never
+  // silently interpreted as a different Reggie flag.
+  public static final int CASE_INSENSITIVE = 1 << 24;
+  public static final int MULTILINE = 1 << 25;
+  public static final int DOTALL = 1 << 26;
+  public static final int LITERAL = 1 << 27;
+
+  private static final int SUPPORTED = CASE_INSENSITIVE | MULTILINE | DOTALL | LITERAL;
+
+  private ReggieFlags() {}
+
+  /** Returns whether {@code flags} contains only Reggie-defined flag bits. */
+  public static boolean areSupported(int flags) {
+    return (flags & ~SUPPORTED) == 0;
+  }
+}

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/compat/JdkPatternCompatibility.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/compat/JdkPatternCompatibility.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.compat;
+
+import com.datadoghq.reggie.ReggieFlags;
+
+/** Explicit adapter that maps supported JDK flag values onto Reggie flag values. */
+public final class JdkPatternCompatibility {
+  private JdkPatternCompatibility() {}
+
+  /** Converts supported JDK pattern flags to {@link ReggieFlags}. */
+  public static int toReggieFlags(int jdkFlags) {
+    int remaining = jdkFlags;
+    int result = 0;
+    if ((remaining & java.util.regex.Pattern.CASE_INSENSITIVE) != 0) {
+      throw new IllegalArgumentException(
+          "JDK CASE_INSENSITIVE is not compatible with Reggie's Unicode case folding");
+    }
+    if ((remaining & java.util.regex.Pattern.MULTILINE) != 0) {
+      result |= ReggieFlags.MULTILINE;
+      remaining &= ~java.util.regex.Pattern.MULTILINE;
+    }
+    if ((remaining & java.util.regex.Pattern.DOTALL) != 0) {
+      result |= ReggieFlags.DOTALL;
+      remaining &= ~java.util.regex.Pattern.DOTALL;
+    }
+    if ((remaining & java.util.regex.Pattern.LITERAL) != 0) {
+      result |= ReggieFlags.LITERAL;
+      remaining &= ~java.util.regex.Pattern.LITERAL;
+    }
+    if (remaining != 0) {
+      throw new IllegalArgumentException("Unsupported JDK regex flags: " + remaining);
+    }
+    return result;
+  }
+}

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/JavaRegexFallbackMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/JavaRegexFallbackMatcher.java
@@ -30,7 +30,11 @@ public final class JavaRegexFallbackMatcher extends ReggieMatcher {
 
   JavaRegexFallbackMatcher(String pattern, String reason) {
     super(pattern);
-    this.javaPattern = Pattern.compile(toJdkCompatible(pattern));
+    // UNICODE_CASE is a no-op unless the pattern also enables case-insensitive matching (via an
+    // inline (?i) modifier), in which case it makes java.util.regex fold non-ASCII letters the
+    // same way Reggie's native parser does (Character.toLowerCase/toUpperCase), instead of JDK's
+    // default ASCII-only case folding.
+    this.javaPattern = Pattern.compile(toJdkCompatible(pattern), Pattern.UNICODE_CASE);
     LOG.warning("Falling back to java.util.regex for pattern '" + pattern + "': " + reason);
   }
 

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieMatcher.java
@@ -52,6 +52,7 @@ public abstract class ReggieMatcher extends com.datadoghq.reggie.ReggieMatcher {
   private boolean expectsNativeRichApi;
 
   protected final String pattern;
+  private String reportedPattern;
 
   // injected by RuntimeCompiler after instantiation
   protected Map<String, Integer> nameToIndex = Collections.emptyMap();
@@ -140,6 +141,10 @@ public abstract class ReggieMatcher extends com.datadoghq.reggie.ReggieMatcher {
 
   protected ReggieMatcher(String pattern) {
     this.pattern = pattern;
+  }
+
+  final void setReportedPattern(String reportedPattern) {
+    this.reportedPattern = reportedPattern;
   }
 
   /**
@@ -767,6 +772,6 @@ public abstract class ReggieMatcher extends com.datadoghq.reggie.ReggieMatcher {
    * @return the regex pattern
    */
   public final String pattern() {
-    return pattern;
+    return reportedPattern != null ? reportedPattern : pattern;
   }
 }

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/RuntimeCompiler.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/RuntimeCompiler.java
@@ -17,6 +17,7 @@ package com.datadoghq.reggie.runtime;
 
 import static org.objectweb.asm.Opcodes.*;
 
+import com.datadoghq.reggie.ReggieFlags;
 import com.datadoghq.reggie.ReggieOption;
 import com.datadoghq.reggie.ReggieOptions;
 import com.datadoghq.reggie.UnsupportedPatternException;
@@ -96,7 +97,7 @@ public class RuntimeCompiler {
 
   // Level 1: Pattern string → matcher instance (fast path for exact matches).
   // NFA-backed patterns are NOT stored here; they use NFA_CLASS_CACHE instead.
-  private static final ConcurrentHashMap<String, ReggieMatcher> PATTERN_CACHE =
+  private static final ConcurrentHashMap<Object, ReggieMatcher> PATTERN_CACHE =
       new ConcurrentHashMap<>();
 
   /**
@@ -136,7 +137,7 @@ public class RuntimeCompiler {
   // NFA matchers mutate shared instance fields (currentStates, nextStates, epsilonProcessed,
   // configGroupStarts) during matching, so a single shared instance cannot be used concurrently.
   // We cache a factory here that produces a fresh enriched instance on every compile() call.
-  private static final ConcurrentHashMap<String, NfaMatcherFactory> NFA_CLASS_CACHE =
+  private static final ConcurrentHashMap<Object, NfaMatcherFactory> NFA_CLASS_CACHE =
       new ConcurrentHashMap<>();
 
   /**
@@ -168,7 +169,7 @@ public class RuntimeCompiler {
   // Level 1c: Pattern string → PikeVMEntry for PIKEVM_CAPTURE patterns.
   // PikeVMMatcher carries mutable per-call buffers and must be freshly instantiated on every
   // compile() call; only the NFA (immutable after construction) and the name map are cached.
-  private static final ConcurrentHashMap<String, PikeVMEntry> PIKEVM_NFA_CACHE =
+  private static final ConcurrentHashMap<Object, PikeVMEntry> PIKEVM_NFA_CACHE =
       new ConcurrentHashMap<>();
 
   /**
@@ -212,7 +213,7 @@ public class RuntimeCompiler {
   // Level 1d: Pattern string → BitStateEntry for BITSTATE_CAPTURE patterns.
   // BitStateMatcher carries mutable per-call buffers and must be freshly instantiated on every
   // compile() call; only the NFA (immutable after construction) and the name map are cached.
-  private static final ConcurrentHashMap<String, BitStateEntry> BITSTATE_NFA_CACHE =
+  private static final ConcurrentHashMap<Object, BitStateEntry> BITSTATE_NFA_CACHE =
       new ConcurrentHashMap<>();
 
   // Level 2: Structural hash → generated class (deduplication for similar patterns).
@@ -255,22 +256,40 @@ public class RuntimeCompiler {
     return compile(pattern, ReggieOptions.DEFAULT);
   }
 
+  /** Compile a pattern with supported {@link ReggieFlags}. */
+  public static ReggieMatcher compile(String pattern, int flags) {
+    return compile(pattern, flags, ReggieOptions.DEFAULT);
+  }
+
+  /** Compile a pattern with supported {@link ReggieFlags} and engine compilation options. */
+  public static ReggieMatcher compile(String pattern, int flags, ReggieOptions options) {
+    if (flags == 0) {
+      return compile(pattern, options);
+    }
+    String normalizedPattern = normalizePatternFlags(pattern, flags);
+    return compile(normalizedPattern, options, cacheKeyForFlags(pattern, flags, options), pattern);
+  }
+
   /** Compile pattern with runtime compilation options. */
   public static ReggieMatcher compile(String pattern, ReggieOptions options) {
-    String cacheKey = cacheKeyFor(pattern, options);
+    return compile(pattern, options, cacheKeyFor(pattern, options), pattern);
+  }
+
+  private static ReggieMatcher compile(
+      String pattern, ReggieOptions options, Object cacheKey, String reportedPattern) {
 
     // Fast path: PIKEVM_CAPTURE patterns are in PIKEVM_NFA_CACHE — return a fresh matcher.
     // PikeVMMatcher carries mutable per-call buffers and must not be shared across calls.
     PikeVMEntry pikevmEntry = PIKEVM_NFA_CACHE.get(cacheKey);
     if (pikevmEntry != null) {
-      return pikevmEntry.newMatcher(pattern);
+      return reportPattern(pikevmEntry.newMatcher(pattern), reportedPattern);
     }
 
     // Fast path: BITSTATE_CAPTURE patterns are in BITSTATE_NFA_CACHE — return a fresh matcher.
     // BitStateMatcher carries mutable per-call buffers and must not be shared across calls.
     BitStateEntry bitStateEntry = BITSTATE_NFA_CACHE.get(cacheKey);
     if (bitStateEntry != null) {
-      return bitStateEntry.newMatcher(pattern);
+      return reportPattern(bitStateEntry.newMatcher(pattern), reportedPattern);
     }
 
     // Fast path: NFA-backed patterns are in NFA_CLASS_CACHE — return a fresh instance.
@@ -278,7 +297,7 @@ public class RuntimeCompiler {
     // threads or calls; we cache a factory and instantiate per-call instead.
     NfaMatcherFactory factory = NFA_CLASS_CACHE.get(cacheKey);
     if (factory != null) {
-      return factory.newInstance(pattern);
+      return reportPattern(factory.newInstance(pattern), reportedPattern);
     }
 
     // Slow path: compile and cache the result.
@@ -292,7 +311,7 @@ public class RuntimeCompiler {
     pikevmEntry = PIKEVM_NFA_CACHE.get(cacheKey);
     if (pikevmEntry != null) {
       PATTERN_CACHE.remove(cacheKey, compiled);
-      return pikevmEntry.newMatcher(pattern);
+      return reportPattern(pikevmEntry.newMatcher(pattern), reportedPattern);
     }
 
     // Post-compilation fixup: if compileInternal registered this pattern as BITSTATE_CAPTURE,
@@ -300,7 +319,7 @@ public class RuntimeCompiler {
     bitStateEntry = BITSTATE_NFA_CACHE.get(cacheKey);
     if (bitStateEntry != null) {
       PATTERN_CACHE.remove(cacheKey, compiled);
-      return bitStateEntry.newMatcher(pattern);
+      return reportPattern(bitStateEntry.newMatcher(pattern), reportedPattern);
     }
 
     // Post-compilation fixup: if compileInternal registered this pattern as NFA-backed,
@@ -308,9 +327,14 @@ public class RuntimeCompiler {
     factory = NFA_CLASS_CACHE.get(cacheKey);
     if (factory != null) {
       PATTERN_CACHE.remove(cacheKey, compiled);
-      return factory.newInstance(pattern);
+      return reportPattern(factory.newInstance(pattern), reportedPattern);
     }
-    return compiled;
+    return reportPattern(compiled, reportedPattern);
+  }
+
+  private static ReggieMatcher reportPattern(ReggieMatcher matcher, String pattern) {
+    matcher.setReportedPattern(pattern);
+    return matcher;
   }
 
   private static final char NAME_SEP = ''; // US (unit separator)
@@ -445,7 +469,10 @@ public class RuntimeCompiler {
 
   /** Get all cached pattern keys. */
   public static Set<String> cachedPatterns() {
-    return PATTERN_CACHE.keySet();
+    return PATTERN_CACHE.keySet().stream()
+        .filter(String.class::isInstance)
+        .map(String.class::cast)
+        .collect(java.util.stream.Collectors.toUnmodifiableSet());
   }
 
   /**
@@ -474,6 +501,34 @@ public class RuntimeCompiler {
     return sb == null ? pattern : sb.toString();
   }
 
+  private record FlaggedCacheKey(String pattern, int flags, String optionsKey) {}
+
+  private static FlaggedCacheKey cacheKeyForFlags(
+      String pattern, int flags, ReggieOptions options) {
+    return new FlaggedCacheKey(pattern, flags, cacheKeyFor(pattern, options));
+  }
+
+  private static String normalizePatternFlags(String pattern, int flags) {
+    if (!ReggieFlags.areSupported(flags)) {
+      throw new IllegalArgumentException("Unsupported Reggie regex flags: " + flags);
+    }
+
+    StringBuilder normalized = new StringBuilder(pattern.length() + 12);
+    // CASE_INSENSITIVE is emitted first so isCaseInsensitive() retains its existing routing hint.
+    if ((flags & ReggieFlags.CASE_INSENSITIVE) != 0) {
+      normalized.append("(?i)");
+    }
+    if ((flags & ReggieFlags.MULTILINE) != 0) {
+      normalized.append("(?m)");
+    }
+    if ((flags & ReggieFlags.DOTALL) != 0) {
+      normalized.append("(?s)");
+    }
+    normalized.append(
+        (flags & ReggieFlags.LITERAL) != 0 ? java.util.regex.Pattern.quote(pattern) : pattern);
+    return normalized.toString();
+  }
+
   private static ReggieMatcher fallbackOrThrow(
       String pattern, String reason, Map<String, Integer> nameMap, ReggieOptions options) {
     if (!options.has(ReggieOption.ALLOW_JDK_FALLBACK)) {
@@ -492,7 +547,7 @@ public class RuntimeCompiler {
    * return a fresh instance on every subsequent call.
    */
   private static ReggieMatcher compileInternal(
-      String pattern, ReggieOptions options, String cacheKey) {
+      String pattern, ReggieOptions options, Object cacheKey) {
     try {
       // 1. Parse pattern to AST
       RegexParser parser = new RegexParser();
@@ -1614,6 +1669,17 @@ public class RuntimeCompiler {
     boolean escaped = false;
     for (int i = 0; i < pattern.length(); i++) {
       char c = pattern.charAt(i);
+      if (c == '\\' && i + 1 < pattern.length() && pattern.charAt(i + 1) == 'Q') {
+        i += 2;
+        while (i + 1 < pattern.length()
+            && !(pattern.charAt(i) == '\\' && pattern.charAt(i + 1) == 'E')) {
+          i++;
+        }
+        if (i + 1 < pattern.length()) {
+          i++;
+        }
+        continue;
+      }
       if (escaped) {
         escaped = false;
         continue;

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/RuntimeCompiler.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/RuntimeCompiler.java
@@ -475,8 +475,10 @@ public class RuntimeCompiler {
    * compile(pattern[, options])}) are returned verbatim. Keys for patterns compiled with {@link
    * ReggieFlags} (via {@code compile(pattern, flags[, options])}) are backed by an internal {@code
    * FlaggedCacheKey} record rather than the pattern string itself; those entries are rendered as
-   * {@code "<pattern> [flags=<flags>]"} so flagged compilations remain visible for cache-size
-   * accounting and debugging.
+   * {@code "<pattern> [flags=<flags>]"}, or {@code "<pattern> [flags=<flags> options=<options>]"}
+   * when non-default {@link ReggieOptions} were also used, so flagged compilations remain visible
+   * for cache-size accounting and debugging, and entries that differ only by options no longer
+   * collapse to the same displayed string.
    */
   public static Set<String> cachedPatterns() {
     return PATTERN_CACHE.keySet().stream()
@@ -489,7 +491,15 @@ public class RuntimeCompiler {
       return s;
     }
     if (key instanceof FlaggedCacheKey flaggedKey) {
-      return flaggedKey.pattern() + " [flags=" + flaggedKey.flags() + "]";
+      String optionsSuffix = "";
+      if (!flaggedKey.optionsKey().equals(flaggedKey.pattern())) {
+        // cacheKeyFor() appends "\0<OPTION_NAME>" for each enabled ReggieOption; render it as a
+        // comma-separated, human-readable options=... suffix so distinct ReggieOptions combined
+        // with the same pattern+flags no longer collapse to the same displayed string.
+        String encodedOptions = flaggedKey.optionsKey().substring(flaggedKey.pattern().length());
+        optionsSuffix = " options=" + encodedOptions.substring(1).replace('\0', ',');
+      }
+      return flaggedKey.pattern() + " [flags=" + flaggedKey.flags() + optionsSuffix + "]";
     }
     return String.valueOf(key);
   }

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/RuntimeCompiler.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/RuntimeCompiler.java
@@ -303,8 +303,11 @@ public class RuntimeCompiler {
     // Slow path: compile and cache the result.
     // compileInternal will populate NFA_CLASS_CACHE if the strategy is NFA-backed, in which case
     // the L1 entry is immediately removed so that subsequent calls hit the fast path above.
+    // The reported pattern is set inside the mapping function so the instance published to
+    // PATTERN_CACHE is already fully initialized and is never mutated again after publication.
     ReggieMatcher compiled =
-        PATTERN_CACHE.computeIfAbsent(cacheKey, k -> compileInternal(pattern, options, k));
+        PATTERN_CACHE.computeIfAbsent(
+            cacheKey, k -> reportPattern(compileInternal(pattern, options, k), reportedPattern));
 
     // Post-compilation fixup: if compileInternal registered this pattern as PIKEVM_CAPTURE,
     // remove it from L1 and return a fresh matcher so callers never share mutable state.
@@ -329,7 +332,7 @@ public class RuntimeCompiler {
       PATTERN_CACHE.remove(cacheKey, compiled);
       return reportPattern(factory.newInstance(pattern), reportedPattern);
     }
-    return reportPattern(compiled, reportedPattern);
+    return compiled;
   }
 
   private static ReggieMatcher reportPattern(ReggieMatcher matcher, String pattern) {
@@ -467,12 +470,28 @@ public class RuntimeCompiler {
     return STRUCTURE_CACHE.size();
   }
 
-  /** Get all cached pattern keys. */
+  /**
+   * Get a string snapshot of all level-1 cache keys. Plain pattern-string keys (from {@code
+   * compile(pattern[, options])}) are returned verbatim. Keys for patterns compiled with {@link
+   * ReggieFlags} (via {@code compile(pattern, flags[, options])}) are backed by an internal {@code
+   * FlaggedCacheKey} record rather than the pattern string itself; those entries are rendered as
+   * {@code "<pattern> [flags=<flags>]"} so flagged compilations remain visible for cache-size
+   * accounting and debugging.
+   */
   public static Set<String> cachedPatterns() {
     return PATTERN_CACHE.keySet().stream()
-        .filter(String.class::isInstance)
-        .map(String.class::cast)
+        .map(RuntimeCompiler::cacheKeyToDisplayString)
         .collect(java.util.stream.Collectors.toUnmodifiableSet());
+  }
+
+  private static String cacheKeyToDisplayString(Object key) {
+    if (key instanceof String s) {
+      return s;
+    }
+    if (key instanceof FlaggedCacheKey flaggedKey) {
+      return flaggedKey.pattern() + " [flags=" + flaggedKey.flags() + "]";
+    }
+    return String.valueOf(key);
   }
 
   /**

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/ReggieCompileFlagsTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/ReggieCompileFlagsTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.datadoghq.reggie.compat.JdkPatternCompatibility;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+class ReggieCompileFlagsTest {
+
+  @Test
+  void caseInsensitiveMatches() {
+    assertMatches("abc", ReggieFlags.CASE_INSENSITIVE, "AbC", true);
+    assertMatches("\\x61", ReggieFlags.CASE_INSENSITIVE, "A", true);
+    assertMatches("\\a", ReggieFlags.CASE_INSENSITIVE, "A", true);
+    assertMatches("abc", 0, "AbC", false);
+  }
+
+  @Test
+  void multilineMatches() {
+    assertFinds("^foo$", ReggieFlags.MULTILINE, "before\nfoo\nafter", true);
+  }
+
+  @Test
+  void dotallMatches() {
+    assertFinds("a.b", ReggieFlags.DOTALL, "a\nb", true);
+    assertFinds("a.b", 0, "a\nb", false);
+  }
+
+  @Test
+  void combinedFlagsMatch() {
+    int flags = ReggieFlags.CASE_INSENSITIVE | ReggieFlags.MULTILINE | ReggieFlags.DOTALL;
+    assertFinds("^a.b$", flags, "before\nA\nb\nafter", true);
+  }
+
+  @Test
+  void literalQuotesMetacharactersAndEmbeddedQuoteTerminator() {
+    int flags = ReggieFlags.LITERAL | ReggieFlags.CASE_INSENSITIVE;
+    String source = "a.b(\\E)";
+
+    assertMatches(source, flags, "A.B(\\e)", true);
+    assertMatches(source, flags, "aXb(\\E)", false);
+    assertMatches("(?i)a.b", ReggieFlags.LITERAL, "(?i)a.b", true);
+  }
+
+  @Test
+  void cacheSeparatesFlaggedAndUnflaggedPatterns() {
+    assertTrue(Reggie.compile("abc", ReggieFlags.CASE_INSENSITIVE).matches("ABC"));
+    assertFalse(Reggie.compile("abc").matches("ABC"));
+  }
+
+  @Test
+  void unsupportedReggieFlagsAreRejected() {
+    assertThrows(IllegalArgumentException.class, () -> Reggie.compile("abc", 1));
+    assertThrows(
+        IllegalArgumentException.class, () -> Reggie.compile("abc", Pattern.CASE_INSENSITIVE));
+  }
+
+  @Test
+  void compatibilityAdapterConvertsSupportedJdkFlags() {
+    int jdkFlags = Pattern.MULTILINE | Pattern.DOTALL | Pattern.LITERAL;
+    int reggieFlags = JdkPatternCompatibility.toReggieFlags(jdkFlags);
+    assertTrue(reggieFlags == (ReggieFlags.MULTILINE | ReggieFlags.DOTALL | ReggieFlags.LITERAL));
+    assertTrue(Reggie.compile("abc", reggieFlags).matches("abc"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> JdkPatternCompatibility.toReggieFlags(Pattern.COMMENTS));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> JdkPatternCompatibility.toReggieFlags(Pattern.CASE_INSENSITIVE));
+  }
+
+  @Test
+  void flagsComposeWithEngineOptionsAndPreserveTheSourcePattern() {
+    com.datadoghq.reggie.runtime.ReggieMatcher matcher =
+        Reggie.compile("abc", ReggieFlags.CASE_INSENSITIVE, ReggieOptions.DEFAULT);
+    assertTrue(matcher.matches("ABC"));
+    assertTrue(matcher.pattern().equals("abc"));
+  }
+
+  private static void assertMatches(String pattern, int flags, String input, boolean expected) {
+    assertTrue(Reggie.compile(pattern, flags).matches(input) == expected);
+  }
+
+  private static void assertFinds(String pattern, int flags, String input, boolean expected) {
+    assertTrue(Reggie.compile(pattern, flags).find(input) == expected);
+  }
+}

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/RuntimeCompilerTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/RuntimeCompilerTest.java
@@ -186,6 +186,16 @@ public class RuntimeCompilerTest {
   }
 
   @Test
+  public void testCachedPatternsIncludesFlaggedEntries() {
+    RuntimeCompiler.compile("abc", com.datadoghq.reggie.ReggieFlags.CASE_INSENSITIVE);
+
+    assertEquals(1, RuntimeCompiler.cacheSize());
+    assertEquals(1, RuntimeCompiler.cachedPatterns().size());
+    assertTrue(
+        RuntimeCompiler.cachedPatterns().stream().anyMatch(k -> k.startsWith("abc [flags=")));
+  }
+
+  @Test
   public void testExplicitCacheKeySamePattern() {
     ReggieMatcher m1 = RuntimeCompiler.cached("key1", "\\d+");
     ReggieMatcher m2 = RuntimeCompiler.cached("key1", "\\d+");

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/RuntimeCompilerTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/RuntimeCompilerTest.java
@@ -453,4 +453,30 @@ public class RuntimeCompilerTest {
   //             "Find results should match JDK for input: " + input);
   //     }
   // }
+
+  // ==================== JDK Fallback Unicode Case Tests ====================
+
+  @Test
+  public void testFallbackMatcherPreservesUnicodeCaseFolding() {
+    // JavaRegexFallbackMatcher must fold non-ASCII letters the same way Reggie's native
+    // case-insensitive parsing does, not JDK's default ASCII-only (?i) folding.
+    ReggieMatcher fallback = new JavaRegexFallbackMatcher("(?i)é", "unit test");
+    assertTrue(fallback.matches("É"));
+  }
+
+  // ==================== Flagged Cache Display Tests ====================
+
+  @Test
+  public void testCachedPatternsIncludeOptionsForFlaggedEntries() {
+    RuntimeCompiler.compile("abc", com.datadoghq.reggie.ReggieFlags.CASE_INSENSITIVE);
+    RuntimeCompiler.compile(
+        "abc",
+        com.datadoghq.reggie.ReggieFlags.CASE_INSENSITIVE,
+        com.datadoghq.reggie.ReggieOptions.builder().allowJdkFallback().build());
+
+    // Two distinct L1 entries (same pattern+flags, different ReggieOptions) must not collapse
+    // into a single displayed string.
+    assertEquals(2, RuntimeCompiler.cacheSize());
+    assertEquals(2, RuntimeCompiler.cachedPatterns().size());
+  }
 }


### PR DESCRIPTION
## Summary

- add Reggie-owned runtime compile flags for case-insensitive, multiline, dotall, and literal matching
- add an explicit JDK flag compatibility adapter while keeping JDK flag values out of the core API
- preserve source-pattern reporting, isolate flagged caches with typed keys, and keep quoted-literal group counting aligned across runtime and annotation processing

## Notes

JDK `CASE_INSENSITIVE` conversion is deliberately rejected because its ASCII-only behavior is not equivalent to Reggie's Unicode case folding.

## Validation

- `./gradlew spotlessApply :reggie-runtime:test --tests com.datadoghq.reggie.ReggieCompileFlagsTest`
- `./gradlew build` (before the final cache-key refinement; the final focused test recompiles and passes the modified runtime code)