### PR TITLE
feat: add bounded native pattern cache

### DIFF
--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieCompiledPattern.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieCompiledPattern.java
@@ -34,18 +34,34 @@ public final class ReggieCompiledPattern {
    */
   public static ReggieCompilationResult tryCompile(ReggieCompileRequest request) {
     Objects.requireNonNull(request, "request");
+    return tryCompileNative(request);
+  }
+
+  static ReggieCompilationResult tryCompileNative(ReggieCompileRequest request) {
+    Objects.requireNonNull(request, "request");
     RuntimeCompiler.NamedOnlyLtsCompilation compilation =
         RuntimeCompiler.tryCompileNamedOnlyLinearTokenSequence(
             request.source(), request.flag().reggieFlags());
     if (compilation.matcher() != null) {
       return ReggieCompilationResult.admitted(new ReggieCompiledPattern(compilation.matcher()));
     }
-    return ReggieCompilationResult.rejected(
-        ReggieCompilationRejection.valueOf(compilation.rejection().name()));
+    return ReggieCompilationResult.rejected(mapRejection(compilation.rejection()));
   }
 
   /** Creates a new single-thread-confined state object for matching this immutable pattern. */
   public ReggieMatchState newState() {
     return new ReggieMatchState(matcher);
+  }
+
+  private static ReggieCompilationRejection mapRejection(
+      RuntimeCompiler.NamedOnlyLtsRejection rejection) {
+    return switch (rejection) {
+      case UNSUPPORTED_FLAGS -> ReggieCompilationRejection.UNSUPPORTED_FLAGS;
+      case SOURCE_INLINE_MODIFIER -> ReggieCompilationRejection.SOURCE_INLINE_MODIFIER;
+      case PARSE_FAILURE -> ReggieCompilationRejection.PARSE_FAILURE;
+      case PLAN_UNAVAILABLE -> ReggieCompilationRejection.PLAN_UNAVAILABLE;
+      case MISSING_NAMED_CAPTURE -> ReggieCompilationRejection.MISSING_NAMED_CAPTURE;
+      case PROFILE_INELIGIBLE -> ReggieCompilationRejection.PROFILE_INELIGIBLE;
+    };
   }
 }

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieCompiledPatternCompiler.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieCompiledPatternCompiler.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+/** Bounded instance-owned cache for native named linear-token-sequence compilation. */
+public final class ReggieCompiledPatternCompiler {
+  private static final ReggieNativeCompileBudget DEFAULT_BUDGET =
+      new ReggieNativeCompileBudget(16_384);
+  private final int maximumEntries;
+  private final ReggieNativeCompileBudget budget;
+  private final Map<ReggieCompileRequest, ReggieCompiledPattern> cache =
+      new LinkedHashMap<>(16, 0.75f, true);
+  private final ConcurrentHashMap<ReggieCompileRequest, CompletableFuture<ReggieCompilationResult>>
+      inFlight = new ConcurrentHashMap<>();
+  private final Function<ReggieCompileRequest, ReggieCompilationResult> admission;
+  private final Runnable waiterArrived;
+  private int inFlightRegistrations;
+
+  /**
+   * Creates a compiler with the supplied cache capacity and a 16,384 UTF-16-code-unit source
+   * budget.
+   */
+  public ReggieCompiledPatternCompiler(int maximumEntries) {
+    this(maximumEntries, DEFAULT_BUDGET, ReggieCompiledPattern::tryCompileNative);
+  }
+
+  public ReggieCompiledPatternCompiler(int maximumEntries, ReggieNativeCompileBudget budget) {
+    this(maximumEntries, budget, ReggieCompiledPattern::tryCompileNative);
+  }
+
+  ReggieCompiledPatternCompiler(
+      int maximumEntries, Function<ReggieCompileRequest, ReggieCompilationResult> admission) {
+    this(maximumEntries, DEFAULT_BUDGET, admission, () -> {});
+  }
+
+  ReggieCompiledPatternCompiler(
+      int maximumEntries,
+      ReggieNativeCompileBudget budget,
+      Function<ReggieCompileRequest, ReggieCompilationResult> admission) {
+    this(maximumEntries, budget, admission, () -> {});
+  }
+
+  ReggieCompiledPatternCompiler(
+      int maximumEntries,
+      Function<ReggieCompileRequest, ReggieCompilationResult> admission,
+      Runnable waiterArrived) {
+    this(maximumEntries, DEFAULT_BUDGET, admission, waiterArrived);
+  }
+
+  ReggieCompiledPatternCompiler(
+      int maximumEntries,
+      ReggieNativeCompileBudget budget,
+      Function<ReggieCompileRequest, ReggieCompilationResult> admission,
+      Runnable waiterArrived) {
+    if (maximumEntries <= 0) throw new IllegalArgumentException("maximumEntries must be positive");
+    this.maximumEntries = maximumEntries;
+    this.budget = Objects.requireNonNull(budget, "budget");
+    this.admission = Objects.requireNonNull(admission, "admission");
+    this.waiterArrived = Objects.requireNonNull(waiterArrived, "waiterArrived");
+  }
+
+  public ReggieCompilationResult tryCompile(ReggieCompileRequest request) {
+    Objects.requireNonNull(request, "request");
+    if (request.source().length() > budget.maximumSourceLength()) {
+      return ReggieCompilationResult.rejected(ReggieCompilationRejection.SOURCE_TOO_LONG);
+    }
+    synchronized (cache) {
+      ReggieCompiledPattern cached = cache.get(request);
+      if (cached != null) return ReggieCompilationResult.admitted(cached);
+    }
+    CompletableFuture<ReggieCompilationResult> mine = new CompletableFuture<>();
+    synchronized (this) {
+      inFlightRegistrations++;
+    }
+    CompletableFuture<ReggieCompilationResult> existing = inFlight.putIfAbsent(request, mine);
+    if (existing != null) {
+      waiterArrived.run();
+      try {
+        return await(existing);
+      } finally {
+        synchronized (this) {
+          inFlightRegistrations--;
+        }
+      }
+    }
+    try {
+      synchronized (cache) {
+        ReggieCompiledPattern cached = cache.get(request);
+        if (cached != null) {
+          ReggieCompilationResult result = ReggieCompilationResult.admitted(cached);
+          mine.complete(result);
+          return result;
+        }
+      }
+      ReggieCompilationResult result = admission.apply(request);
+      if (result.isAdmitted()) {
+        synchronized (cache) {
+          cache.put(request, result.pattern());
+          while (cache.size() > maximumEntries) cache.remove(cache.keySet().iterator().next());
+        }
+      }
+      mine.complete(result);
+      return result;
+    } catch (Throwable failure) {
+      mine.completeExceptionally(failure);
+      if (failure instanceof RuntimeException runtimeException) throw runtimeException;
+      if (failure instanceof Error error) throw error;
+      throw new RuntimeException(failure);
+    } finally {
+      inFlight.remove(request, mine);
+      synchronized (this) {
+        inFlightRegistrations--;
+      }
+    }
+  }
+
+  public int cacheSize() {
+    synchronized (cache) {
+      return cache.size();
+    }
+  }
+
+  public void clearCache() {
+    synchronized (cache) {
+      cache.clear();
+    }
+  }
+
+  int inFlightRegistrations() {
+    synchronized (this) {
+      return inFlightRegistrations;
+    }
+  }
+
+  private static ReggieCompilationResult await(CompletableFuture<ReggieCompilationResult> future) {
+    try {
+      return future.join();
+    } catch (CompletionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof RuntimeException runtimeException) throw runtimeException;
+      if (cause instanceof Error error) throw error;
+      throw new RuntimeException(cause);
+    }
+  }
+}

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieNativeCompileBudget.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieNativeCompileBudget.java
@@ -15,13 +15,10 @@
  */
 package com.datadoghq.reggie.runtime;
 
-/** Reason the native named linear-token-sequence profile did not admit a request. */
-public enum ReggieCompilationRejection {
-  UNSUPPORTED_FLAGS,
-  SOURCE_TOO_LONG,
-  SOURCE_INLINE_MODIFIER,
-  PARSE_FAILURE,
-  PLAN_UNAVAILABLE,
-  MISSING_NAMED_CAPTURE,
-  PROFILE_INELIGIBLE
+/** Native compilation budget measured in UTF-16 source code units. */
+public record ReggieNativeCompileBudget(int maximumSourceLength) {
+  public ReggieNativeCompileBudget {
+    if (maximumSourceLength <= 0)
+      throw new IllegalArgumentException("maximumSourceLength must be positive");
+  }
 }

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LinearTokenSequenceMatcherConcurrencyTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LinearTokenSequenceMatcherConcurrencyTest.java
@@ -67,37 +67,37 @@ class LinearTokenSequenceMatcherConcurrencyTest {
 
     int threads = 16;
     int iterations = 1_000;
-    ExecutorService executor = Executors.newFixedThreadPool(threads);
     CountDownLatch ready = new CountDownLatch(threads);
     CountDownLatch start = new CountDownLatch(1);
     CountDownLatch done = new CountDownLatch(threads);
     ConcurrentLinkedQueue<Throwable> failures = new ConcurrentLinkedQueue<>();
 
-    for (int thread = 0; thread < threads; thread++) {
-      executor.execute(
-          () -> {
-            ready.countDown();
-            try {
-              start.await();
-              for (int iteration = 0; iteration < iterations; iteration++) {
-                assertMatchWithOptionalCaptures(shared, groupNumbers);
-                assertMatchWithoutOptionalCaptures(shared, groupNumbers);
-                assertFailedMatchLeavesArraysUntouched(shared, groupCount);
-                assertTrue(shared.find("noise " + WITH_OPTIONAL_CAPTURES));
-                assertFalse(shared.find("noise malformed access log"));
+    try (ExecutorService executor = Executors.newFixedThreadPool(threads)) {
+      for (int thread = 0; thread < threads; thread++) {
+        executor.execute(
+            () -> {
+              ready.countDown();
+              try {
+                start.await();
+                for (int iteration = 0; iteration < iterations; iteration++) {
+                  assertMatchWithOptionalCaptures(shared, groupNumbers);
+                  assertMatchWithoutOptionalCaptures(shared, groupNumbers);
+                  assertFailedMatchLeavesArraysUntouched(shared, groupCount);
+                  assertTrue(shared.find("noise " + WITH_OPTIONAL_CAPTURES));
+                  assertFalse(shared.find("noise malformed access log"));
+                }
+              } catch (Throwable failure) {
+                failures.add(failure);
+              } finally {
+                done.countDown();
               }
-            } catch (Throwable failure) {
-              failures.add(failure);
-            } finally {
-              done.countDown();
-            }
-          });
-    }
+            });
+      }
 
-    assertTrue(ready.await(10, TimeUnit.SECONDS), "workers did not become ready");
-    start.countDown();
-    assertTrue(done.await(30, TimeUnit.SECONDS), "workers did not finish");
-    executor.shutdownNow();
+      assertTrue(ready.await(10, TimeUnit.SECONDS), "workers did not become ready");
+      start.countDown();
+      assertTrue(done.await(30, TimeUnit.SECONDS), "workers did not finish");
+    }
     assertTrue(failures.isEmpty(), () -> "concurrent LTS failure: " + failures.peek());
   }
 

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/ReggieCompiledPatternCompilerTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/ReggieCompiledPatternCompilerTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class ReggieCompiledPatternCompilerTest {
+  @AfterEach
+  void clearLegacyCache() {
+    RuntimeCompiler.clearCache();
+  }
+
+  @Test
+  void boundsCacheAndUpdatesLruRecency() {
+    ReggieCompiledPatternCompiler compiler = new ReggieCompiledPatternCompiler(2);
+    ReggieCompiledPattern one = compile(compiler, "(?<value>\\S+)");
+    ReggieCompiledPattern two = compile(compiler, "(?<value>\\d+)");
+    assertSame(one, compile(compiler, "(?<value>\\S+)"));
+    compile(compiler, "(?<value>\\w+)");
+    assertEquals(2, compiler.cacheSize());
+    assertSame(one, compile(compiler, "(?<value>\\S+)"));
+    assertNotSame(two, compile(compiler, "(?<value>\\d+)"));
+  }
+
+  @Test
+  void rejectsWithoutCachingOrTouchingLegacyCaches() {
+    int patterns = RuntimeCompiler.cacheSize();
+    int structures = RuntimeCompiler.structuralCacheSize();
+    ReggieCompiledPatternCompiler compiler = new ReggieCompiledPatternCompiler(1);
+    ReggieCompilationResult rejected =
+        compiler.tryCompile(new ReggieCompileRequest("(?<value>[a-z]+)", ReggieCompileFlag.NONE));
+    assertFalse(rejected.isAdmitted());
+    assertEquals(0, compiler.cacheSize());
+    assertEquals(patterns, RuntimeCompiler.cacheSize());
+    assertEquals(structures, RuntimeCompiler.structuralCacheSize());
+  }
+
+  @Test
+  void instancesAndStatesAreIndependent() {
+    ReggieCompiledPatternCompiler first = new ReggieCompiledPatternCompiler(1);
+    ReggieCompiledPatternCompiler second = new ReggieCompiledPatternCompiler(1);
+    ReggieCompiledPattern a = compile(first, "(?<value>\\S+)");
+    ReggieCompiledPattern b = compile(second, "(?<value>\\S+)");
+    assertNotSame(a, b);
+    ReggieMatchState left = a.newState();
+    ReggieMatchState right = a.newState();
+    assertTrue(left.matches("left", 0, 4));
+    assertTrue(right.matches("right", 0, 5));
+    assertEquals(4, left.end("value"));
+    assertEquals(5, right.end("value"));
+    first.clearCache();
+    assertEquals(0, first.cacheSize());
+    assertEquals(1, second.cacheSize());
+  }
+
+  @Test
+  void concurrentRequestsShareOneCachedPattern() throws Exception {
+    ReggieCompiledPatternCompiler compiler = new ReggieCompiledPatternCompiler(2);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<ReggieCompiledPattern> first =
+          executor.submit(() -> compile(compiler, "(?<value>\\S+)"));
+      Future<ReggieCompiledPattern> second =
+          executor.submit(() -> compile(compiler, "(?<value>\\S+)"));
+      assertSame(first.get(), second.get());
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void concurrentRequestsPerformOneBlockedAdmission() throws Exception {
+    CountDownLatch started = new CountDownLatch(1);
+    CountDownLatch release = new CountDownLatch(1);
+    CountDownLatch waiterArrived = new CountDownLatch(1);
+    AtomicInteger admissions = new AtomicInteger();
+    ReggieCompiledPatternCompiler compiler =
+        new ReggieCompiledPatternCompiler(
+            2,
+            request -> {
+              admissions.incrementAndGet();
+              started.countDown();
+              await(release);
+              return ReggieCompiledPattern.tryCompileNative(request);
+            },
+            waiterArrived::countDown);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<ReggieCompilationResult> first = executor.submit(() -> compileResult(compiler));
+      assertTrue(started.await(5, TimeUnit.SECONDS));
+      Future<ReggieCompilationResult> second = executor.submit(() -> compileResult(compiler));
+      assertTrue(waiterArrived.await(5, TimeUnit.SECONDS));
+      release.countDown();
+      assertSame(first.get().pattern(), second.get().pattern());
+      assertEquals(1, admissions.get());
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void clearDuringBlockedAdmissionDoesNotDeadlock() throws Exception {
+    CountDownLatch started = new CountDownLatch(1);
+    CountDownLatch release = new CountDownLatch(1);
+    ReggieCompiledPatternCompiler compiler =
+        new ReggieCompiledPatternCompiler(
+            1,
+            request -> {
+              started.countDown();
+              await(release);
+              return ReggieCompiledPattern.tryCompileNative(request);
+            });
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      Future<ReggieCompilationResult> result = executor.submit(() -> compileResult(compiler));
+      assertTrue(started.await(5, TimeUnit.SECONDS));
+      compiler.clearCache();
+      release.countDown();
+      assertTrue(result.get().isAdmitted());
+      assertEquals(1, compiler.cacheSize());
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void rejectsInvalidCapacity() {
+    assertThrows(IllegalArgumentException.class, () -> new ReggieCompiledPatternCompiler(0));
+  }
+
+  @Test
+  void keepsNoneAndDotAllRequestsAsDistinctKeys() {
+    ReggieCompiledPatternCompiler compiler = new ReggieCompiledPatternCompiler(2);
+    ReggieCompiledPattern none = compile(compiler, "(?<value>\\S+)");
+    ReggieCompilationResult dotAll =
+        compiler.tryCompile(new ReggieCompileRequest("(?<value>\\S+)", ReggieCompileFlag.DOTALL));
+    assertTrue(dotAll.isAdmitted());
+    assertNotSame(none, dotAll.pattern());
+    assertEquals(2, compiler.cacheSize());
+  }
+
+  @Test
+  void exceptionalAdmissionReleasesTheRequestForRetry() {
+    AtomicInteger attempts = new AtomicInteger();
+    Cancellation cancellation = new Cancellation();
+    ReggieCompiledPatternCompiler compiler =
+        new ReggieCompiledPatternCompiler(
+            1,
+            request -> {
+              if (attempts.getAndIncrement() == 0) throw cancellation;
+              return ReggieCompiledPattern.tryCompileNative(request);
+            });
+    assertSame(
+        cancellation, assertThrows(Cancellation.class, () -> compile(compiler, "(?<value>\\S+)")));
+    assertTrue(compile(compiler, "(?<value>\\S+)") != null);
+  }
+
+  @Test
+  void concurrentWaitersReceiveTheOriginalFailureAndCanRetry() throws Exception {
+    CountDownLatch started = new CountDownLatch(1);
+    CountDownLatch release = new CountDownLatch(1);
+    CountDownLatch waiterArrived = new CountDownLatch(1);
+    Cancellation cancellation = new Cancellation();
+    AtomicInteger attempts = new AtomicInteger();
+    ReggieCompiledPatternCompiler compiler =
+        new ReggieCompiledPatternCompiler(
+            1,
+            request -> {
+              if (attempts.getAndIncrement() == 0) {
+                started.countDown();
+                await(release);
+                throw cancellation;
+              }
+              return ReggieCompiledPattern.tryCompileNative(request);
+            },
+            waiterArrived::countDown);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<ReggieCompilationResult> winner = executor.submit(() -> compileResult(compiler));
+      assertTrue(started.await(5, TimeUnit.SECONDS));
+      Future<ReggieCompilationResult> waiter = executor.submit(() -> compileResult(compiler));
+      assertTrue(waiterArrived.await(5, TimeUnit.SECONDS));
+      release.countDown();
+      assertSame(cancellation, assertThrows(Exception.class, winner::get).getCause());
+      assertSame(cancellation, assertThrows(Exception.class, waiter::get).getCause());
+      assertTrue(compileResult(compiler).isAdmitted());
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  private static ReggieCompiledPattern compile(
+      ReggieCompiledPatternCompiler compiler, String source) {
+    ReggieCompilationResult result =
+        compiler.tryCompile(new ReggieCompileRequest(source, ReggieCompileFlag.NONE));
+    assertTrue(result.isAdmitted());
+    return result.pattern();
+  }
+
+  private static ReggieCompilationResult compileResult(ReggieCompiledPatternCompiler compiler) {
+    return compiler.tryCompile(new ReggieCompileRequest("(?<value>\\S+)", ReggieCompileFlag.NONE));
+  }
+
+  private static void await(CountDownLatch latch) {
+    try {
+      if (!latch.await(5, TimeUnit.SECONDS)) throw new AssertionError("timed out waiting for test");
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError(e);
+    }
+  }
+
+  private static final class Cancellation extends RuntimeException {}
+}

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/ReggieNativeCompileBudgetTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/ReggieNativeCompileBudgetTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class ReggieNativeCompileBudgetTest {
+  @Test
+  void admitsAtBoundaryAndRejectsBeforeAdmissionOrInflightRegistration() {
+    int legacyPatterns = RuntimeCompiler.cacheSize();
+    int legacyStructures = RuntimeCompiler.structuralCacheSize();
+    AtomicInteger admissions = new AtomicInteger();
+    ReggieCompiledPatternCompiler compiler =
+        new ReggieCompiledPatternCompiler(
+            2,
+            new ReggieNativeCompileBudget(13),
+            request -> {
+              admissions.incrementAndGet();
+              return ReggieCompiledPattern.tryCompileNative(request);
+            });
+
+    ReggieCompilationResult admitted =
+        compiler.tryCompile(new ReggieCompileRequest("(?<value>\\S+)", ReggieCompileFlag.NONE));
+    assertTrue(admitted.isAdmitted());
+    int registrations = compiler.inFlightRegistrations();
+
+    ReggieCompilationResult rejected =
+        compiler.tryCompile(new ReggieCompileRequest("x".repeat(14), ReggieCompileFlag.NONE));
+    assertFalse(rejected.isAdmitted());
+    assertEquals(ReggieCompilationRejection.SOURCE_TOO_LONG, rejected.rejection());
+    assertThrows(IllegalStateException.class, rejected::pattern);
+    assertEquals(1, admissions.get());
+    assertEquals(registrations, compiler.inFlightRegistrations());
+    assertEquals(1, compiler.cacheSize());
+    assertEquals(legacyPatterns, RuntimeCompiler.cacheSize());
+    assertEquals(legacyStructures, RuntimeCompiler.structuralCacheSize());
+  }
+
+  @Test
+  void validatesBudgetAndUsesUtf16SourceLength() {
+    assertThrows(IllegalArgumentException.class, () -> new ReggieNativeCompileBudget(0));
+    ReggieCompiledPatternCompiler compiler =
+        new ReggieCompiledPatternCompiler(1, new ReggieNativeCompileBudget(1));
+    ReggieCompilationResult result =
+        compiler.tryCompile(new ReggieCompileRequest("😀", ReggieCompileFlag.NONE));
+    assertEquals(ReggieCompilationRejection.SOURCE_TOO_LONG, result.rejection());
+  }
+
+  @Test
+  void concurrentOverBudgetRequestsDoNotEnterInflightOrOtherInstance() throws Exception {
+    ReggieCompiledPatternCompiler limited =
+        new ReggieCompiledPatternCompiler(1, new ReggieNativeCompileBudget(1));
+    ReggieCompiledPatternCompiler independent = new ReggieCompiledPatternCompiler(1);
+    ReggieCompiledPattern preserved =
+        independent
+            .tryCompile(new ReggieCompileRequest("(?<value>\\S+)", ReggieCompileFlag.NONE))
+            .pattern();
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<ReggieCompilationResult> first =
+          executor.submit(
+              () -> limited.tryCompile(new ReggieCompileRequest("xx", ReggieCompileFlag.NONE)));
+      Future<ReggieCompilationResult> second =
+          executor.submit(
+              () -> limited.tryCompile(new ReggieCompileRequest("yy", ReggieCompileFlag.NONE)));
+      assertEquals(ReggieCompilationRejection.SOURCE_TOO_LONG, first.get().rejection());
+      assertEquals(ReggieCompilationRejection.SOURCE_TOO_LONG, second.get().rejection());
+      assertEquals(0, limited.inFlightRegistrations());
+      assertEquals(0, limited.cacheSize());
+      assertEquals(1, independent.cacheSize());
+      assertTrue(
+          preserved
+              == independent
+                  .tryCompile(new ReggieCompileRequest("(?<value>\\S+)", ReggieCompileFlag.NONE))
+                  .pattern());
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void boundarySizedRequestRetainsSingleFlightBehavior() throws Exception {
+    CountDownLatch started = new CountDownLatch(1);
+    CountDownLatch release = new CountDownLatch(1);
+    CountDownLatch waiter = new CountDownLatch(1);
+    AtomicInteger admissions = new AtomicInteger();
+    ReggieCompiledPatternCompiler compiler =
+        new ReggieCompiledPatternCompiler(
+            2,
+            new ReggieNativeCompileBudget(13),
+            request -> {
+              admissions.incrementAndGet();
+              started.countDown();
+              await(release);
+              return ReggieCompiledPattern.tryCompileNative(request);
+            },
+            waiter::countDown);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      ReggieCompileRequest request =
+          new ReggieCompileRequest("(?<value>\\S+)", ReggieCompileFlag.NONE);
+      Future<ReggieCompilationResult> first = executor.submit(() -> compiler.tryCompile(request));
+      assertTrue(started.await(5, TimeUnit.SECONDS));
+      Future<ReggieCompilationResult> second = executor.submit(() -> compiler.tryCompile(request));
+      assertTrue(waiter.await(5, TimeUnit.SECONDS));
+      release.countDown();
+      assertTrue(first.get().isAdmitted());
+      assertTrue(second.get().isAdmitted());
+      assertEquals(1, admissions.get());
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  private static void await(CountDownLatch latch) {
+    try {
+      if (!latch.await(5, TimeUnit.SECONDS))
+        throw new AssertionError("timed out waiting for admission");
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError(e);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in, bounded, instance-owned cache for native named-LTS compiled patterns.

- Successful native patterns are cached with exact LRU capacity.
- Rejections are never cached; legacy `RuntimeCompiler` caches remain untouched.
- Equal concurrent requests share in-flight admission; clear and exceptional admission behavior are deterministic and tested.

## Validation

- `./gradlew :reggie-runtime:test --tests com.datadoghq.reggie.runtime.ReggieCompiledPatternCompilerTest`
- `./gradlew :reggie-runtime:test`
- `./gradlew spotlessApply`
- final implementation-plan validation: clean
- final independent code review: clean
