### PR TITLE
feat: expose native pattern capabilities

### DIFF
--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/InterruptibleCharSequence.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/InterruptibleCharSequence.java
@@ -18,10 +18,8 @@ package com.datadoghq.reggie.runtime;
 /**
  * A character sequence that can cooperatively interrupt a native Reggie match.
  *
- * <p>{@link #checkInterrupted()} is invoked synchronously on the matching caller thread. The
- * matching state ({@link ReggieMatchState}) is single-thread-confined and must not be shared across
- * threads; the {@link InterruptibleCharSequence} itself may be freely reused across independent
- * match calls.
+ * <p>{@link #checkInterrupted()} is invoked synchronously on the matching caller thread. Matching
+ * state remains single-thread-confined; implementations must not concurrently reuse a state.
  */
 public interface InterruptibleCharSequence extends CharSequence {
   /**

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieCompiledPattern.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieCompiledPattern.java
@@ -16,6 +16,7 @@
 package com.datadoghq.reggie.runtime;
 
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Immutable native compiled pattern for the named linear-token-sequence profile.
@@ -23,6 +24,11 @@ import java.util.Objects;
  * <p>This API never selects another Reggie strategy and never delegates to the JDK.
  */
 public final class ReggieCompiledPattern {
+  private static final Set<ReggieNativeCapability> CAPABILITIES =
+      Set.of(
+          ReggieNativeCapability.NATIVE_ONLY,
+          ReggieNativeCapability.LINEAR_TIME,
+          ReggieNativeCapability.INTERRUPTIBLE_CHAR_SEQUENCE);
   private final LinearTokenSequenceMatcher matcher;
 
   private ReggieCompiledPattern(LinearTokenSequenceMatcher matcher) {
@@ -38,14 +44,14 @@ public final class ReggieCompiledPattern {
   }
 
   static ReggieCompilationResult tryCompileNative(ReggieCompileRequest request) {
-    Objects.requireNonNull(request, "request");
     RuntimeCompiler.NamedOnlyLtsCompilation compilation =
         RuntimeCompiler.tryCompileNamedOnlyLinearTokenSequence(
             request.source(), request.flag().reggieFlags());
     if (compilation.matcher() != null) {
       return ReggieCompilationResult.admitted(new ReggieCompiledPattern(compilation.matcher()));
     }
-    return ReggieCompilationResult.rejected(mapRejection(compilation.rejection()));
+    return ReggieCompilationResult.rejected(
+        ReggieCompilationRejection.valueOf(compilation.rejection().name()));
   }
 
   /** Creates a new single-thread-confined state object for matching this immutable pattern. */
@@ -53,15 +59,8 @@ public final class ReggieCompiledPattern {
     return new ReggieMatchState(matcher);
   }
 
-  private static ReggieCompilationRejection mapRejection(
-      RuntimeCompiler.NamedOnlyLtsRejection rejection) {
-    return switch (rejection) {
-      case UNSUPPORTED_FLAGS -> ReggieCompilationRejection.UNSUPPORTED_FLAGS;
-      case SOURCE_INLINE_MODIFIER -> ReggieCompilationRejection.SOURCE_INLINE_MODIFIER;
-      case PARSE_FAILURE -> ReggieCompilationRejection.PARSE_FAILURE;
-      case PLAN_UNAVAILABLE -> ReggieCompilationRejection.PLAN_UNAVAILABLE;
-      case MISSING_NAMED_CAPTURE -> ReggieCompilationRejection.MISSING_NAMED_CAPTURE;
-      case PROFILE_INELIGIBLE -> ReggieCompilationRejection.PROFILE_INELIGIBLE;
-    };
+  /** Returns the immutable capabilities of this native named-LTS compiled pattern. */
+  public Set<ReggieNativeCapability> capabilities() {
+    return CAPABILITIES;
   }
 }

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieCompiledPatternCompiler.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieCompiledPatternCompiler.java
@@ -96,13 +96,7 @@ public final class ReggieCompiledPatternCompiler {
     CompletableFuture<ReggieCompilationResult> existing = inFlight.putIfAbsent(request, mine);
     if (existing != null) {
       waiterArrived.run();
-      try {
-        return await(existing);
-      } finally {
-        synchronized (this) {
-          inFlightRegistrations--;
-        }
-      }
+      return await(existing);
     }
     try {
       synchronized (cache) {
@@ -129,9 +123,6 @@ public final class ReggieCompiledPatternCompiler {
       throw new RuntimeException(failure);
     } finally {
       inFlight.remove(request, mine);
-      synchronized (this) {
-        inFlightRegistrations--;
-      }
     }
   }
 

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieNativeCapability.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieNativeCapability.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+/** Capabilities explicitly guaranteed by a native named linear-token-sequence compiled pattern. */
+public enum ReggieNativeCapability {
+  /** Compiles and matches only through Reggie's native named-LTS profile, never a JDK fallback. */
+  NATIVE_ONLY,
+
+  /**
+   * Uses a linear-time native LTS algorithm for the admitted pattern, excluding work or latency
+   * imposed by a caller-provided {@link CharSequence} and cooperative checkpoints.
+   */
+  LINEAR_TIME,
+
+  /**
+   * Supports caller-thread cooperative interruption through {@link InterruptibleCharSequence} in
+   * {@link ReggieMatchState#matches(CharSequence, int, int)}: before validation and about every 256
+   * native character reads. It is not preemptive thread interruption.
+   */
+  INTERRUPTIBLE_CHAR_SEQUENCE
+}

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/InterruptibleCharSequenceTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/InterruptibleCharSequenceTest.java
@@ -73,6 +73,20 @@ class InterruptibleCharSequenceTest {
   }
 
   @Test
+  void interruptionChecksRunOnTheMatchingCallerThread() {
+    Thread caller = Thread.currentThread();
+    ReggieMatchState state = stateFor("(?<value>\\S+)");
+    Probe input =
+        new Probe("value", 1) {
+          @Override
+          void check() {
+            assertEquals(caller, Thread.currentThread());
+          }
+        };
+    assertTrue(state.matches(input, 0, input.length()));
+  }
+
+  @Test
   void checkpointsOptionalHttpAndIpOrHostValidationPaths() {
     String target = "a".repeat(600);
     ReggieMatchState optionalHttp =

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LinearTokenSequenceMatcherConcurrencyTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LinearTokenSequenceMatcherConcurrencyTest.java
@@ -94,8 +94,11 @@ class LinearTokenSequenceMatcherConcurrencyTest {
             });
       }
 
-      assertTrue(ready.await(10, TimeUnit.SECONDS), "workers did not become ready");
-      start.countDown();
+      try {
+        assertTrue(ready.await(10, TimeUnit.SECONDS), "workers did not become ready");
+      } finally {
+        start.countDown();
+      }
       assertTrue(done.await(30, TimeUnit.SECONDS), "workers did not finish");
     }
     assertTrue(failures.isEmpty(), () -> "concurrent LTS failure: " + failures.peek());
@@ -150,8 +153,11 @@ class LinearTokenSequenceMatcherConcurrencyTest {
             });
       }
 
-      assertTrue(ready.await(10, TimeUnit.SECONDS), "workers did not become ready");
-      start.countDown();
+      try {
+        assertTrue(ready.await(10, TimeUnit.SECONDS), "workers did not become ready");
+      } finally {
+        start.countDown();
+      }
       assertTrue(done.await(30, TimeUnit.SECONDS), "workers did not finish");
     }
     assertTrue(

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/ReggieNativeCapabilityTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/ReggieNativeCapabilityTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ReggieNativeCapabilityTest {
+  private static final Set<ReggieNativeCapability> EXPECTED =
+      Set.of(
+          ReggieNativeCapability.NATIVE_ONLY,
+          ReggieNativeCapability.LINEAR_TIME,
+          ReggieNativeCapability.INTERRUPTIBLE_CHAR_SEQUENCE);
+
+  @Test
+  void directAndCachedPatternsReportTheExactImmutableProfile() {
+    ReggieCompilationResult direct =
+        ReggieCompiledPattern.tryCompile(
+            new ReggieCompileRequest("(?<value>\\S+)", ReggieCompileFlag.NONE));
+    assertTrue(direct.isAdmitted());
+    assertEquals(EXPECTED, direct.pattern().capabilities());
+    assertSame(direct.pattern().capabilities(), direct.pattern().capabilities());
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> direct.pattern().capabilities().add(ReggieNativeCapability.NATIVE_ONLY));
+
+    ReggieCompiledPatternCompiler compiler = new ReggieCompiledPatternCompiler(1);
+    ReggieCompiledPattern cached =
+        compiler
+            .tryCompile(new ReggieCompileRequest("(?<value>\\S+)", ReggieCompileFlag.NONE))
+            .pattern();
+    assertEquals(EXPECTED, cached.capabilities());
+    assertSame(
+        cached,
+        compiler
+            .tryCompile(new ReggieCompileRequest("(?<value>\\S+)", ReggieCompileFlag.NONE))
+            .pattern());
+  }
+
+  @Test
+  void rejectionCannotExposeCapabilities() {
+    ReggieCompilationResult rejected =
+        ReggieCompiledPattern.tryCompile(
+            new ReggieCompileRequest("(?<value>[a-z]+)", ReggieCompileFlag.NONE));
+    assertThrows(IllegalStateException.class, rejected::pattern);
+  }
+
+  @Test
+  void capabilitiesSurviveEvictionAndSeparateCompilerInstances() {
+    ReggieCompiledPatternCompiler first = new ReggieCompiledPatternCompiler(1);
+    ReggieCompiledPatternCompiler second = new ReggieCompiledPatternCompiler(1);
+    ReggieCompiledPattern original =
+        first
+            .tryCompile(new ReggieCompileRequest("(?<value>\\S+)", ReggieCompileFlag.NONE))
+            .pattern();
+    assertTrue(
+        first
+            .tryCompile(new ReggieCompileRequest("(?<value>\\d+)", ReggieCompileFlag.NONE))
+            .isAdmitted());
+    ReggieCompiledPattern recompiled =
+        first
+            .tryCompile(new ReggieCompileRequest("(?<value>\\S+)", ReggieCompileFlag.NONE))
+            .pattern();
+    ReggieCompiledPattern independent =
+        second
+            .tryCompile(new ReggieCompileRequest("(?<value>\\S+)", ReggieCompileFlag.NONE))
+            .pattern();
+    assertEquals(EXPECTED, original.capabilities());
+    assertEquals(EXPECTED, recompiled.capabilities());
+    assertEquals(EXPECTED, independent.capabilities());
+    assertNotSame(original, recompiled);
+  }
+}


### PR DESCRIPTION
## Summary

Exposes explicit immutable capabilities for native named-LTS compiled patterns:

- native-only execution;
- native-algorithm linearity, scoped to caller-controlled sequence cost;
- caller-thread cooperative interruptible `CharSequence` matching.

The capability set is stable across direct compilation, bounded-cache hits, eviction/recompile, and independent compiler instances.

## Validation

- `./gradlew :reggie-runtime:test --tests com.datadoghq.reggie.runtime.ReggieNativeCapabilityTest --tests com.datadoghq.reggie.runtime.InterruptibleCharSequenceTest`
- `./gradlew :reggie-runtime:test`
- `./gradlew spotlessApply`
- final implementation-plan validation: clean
- final independent code review: clean
