### PR TITLE
fix: gate linear token sequences by flag profile

### DIFF
--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/automaton/CharSet.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/automaton/CharSet.java
@@ -169,6 +169,7 @@ public final class CharSet {
               new Range(' ', ' '),
               new Range('\t', '\t'),
               new Range('\n', '\n'),
+              new Range('\u000B', '\u000B'),
               new Range('\r', '\r'),
               new Range('\f', '\f')));
 

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LinearTokenSequenceMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LinearTokenSequenceMatcher.java
@@ -580,7 +580,7 @@ final class LinearTokenSequenceMatcher extends ReggieMatcher {
   }
 
   private static boolean isJdkWhitespace(char ch) {
-    return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\f' || ch == '\r';
+    return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\u000B' || ch == '\f' || ch == '\r';
   }
 
   private static boolean isDigit(char ch) {

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/RuntimeCompiler.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/RuntimeCompiler.java
@@ -75,6 +75,7 @@ import com.datadoghq.reggie.codegen.parsing.RegexParser;
 import java.io.PrintWriter;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -267,16 +268,30 @@ public class RuntimeCompiler {
       return compile(pattern, options);
     }
     String normalizedPattern = normalizePatternFlags(pattern, flags);
-    return compile(normalizedPattern, options, cacheKeyForFlags(pattern, flags, options), pattern);
+    return compile(
+        normalizedPattern,
+        options,
+        cacheKeyForFlags(pattern, flags, options),
+        pattern,
+        LinearTokenSequenceAdmission.forFlags(pattern, flags));
   }
 
   /** Compile pattern with runtime compilation options. */
   public static ReggieMatcher compile(String pattern, ReggieOptions options) {
-    return compile(pattern, options, cacheKeyFor(pattern, options), pattern);
+    return compile(
+        pattern,
+        options,
+        cacheKeyFor(pattern, options),
+        pattern,
+        LinearTokenSequenceAdmission.forSource(pattern));
   }
 
   private static ReggieMatcher compile(
-      String pattern, ReggieOptions options, Object cacheKey, String reportedPattern) {
+      String pattern,
+      ReggieOptions options,
+      Object cacheKey,
+      String reportedPattern,
+      LinearTokenSequenceAdmission linearTokenSequenceAdmission) {
 
     // Fast path: PIKEVM_CAPTURE patterns are in PIKEVM_NFA_CACHE — return a fresh matcher.
     // PikeVMMatcher carries mutable per-call buffers and must not be shared across calls.
@@ -307,7 +322,11 @@ public class RuntimeCompiler {
     // PATTERN_CACHE is already fully initialized and is never mutated again after publication.
     ReggieMatcher compiled =
         PATTERN_CACHE.computeIfAbsent(
-            cacheKey, k -> reportPattern(compileInternal(pattern, options, k), reportedPattern));
+            cacheKey,
+            k ->
+                reportPattern(
+                    compileInternal(pattern, options, k, linearTokenSequenceAdmission),
+                    reportedPattern));
 
     // Post-compilation fixup: if compileInternal registered this pattern as PIKEVM_CAPTURE,
     // remove it from L1 and return a fresh matcher so callers never share mutable state.
@@ -510,11 +529,13 @@ public class RuntimeCompiler {
    * cache (level 2) checked here
    */
   private static ReggieMatcher compileInternal(String pattern) {
-    return compileInternal(pattern, ReggieOptions.DEFAULT, pattern);
+    return compileInternal(
+        pattern, ReggieOptions.DEFAULT, pattern, LinearTokenSequenceAdmission.forSource(pattern));
   }
 
   private static ReggieMatcher compileInternal(String pattern, ReggieOptions options) {
-    return compileInternal(pattern, options, pattern);
+    return compileInternal(
+        pattern, options, pattern, LinearTokenSequenceAdmission.forSource(pattern));
   }
 
   private static String cacheKeyFor(String pattern, ReggieOptions options) {
@@ -531,6 +552,99 @@ public class RuntimeCompiler {
   }
 
   private record FlaggedCacheKey(String pattern, int flags, String optionsKey) {}
+
+  /**
+   * Carries the source-level semantic profile used only to admit the named-capture LTS shortcut.
+   *
+   * <p>The normalized pattern cannot supply this information: explicit {@link ReggieFlags#DOTALL}
+   * is encoded as a leading {@code (?s)}, while the same text may have been present in the caller's
+   * original source.
+   */
+  private record LinearTokenSequenceAdmission(boolean isEligible, boolean isDotAll) {
+    private static LinearTokenSequenceAdmission forSource(String source) {
+      return new LinearTokenSequenceAdmission(!hasSourceInlineModifier(source), false);
+    }
+
+    private static LinearTokenSequenceAdmission forFlags(String source, int flags) {
+      boolean isDotAll = flags == ReggieFlags.DOTALL;
+      return new LinearTokenSequenceAdmission(
+          isDotAll && !hasSourceInlineModifier(source), isDotAll);
+    }
+  }
+
+  static boolean hasSourceInlineModifier(String source) {
+    boolean inCharacterClass = false;
+    int index = 0;
+    while (index < source.length()) {
+      char ch = source.charAt(index);
+      if (ch == '\\') {
+        if (index + 1 < source.length() && source.charAt(index + 1) == 'Q') {
+          index += 2;
+          while (index < source.length()) {
+            if (source.charAt(index) == '\\'
+                && index + 1 < source.length()
+                && source.charAt(index + 1) == 'E') {
+              index += 2;
+              break;
+            }
+            index++;
+          }
+        } else {
+          index += 2;
+        }
+        continue;
+      }
+      if (inCharacterClass) {
+        if (ch == ']') {
+          inCharacterClass = false;
+        }
+        index++;
+        continue;
+      }
+      if (ch == '[') {
+        inCharacterClass = true;
+        index++;
+        // In Java regex, ']' as the first character of a class (or first after '^')
+        // is a literal, not the class terminator. Skip it so the scanner does not
+        // exit the class prematurely.
+        if (index < source.length() && source.charAt(index) == '^') {
+          index++;
+        }
+        if (index < source.length() && source.charAt(index) == ']') {
+          index++;
+        }
+        continue;
+      }
+      if (ch == '(' && index + 1 < source.length() && source.charAt(index + 1) == '?') {
+        int modifierStart = index + 2;
+        if (modifierStart < source.length() && source.charAt(modifierStart) == '#') {
+          index = modifierStart + 1;
+          while (index < source.length() && source.charAt(index) != ')') {
+            index++;
+          }
+          if (index < source.length()) {
+            index++;
+          }
+          continue;
+        }
+        int cursor = modifierStart;
+        while (cursor < source.length() && isInlineModifierCharacter(source.charAt(cursor))) {
+          cursor++;
+        }
+        if (cursor > modifierStart
+            && cursor < source.length()
+            && (source.charAt(cursor) == ':' || source.charAt(cursor) == ')')) {
+          return true;
+        }
+      }
+      index++;
+    }
+    return false;
+  }
+
+  private static boolean isInlineModifierCharacter(char ch) {
+    return ch == 'i' || ch == 'm' || ch == 's' || ch == 'x' || ch == '-';
+  }
 
   private static FlaggedCacheKey cacheKeyForFlags(
       String pattern, int flags, ReggieOptions options) {
@@ -576,7 +690,10 @@ public class RuntimeCompiler {
    * return a fresh instance on every subsequent call.
    */
   private static ReggieMatcher compileInternal(
-      String pattern, ReggieOptions options, Object cacheKey) {
+      String pattern,
+      ReggieOptions options,
+      Object cacheKey,
+      LinearTokenSequenceAdmission linearTokenSequenceAdmission) {
     try {
       // 1. Parse pattern to AST
       RegexParser parser = new RegexParser();
@@ -585,7 +702,7 @@ public class RuntimeCompiler {
       if (options.has(ReggieOption.CAPTURE_NAMED_ONLY)) {
         ast = CaptureProjection.preserveNamedAndSemanticCaptures(ast);
         ReggieMatcher linearTokenSequenceMatcher =
-            tryCompileLinearTokenSequence(pattern, ast, nameMap);
+            tryCompileLinearTokenSequence(pattern, ast, nameMap, linearTokenSequenceAdmission);
         if (linearTokenSequenceMatcher != null) {
           return linearTokenSequenceMatcher;
         }
@@ -814,20 +931,31 @@ public class RuntimeCompiler {
   }
 
   private static ReggieMatcher tryCompileLinearTokenSequence(
-      String pattern, RegexNode ast, Map<String, Integer> nameMap) {
+      String pattern,
+      RegexNode ast,
+      Map<String, Integer> nameMap,
+      LinearTokenSequenceAdmission admission) {
+    if (!admission.isEligible()) {
+      return null;
+    }
     return LinearTokenSequencePlan.from(PatternCategorizer.categorize(ast))
         .filter(plan -> plan.coversCaptureIndexes(nameMap.values()))
-        .filter(plan -> isRuntimeExecutableLinearTokenSequence(pattern, plan))
+        .filter(plan -> isRuntimeExecutableLinearTokenSequence(admission.isDotAll(), plan))
         .map(plan -> new LinearTokenSequenceMatcher(pattern, plan, countGroups(pattern), nameMap))
         .map(m -> m.embedsNameMap() ? m : new NameEnrichingMatcher(m))
         .orElse(null);
   }
 
   private static boolean isRuntimeExecutableLinearTokenSequence(
-      String pattern, LinearTokenSequencePlan plan) {
+      boolean dotAll, LinearTokenSequencePlan plan) {
+    return validateOps(dotAll, plan.ops(), true);
+  }
+
+  private static boolean validateOps(
+      boolean dotAll, List<LinearTokenSequencePlan.Op> ops, boolean isTopLevel) {
     boolean requiresDotAll = false;
-    for (int i = 0; i < plan.ops().size(); i++) {
-      LinearTokenSequencePlan.Op op = plan.ops().get(i);
+    for (int i = 0; i < ops.size(); i++) {
+      LinearTokenSequencePlan.Op op = ops.get(i);
       if (op.kind() == LinearTokenSequencePlan.OpKind.ANCHOR) return false;
       if (op.kind() == LinearTokenSequencePlan.OpKind.SKIP_ANY_EXCEPT_NEWLINE) return false;
       if (op.kind() == LinearTokenSequencePlan.OpKind.SKIP_ANY
@@ -836,16 +964,39 @@ public class RuntimeCompiler {
       }
       if ((op.kind() == LinearTokenSequencePlan.OpKind.SKIP_ANY
               || op.kind() == LinearTokenSequencePlan.OpKind.SKIP_ANY_EXCEPT_NEWLINE)
-          && i != plan.ops().size() - 1) {
+          && i != ops.size() - 1) {
         return false;
       }
-      if (op.kind() == LinearTokenSequencePlan.OpKind.OPTIONAL_SEQUENCE
-          && i + 1 < plan.ops().size()
-          && canOptionalPresentBranchStealFollowingInput(op, plan.ops().get(i + 1))) {
-        return false;
+      if (op.kind() == LinearTokenSequencePlan.OpKind.OPTIONAL_SEQUENCE) {
+        if (!validateOps(dotAll, op.children(), false)) return false;
+        // An optional sequence containing a wildcard (SKIP_ANY or SKIP_ANY_EXCEPT_NEWLINE)
+        // cannot backtrack: the present branch greedily consumes all remaining input,
+        // so any ops following the optional sequence would fail. Reject when there are
+        // more ops after the optional.
+        if (isTopLevel && i + 1 < ops.size() && containsWildcard(op)) {
+          return false;
+        }
+        if (isTopLevel
+            && i + 1 < ops.size()
+            && canOptionalPresentBranchStealFollowingInput(op, ops.get(i + 1))) {
+          return false;
+        }
       }
     }
-    return !requiresDotAll || pattern.startsWith("(?s)");
+    return !requiresDotAll || dotAll;
+  }
+
+  private static boolean containsWildcard(LinearTokenSequencePlan.Op optional) {
+    for (LinearTokenSequencePlan.Op child : optional.children()) {
+      if (child.kind() == LinearTokenSequencePlan.OpKind.SKIP_ANY
+          || child.kind() == LinearTokenSequencePlan.OpKind.SKIP_ANY_EXCEPT_NEWLINE) {
+        return true;
+      }
+      if (!child.children().isEmpty() && containsWildcard(child)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private static boolean canOptionalPresentBranchStealFollowingInput(

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LinearTokenSequenceAccessLogTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LinearTokenSequenceAccessLogTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.datadoghq.reggie.Reggie;
+import com.datadoghq.reggie.ReggieFlags;
 import com.datadoghq.reggie.ReggieOptions;
 import com.datadoghq.reggie.codegen.parsing.RegexParser;
 import java.io.IOException;
@@ -46,7 +47,7 @@ class LinearTokenSequenceAccessLogTest {
 
   @Test
   void matchesCombinedAccessLogWithDelimiterAwareCaptures() {
-    ReggieMatcher matcher = Reggie.compile(COMBINED_ACCESS_LOG_PATTERN, NAMED_ONLY);
+    ReggieMatcher matcher = compileNamedOnly(COMBINED_ACCESS_LOG_PATTERN);
     String input =
         "10.202.82.195 - - [15/Mar/2019:19:45:35 -0700]  \"POST /config?x=y HTTP/1.1\" "
             + "200 17888 \"https://example.com/index.html\" \"Mozilla/5.0 Test\" \"-\" "
@@ -75,7 +76,7 @@ class LinearTokenSequenceAccessLogTest {
   @Test
   void routesRealExpandedCommonAccessLogPatternThroughLinearTokenSequenceMatcher()
       throws Exception {
-    ReggieMatcher matcher = Reggie.compile(testResource("logs-grok-pattern-1.regex"), NAMED_ONLY);
+    ReggieMatcher matcher = compileNamedOnly(testResource("logs-grok-pattern-1.regex"));
     String input =
         "10.202.82.195 - - [15/Mar/2019:19:45:35 -0700]  \"POST /config?x=y HTTP/1.1\" "
             + "200 17888";
@@ -95,7 +96,7 @@ class LinearTokenSequenceAccessLogTest {
   @Test
   void routesRealExpandedCombinedAccessLogPatternThroughLinearTokenSequenceMatcher()
       throws Exception {
-    ReggieMatcher matcher = Reggie.compile(testResource("logs-grok-pattern-2.regex"), NAMED_ONLY);
+    ReggieMatcher matcher = compileNamedOnly(testResource("logs-grok-pattern-2.regex"));
     String input =
         "10.202.82.195 - - [15/Mar/2019:19:45:35 -0700]  \"POST /config?x=y HTTP/1.1\" "
             + "200 17888 \"https://example.com/index.html\" \"Mozilla/5.0 Test\" \"-\" "
@@ -211,7 +212,7 @@ class LinearTokenSequenceAccessLogTest {
 
   @Test
   void leavesCallerArraysUnchangedOnNoMatch() {
-    ReggieMatcher matcher = Reggie.compile(COMBINED_ACCESS_LOG_PATTERN, NAMED_ONLY);
+    ReggieMatcher matcher = compileNamedOnly(COMBINED_ACCESS_LOG_PATTERN);
     int[] starts = new int[17];
     int[] ends = new int[17];
     starts[1] = 123;
@@ -227,13 +228,20 @@ class LinearTokenSequenceAccessLogTest {
     assertEquals(value, input.substring(starts[group], ends[group]));
   }
 
+  private static ReggieMatcher compileNamedOnly(String pattern) {
+    if (pattern.startsWith("(?s)")) {
+      return Reggie.compile(pattern.substring("(?s)".length()), ReggieFlags.DOTALL, NAMED_ONLY);
+    }
+    return Reggie.compile(pattern, NAMED_ONLY);
+  }
+
   private static void assertNamedCaptureBoundariesEquivalent(String pattern, String... inputs)
       throws Exception {
     RegexParser parser = new RegexParser();
     parser.parse(pattern);
     Map<String, Integer> nameToIndex = parser.getGroupNameMap();
     Pattern jdkPattern = Pattern.compile(pattern);
-    ReggieMatcher reggieMatcher = Reggie.compile(pattern, NAMED_ONLY);
+    ReggieMatcher reggieMatcher = compileNamedOnly(pattern);
     assertDelegateTypeUnchecked(reggieMatcher, LinearTokenSequenceMatcher.class);
 
     for (String input : inputs) {
@@ -270,7 +278,7 @@ class LinearTokenSequenceAccessLogTest {
 
   private static void assertBoundedFixtureUsesOnlyItsRegion(
       String pattern, String matchingInput, String failingInput) throws Exception {
-    ReggieMatcher matcher = Reggie.compile(pattern, NAMED_ONLY);
+    ReggieMatcher matcher = compileNamedOnly(pattern);
     assertDelegateType(matcher, LinearTokenSequenceMatcher.class);
     LinearTokenSequenceMatcher ltsMatcher = (LinearTokenSequenceMatcher) matcher;
     int groupCount = Pattern.compile(pattern).matcher("").groupCount();

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LinearTokenSequenceMatcherConcurrencyTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LinearTokenSequenceMatcherConcurrencyTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.datadoghq.reggie.Reggie;
+import com.datadoghq.reggie.ReggieFlags;
 import com.datadoghq.reggie.ReggieOptions;
 import com.datadoghq.reggie.codegen.parsing.RegexParser;
 import java.io.IOException;
@@ -57,8 +58,8 @@ class LinearTokenSequenceMatcherConcurrencyTest {
     Reggie.clearCache();
     String pattern = testResource("logs-grok-pattern-1.regex");
     Map<String, Integer> groupNumbers = groupNumbers(pattern);
-    ReggieMatcher shared = Reggie.compile(pattern, NAMED_ONLY);
-    ReggieMatcher second = Reggie.compile(pattern, NAMED_ONLY);
+    ReggieMatcher shared = compileNamedOnlyFixture(pattern);
+    ReggieMatcher second = compileNamedOnlyFixture(pattern);
     int groupCount = shared.match(WITH_OPTIONAL_CAPTURES).groupCount();
 
     assertSame(shared, second);
@@ -155,6 +156,13 @@ class LinearTokenSequenceMatcherConcurrencyTest {
     }
     assertTrue(
         failures.isEmpty(), () -> "concurrent nested-optional LTS failure: " + failures.peek());
+  }
+
+  private static ReggieMatcher compileNamedOnlyFixture(String pattern) {
+    if (pattern.startsWith("(?s)")) {
+      return Reggie.compile(pattern.substring("(?s)".length()), ReggieFlags.DOTALL, NAMED_ONLY);
+    }
+    return Reggie.compile(pattern, NAMED_ONLY);
   }
 
   private static void assertMatchWithOptionalCaptures(

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LinearTokenSequenceMatcherTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LinearTokenSequenceMatcherTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.datadoghq.reggie.Reggie;
+import com.datadoghq.reggie.ReggieFlags;
 import com.datadoghq.reggie.ReggieOptions;
 import com.datadoghq.reggie.codegen.analysis.LinearTokenSequencePlan;
 import com.datadoghq.reggie.codegen.analysis.PatternCategorizer;
@@ -314,9 +315,7 @@ class LinearTokenSequenceMatcherTest {
     Pattern jdkWhitespace = Pattern.compile("\\s+");
     Pattern jdkNonWhitespace = Pattern.compile("\\S+");
 
-    // LTS \s mirrors CharSet.WHITESPACE (no \u000B); JDK \s includes \u000B.
-    // Verify consistency for the five characters both agree on.
-    for (char ch : new char[] {' ', '\t', '\n', '\f', '\r'}) {
+    for (char ch : new char[] {' ', '\t', '\n', '\u000B', '\f', '\r'}) {
       String input = String.valueOf(ch);
       assertEquals(
           jdkWhitespace.matcher(input).matches(),
@@ -354,7 +353,7 @@ class LinearTokenSequenceMatcherTest {
   @Test
   void runtimeCompilerRoutesCombinedAccessLogTemplateWithNonGrokNames() throws Exception {
     String pattern =
-        "(?s)(?<client>(?:[0-9]{1,3}\\.){3}[0-9]{1,3}|[A-Za-z0-9.-]+) "
+        "(?<client>(?:[0-9]{1,3}\\.){3}[0-9]{1,3}|[A-Za-z0-9.-]+) "
             + "(?<ident>\\S+) (?<auth>\\S+) "
             + "\\[(?<timestamp>[\\d]{2}/(?:[jJ][aA][nN]|[mM][aA][rR])/[\\d]{4,19}:[\\d]{2}:[\\d]{2}:[\\d]{2} [+-]\\d\\d:?\\d\\d)\\]\\s+"
             + "\"(?>(?<method>\\b\\w+\\b) |)(?<target>\\S+)(?> HTTP\\/(?<version>\\d+\\.\\d+)|)\" "
@@ -363,7 +362,7 @@ class LinearTokenSequenceMatcherTest {
             + "(?<duration>[+-]?(?>\\d+(?:\\.(?:\\d*)?)?|\\.\\d+)) "
             + "(?<upstream>[+-]?(?>\\d+(?:\\.(?:\\d*)?)?|\\.\\d+)).* "
             + "\\[(?<logger>\\b\\w+\\b)\\] .*";
-    ReggieMatcher matcher = Reggie.compile(pattern, NAMED_ONLY_OPTIONS);
+    ReggieMatcher matcher = Reggie.compile(pattern, ReggieFlags.DOTALL, NAMED_ONLY_OPTIONS);
     String input =
         "10.202.82.195 - - [15/Mar/2019:19:45:35 -0700]  \"POST /config?x=y HTTP/1.1\" "
             + "200 17888 \"https://example.com/index.html\" \"Mozilla/5.0 Test\" \"-\" "
@@ -430,7 +429,6 @@ class LinearTokenSequenceMatcherTest {
   @Test
   void bracketedWordAfterSkipPreservesDefaultDotAndDotAllNewlineSemantics() throws Exception {
     String defaultPattern = ".* \\[(?<logger>\\b\\w+\\b)\\] .*";
-    String dotAllPattern = "(?s)" + defaultPattern;
     String newlineBeforeLogger = "prefix\n [logger] trailing";
     String newlineAfterLogger = "prefix [logger] trailing\nrest";
 
@@ -444,9 +442,10 @@ class LinearTokenSequenceMatcherTest {
         jdkDefault.matcher(newlineAfterLogger).matches(),
         defaultMatcher.matches(newlineAfterLogger));
 
-    ReggieMatcher dotAllMatcher = Reggie.compile(dotAllPattern, NAMED_ONLY_OPTIONS);
+    ReggieMatcher dotAllMatcher =
+        Reggie.compile(defaultPattern, ReggieFlags.DOTALL, NAMED_ONLY_OPTIONS);
     assertDelegateType(dotAllMatcher, LinearTokenSequenceMatcher.class);
-    Pattern jdkDotAll = Pattern.compile(dotAllPattern);
+    Pattern jdkDotAll = Pattern.compile(defaultPattern, Pattern.DOTALL);
     assertEquals(
         jdkDotAll.matcher(newlineBeforeLogger).matches(),
         dotAllMatcher.matches(newlineBeforeLogger));
@@ -470,6 +469,112 @@ class LinearTokenSequenceMatcherTest {
     ReggieMatcher matcher = Reggie.compile(pattern, NAMED_ONLY_OPTIONS);
 
     assertNotLinearTokenSequenceDelegate(matcher);
+  }
+
+  @Test
+  void linearTokenSequenceAdmitsDotAllOnlyThroughAnExplicitReggieFlag() throws Exception {
+    String pattern = ".* \\[(?<logger>\\b\\w+\\b)\\] .*";
+
+    Reggie.clearCache();
+    assertNotLinearTokenSequenceDelegate(Reggie.compile(pattern, NAMED_ONLY_OPTIONS));
+
+    Reggie.clearCache();
+    ReggieMatcher dotAllMatcher = Reggie.compile(pattern, ReggieFlags.DOTALL, NAMED_ONLY_OPTIONS);
+    assertDelegateType(dotAllMatcher, LinearTokenSequenceMatcher.class);
+    assertNotNull(dotAllMatcher.match("prefix\n [logger] trailing\nrest"));
+
+    Reggie.clearCache();
+    assertNotLinearTokenSequenceDelegate(
+        Reggie.compile("(?s)" + pattern, ReggieFlags.DOTALL, NAMED_ONLY_OPTIONS));
+  }
+
+  @Test
+  void linearTokenSequenceDotAllAdmissionIsCacheOrderIndependent() throws Exception {
+    String pattern = ".* \\[(?<logger>\\b\\w+\\b)\\] .*";
+
+    Reggie.clearCache();
+    assertNotLinearTokenSequenceDelegate(Reggie.compile(pattern, NAMED_ONLY_OPTIONS));
+    assertDelegateType(
+        Reggie.compile(pattern, ReggieFlags.DOTALL, NAMED_ONLY_OPTIONS),
+        LinearTokenSequenceMatcher.class);
+
+    Reggie.clearCache();
+    assertDelegateType(
+        Reggie.compile(pattern, ReggieFlags.DOTALL, NAMED_ONLY_OPTIONS),
+        LinearTokenSequenceMatcher.class);
+    assertNotLinearTokenSequenceDelegate(Reggie.compile(pattern, NAMED_ONLY_OPTIONS));
+  }
+
+  @Test
+  void linearTokenSequenceRejectsNonDotAllReggieFlags() throws Exception {
+    String pattern = "(?<value>\\S+)";
+    for (int flags :
+        new int[] {
+          ReggieFlags.CASE_INSENSITIVE,
+          ReggieFlags.MULTILINE,
+          ReggieFlags.LITERAL,
+          ReggieFlags.CASE_INSENSITIVE | ReggieFlags.DOTALL
+        }) {
+      Reggie.clearCache();
+      assertNotLinearTokenSequenceDelegate(Reggie.compile(pattern, flags, NAMED_ONLY_OPTIONS));
+    }
+  }
+
+  @Test
+  void linearTokenSequenceRejectsParserSupportedInlineModifiers() throws Exception {
+    for (String pattern :
+        new String[] {
+          "(?i)(?<value>\\S+)",
+          "(?m)(?<value>\\S+)",
+          "(?s)(?<value>\\S+)",
+          "(?x)(?<value>\\S+)",
+          "(?-i)(?<value>\\S+)",
+          "(?im)(?<value>\\S+)",
+          "(?i:(?<value>\\S+))"
+        }) {
+      Reggie.clearCache();
+      assertNotLinearTokenSequenceDelegate(Reggie.compile(pattern, NAMED_ONLY_OPTIONS));
+    }
+  }
+
+  @Test
+  void inlineModifierLookalikesDoNotBlockLinearTokenSequence() throws Exception {
+    for (String pattern :
+        new String[] {
+          "\\Q(?s)\\E(?<value>\\S+)",
+          "\\(\\?s\\)(?<value>\\S+)",
+          "(?# no modifier here)(?<value>\\S+)"
+        }) {
+      Reggie.clearCache();
+      assertDelegateType(
+          Reggie.compile(pattern, NAMED_ONLY_OPTIONS), LinearTokenSequenceMatcher.class);
+    }
+  }
+
+  @Test
+  void sourceInlineModifierScannerHonorsParserLiteralContexts() {
+    for (String source :
+        new String[] {
+          "\\(\\?s\\)(?<value>\\S+)",
+          "\\Q(?s)\\E(?<value>\\S+)",
+          "[(?s)](?<value>\\S+)",
+          "[\\Q(?s)\\E](?<value>\\S+)",
+          "(?# (?s) )(?<value>\\S+)"
+        }) {
+      assertFalse(RuntimeCompiler.hasSourceInlineModifier(source), source);
+    }
+    for (String source : new String[] {"(?i)(?<value>\\S+)", "(?s:(?<value>\\S+))"}) {
+      assertTrue(RuntimeCompiler.hasSourceInlineModifier(source), source);
+    }
+  }
+
+  @Test
+  void unsupportedInlineModifierFamiliesRemainSyntaxErrors() {
+    for (String modifier : new String[] {"u", "U", "d"}) {
+      assertThrows(
+          com.datadoghq.reggie.UnsupportedPatternException.class,
+          () -> Reggie.compile("(?%s)(?<value>\\S+)".formatted(modifier), NAMED_ONLY_OPTIONS));
+    }
   }
 
   private static final ReggieOptions NAMED_ONLY_OPTIONS =


### PR DESCRIPTION
## Summary

- admits named-capture Linear Token Sequences only for explicit Reggie DOTALL requests
- keeps source-inline modifiers and non-DOTALL semantic flags on the normal compiler route
- derives modifier status from original source before normalization, including escape, quote, class,
  and comment contexts
- converts logs LTS-positive fixtures to the Reggie-owned DOTALL API

## Validation

- ./gradlew jacocoVerify build
- focused LTS, access-log, concurrency, and flag API suites
- final implementation-plan validation and independent code review

Stacked on #113 (which is stacked on #112 and #111).
