### PR TITLE
feat: add native full capture spans

### DIFF
--- a/doc/plans/logs-backend.md
+++ b/doc/plans/logs-backend.md
@@ -64,38 +64,61 @@ Key parser locations:
 - Source: reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/parsing/RegexParser.java
 ---
 
-## Final adoption architecture/status
+## Adoption progress — July 2026
 
-The logs-backend Grok access-log path now uses a native, deterministic Reggie route under
-`CapturePolicy.NAMED_ONLY`:
+### Completed Reggie prerequisites
+
+The native logs migration stack is implemented as the draft PR chain #111 through #121.  The
+current top is #121 (`agent/logs-reggie-l1l`, based on #120).  The slices provide a deliberately
+small, native-only linear-token-sequence route:
 
 ```
 regex AST -> PatternCategorizer -> LinearTokenSequencePlan -> LinearTokenSequenceMatcher
 ```
 
-Important properties:
+The route now has the following properties:
 
-- The route is structural: it categorizes reusable token atoms (IP/host, non-space fields,
-  quoted fields, integers, decimals, optional request fragments, delimiter captures, and trailing
-  bracketed logger capture). It does **not** route by exact pattern string or `grokN` capture names.
-- `CapturePolicy.NAMED_ONLY` preserves original named group indexes so Grok can continue calling
-  `group(originalIndex)` after discovering names from the expanded regex.
-- The old ad-hoc `AccessLogGrokMatcher` oracle has been removed; production routing now depends on
-  the generic categorizer/planner/runtime matcher only.
-- The two real expanded logs-backend Grok patterns are committed as runtime test resources and have
-  regression tests proving they route through `LinearTokenSequenceMatcher`.
-- JDK/Reggie named capture-boundary equivalence is tested for the real expanded patterns across
-  common/combined access logs, optional method/version fields, `-` byte count, empty quoted fields,
-  IPv6/hostname clients, and logger bracket decoys.
+- Native direct compilation is bounded, cacheable, interruption-aware, and never falls back to the
+  JDK or general Reggie compiler.
+- L1l changes the direct facade from named-only spans to **full numeric spans**: `groupCount()`,
+  `start(int)`, and `end(int)` preserve all source capture indices for admitted patterns.  This is
+  required because Grok extracts captures by number and shadow comparison checks every group.
+- Admission is fail-closed. It requires a direct source capture layout, one matching plan operation
+  per group, deterministic non-backtracking boundaries, and the supported `NONE`/`DOTALL` flag
+  profile. Existing named-only routing and global compiler caches are unchanged.
+- The L1l implementation was independently plan-validated and code-reviewed, and passed
+  `:reggie-runtime:test` (2,542 tests; 29 skipped).
 
-Integrated benchmark after scratch-state reuse and oracle removal (`-wi 2 -i 3 -f 2 -prof gc`):
+### Not yet done
+
+This is **not** full logs-backend adoption and no logs-backend production supplier has been changed.
+The direct full-capture profile intentionally rejects shapes whose capture or matching semantics are
+not proven by the LTS executor, including IP/host and other alternatives, delimiter/quoted/bracket
+specializations, adjacent variable-width captures, and all optional forms except the proven HTTP
+version fragment.
+
+Next work, after the Reggie PR stack lands:
+
+1. Add a logs-backend `RegexPatternSupplier` adapter that maps `RegexMatcher.matches()`,
+   `group(int)`, and `groupCount()` to `ReggieCompiledPattern` / `ReggieMatchState`.
+2. Compile Reggie only for admitted patterns; make JDK selection an explicit logs-side fallback for
+   rejection. Do not use a hidden Reggie JDK fallback.
+3. Run the real expanded Grok corpus through JDK-vs-Reggie shadow comparison, including result,
+   group count, and all numeric group values; record admission and rejection cohorts.
+4. Enable native-primary only for a proven cohort, then gradually expand the profile in separately
+   reviewed correctness slices. IP/host alternatives and delimiter/quoted/bracket captures require
+   such slices before they can enter that cohort.
+
+The remaining performance target applies only once the logs adapter has a native-primary cohort:
+
+Historic target benchmark after scratch-state reuse (`-wi 2 -i 3 -f 2 -prof gc`):
 
 | Engine | Score | Allocation |
 |---|---:|---:|
 | JDK regex | 16.210 ± 2.128 us/op | 7701.393 ± 154.805 B/op |
 | Reggie native token sequence | 2.353 ± 0.161 us/op | 7682.979 ± 61.845 B/op |
 
-Target coverage for the logs-backend benchmark remains:
+Target coverage for the logs-backend benchmark, once adapter rollout starts, remains:
 
 ```
 [Reggie] coverage: 2/2 native, 0/2 internal JDK fallback, 0/2 after atomic-strip, 0/2 supplier JDK fallback

--- a/doc/plans/logs-backend.md
+++ b/doc/plans/logs-backend.md
@@ -85,7 +85,8 @@ The route now has the following properties:
   required because Grok extracts captures by number and shadow comparison checks every group.
 - Admission is fail-closed. It requires a direct source capture layout, one matching plan operation
   per group, deterministic non-backtracking boundaries, and the supported `NONE`/`DOTALL` flag
-  profile. Existing named-only routing and global compiler caches are unchanged.
+  profile. A leading `(?s)` is now DOTALL-equivalent for the named-only route as well; other source
+  inline modifiers remain ineligible. The global compiler caches are unchanged.
 - The L1l implementation was independently plan-validated and code-reviewed, and passed
   `:reggie-runtime:test` (2,542 tests; 29 skipped).
 
@@ -111,7 +112,9 @@ Next work, after the Reggie PR stack lands:
 
 The remaining performance target applies only once the logs adapter has a native-primary cohort:
 
-Historic target benchmark after scratch-state reuse (`-wi 2 -i 3 -f 2 -prof gc`):
+Historic target benchmark, pre-L1l baseline (`-wi 2 -i 3 -f 2 -prof gc`). Recorded before the L1l
+per-`ReggieMatchState` workspace/checkpointing-sequence reuse; the allocation column above does not
+reflect that change and needs re-measurement:
 
 | Engine | Score | Allocation |
 |---|---:|---:|

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/CaptureBoundaryAnalysis.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/CaptureBoundaryAnalysis.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2026-Present Datadog, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datadoghq.reggie.codegen.analysis;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Capture-layout and boundary-determinism checks shared by the native full-capture and named-only
+ * linear-token-sequence admission paths.
+ */
+public final class CaptureBoundaryAnalysis {
+  private CaptureBoundaryAnalysis() {}
+
+  /** Returns whether every required group index has exactly one capturing plan operation. */
+  public static boolean hasExactCaptureLayout(
+      LinearTokenSequencePlan plan, Set<Integer> requiredIndexes) {
+    if (!plan.coversCaptureIndexes(requiredIndexes)) return false;
+    Map<Integer, Integer> occurrences = new HashMap<>();
+    countCaptureOperations(plan.ops(), occurrences);
+    if (occurrences.size() != requiredIndexes.size()) return false;
+    for (int index : requiredIndexes) {
+      if (occurrences.getOrDefault(index, 0) != 1) return false;
+    }
+    return true;
+  }
+
+  private static void countCaptureOperations(
+      List<LinearTokenSequencePlan.Op> ops, Map<Integer, Integer> occurrences) {
+    for (LinearTokenSequencePlan.Op op : ops) {
+      if (op.groupNumber() > 0) occurrences.merge(op.groupNumber(), 1, Integer::sum);
+      countCaptureOperations(op.children(), occurrences);
+    }
+  }
+
+  /** Declines categorizer transforms that do not retain a direct source-group boundary witness. */
+  public static boolean hasOnlyDirectCaptureOps(LinearTokenSequencePlan plan) {
+    return hasOnlyDirectCaptureOps(plan.ops());
+  }
+
+  private static boolean hasOnlyDirectCaptureOps(List<LinearTokenSequencePlan.Op> ops) {
+    for (LinearTokenSequencePlan.Op op : ops) {
+      if (op.kind() == LinearTokenSequencePlan.OpKind.CAPTURE_UNTIL_DELIMITER
+          || op.kind() == LinearTokenSequencePlan.OpKind.CAPTURE_QUOTED_UNTIL_DELIMITER
+          || op.kind() == LinearTokenSequencePlan.OpKind.CAPTURE_QUOTED_NON_SPACE
+          || op.kind() == LinearTokenSequencePlan.OpKind.CAPTURE_BRACKETED_WORD_AFTER_SKIP
+          || op.kind() == LinearTokenSequencePlan.OpKind.CAPTURE_IP_OR_HOST) {
+        return false;
+      }
+      if (!hasOnlyDirectCaptureOps(op.children())) return false;
+    }
+    return true;
+  }
+
+  /**
+   * Returns whether every variable-width plan operation is followed by an operation that proves its
+   * match boundary, so the executor never needs to backtrack to find it.
+   *
+   * @param httpVersionLiteral the literal the executor matches for the optional HTTP-version
+   *     capture shape; supplied by the caller so this codegen-side analysis never depends on the
+   *     runtime matcher's constant.
+   */
+  public static boolean hasDeterministicCaptureBoundaries(
+      LinearTokenSequencePlan plan, String httpVersionLiteral) {
+    return hasDeterministicCaptureBoundaries(plan.ops(), httpVersionLiteral);
+  }
+
+  private static boolean hasDeterministicCaptureBoundaries(
+      List<LinearTokenSequencePlan.Op> ops, String httpVersionLiteral) {
+    for (int index = 0; index < ops.size(); index++) {
+      LinearTokenSequencePlan.Op op = ops.get(index);
+      if (op.kind() == LinearTokenSequencePlan.OpKind.OPTIONAL_SEQUENCE) {
+        LinearTokenSequencePlan.Op successor = index + 1 < ops.size() ? ops.get(index + 1) : null;
+        if (!isProvenOptionalHttpVersion(ops, index, httpVersionLiteral)
+            || !hasDeterministicCaptureBoundaries(op.children(), successor, httpVersionLiteral))
+          return false;
+        continue;
+      }
+      if (!op.children().isEmpty()
+          && !hasDeterministicCaptureBoundaries(op.children(), httpVersionLiteral)) return false;
+      if (!isVariableWidth(op) || index == ops.size() - 1) continue;
+      LinearTokenSequencePlan.Op next = ops.get(index + 1);
+      if (next.groupNumber() > 0) return false;
+      if (next.kind() == LinearTokenSequencePlan.OpKind.OPTIONAL_SEQUENCE) {
+        if (next.children().isEmpty()
+            || next.children().get(0).kind() != LinearTokenSequencePlan.OpKind.LITERAL
+            || index + 2 == ops.size()
+            || !isBoundary(ops.get(index + 2))
+            || !isSafeLiteralBoundary(op, next.children().get(0).literal())) return false;
+      } else if (!isSafeBoundary(op, next)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean isProvenOptionalHttpVersion(
+      List<LinearTokenSequencePlan.Op> ops, int optionalIndex, String httpVersionLiteral) {
+    if (optionalIndex + 1 >= ops.size()) return false;
+    LinearTokenSequencePlan.Op optional = ops.get(optionalIndex);
+    LinearTokenSequencePlan.Op successor = ops.get(optionalIndex + 1);
+    if (successor.kind() != LinearTokenSequencePlan.OpKind.LITERAL
+        || !successor.literal().startsWith("\"")
+        || optional.children().size() != 2) return false;
+    LinearTokenSequencePlan.Op prefix = optional.children().get(0);
+    LinearTokenSequencePlan.Op version = optional.children().get(1);
+    return prefix.kind() == LinearTokenSequencePlan.OpKind.LITERAL
+        && httpVersionLiteral.equals(prefix.literal())
+        && version.kind() == LinearTokenSequencePlan.OpKind.CAPTURE_DECIMAL_NUMBER;
+  }
+
+  private static boolean hasDeterministicCaptureBoundaries(
+      List<LinearTokenSequencePlan.Op> ops,
+      LinearTokenSequencePlan.Op successor,
+      String httpVersionLiteral) {
+    if (!hasDeterministicCaptureBoundaries(ops, httpVersionLiteral)) return false;
+    if (successor == null || ops.isEmpty()) return true;
+    LinearTokenSequencePlan.Op last = ops.get(ops.size() - 1);
+    return !isVariableWidth(last) || isSafeBoundary(last, successor);
+  }
+
+  private static boolean isVariableWidth(LinearTokenSequencePlan.Op op) {
+    return switch (op.kind()) {
+      case CAPTURE_NON_SPACE,
+          CAPTURE_DIGITS,
+          CAPTURE_SIGNED_INTEGER,
+          CAPTURE_DECIMAL_NUMBER,
+          CAPTURE_SIGNED_DECIMAL_NUMBER,
+          CAPTURE_WORD,
+          CAPTURE_UNTIL_DELIMITER,
+          CAPTURE_QUOTED_UNTIL_DELIMITER,
+          CAPTURE_QUOTED_NON_SPACE,
+          CAPTURE_IP_OR_HOST,
+          CAPTURE_SIGNED_INTEGER_OR_DASH,
+          CAPTURE_SIGNED_INTEGER_OR_UNCAPTURED_DASH,
+          CAPTURE_BRACKETED_WORD_AFTER_SKIP,
+          WHITESPACE_PLUS,
+          SKIP_ANY ->
+          true;
+      default -> false;
+    };
+  }
+
+  private static boolean isSafeBoundary(
+      LinearTokenSequencePlan.Op variable, LinearTokenSequencePlan.Op next) {
+    if (next.kind() == LinearTokenSequencePlan.OpKind.WHITESPACE_PLUS) {
+      return consumesNonWhitespace(variable);
+    }
+    return next.kind() == LinearTokenSequencePlan.OpKind.LITERAL
+        && isSafeLiteralBoundary(variable, next.literal());
+  }
+
+  private static boolean isSafeLiteralBoundary(
+      LinearTokenSequencePlan.Op variable, String literal) {
+    if (literal == null || literal.isEmpty()) return false;
+    char boundary = literal.charAt(0);
+    return switch (variable.kind()) {
+      case CAPTURE_NON_SPACE, CAPTURE_IP_OR_HOST, CAPTURE_QUOTED_NON_SPACE ->
+          isWhitespace(boundary);
+      case CAPTURE_DIGITS,
+          CAPTURE_SIGNED_INTEGER,
+          CAPTURE_SIGNED_INTEGER_OR_DASH,
+          CAPTURE_SIGNED_INTEGER_OR_UNCAPTURED_DASH ->
+          !isDigit(boundary);
+      case CAPTURE_DECIMAL_NUMBER, CAPTURE_SIGNED_DECIMAL_NUMBER ->
+          !isDigit(boundary) && boundary != '.';
+      case CAPTURE_WORD -> !isWord(boundary);
+      case WHITESPACE_PLUS -> !isWhitespace(boundary);
+      case CAPTURE_UNTIL_DELIMITER -> boundary == variable.delimiter();
+      case CAPTURE_QUOTED_UNTIL_DELIMITER, CAPTURE_BRACKETED_WORD_AFTER_SKIP -> true;
+      default -> false;
+    };
+  }
+
+  private static boolean consumesNonWhitespace(LinearTokenSequencePlan.Op op) {
+    return switch (op.kind()) {
+      case CAPTURE_NON_SPACE,
+          CAPTURE_DIGITS,
+          CAPTURE_SIGNED_INTEGER,
+          CAPTURE_DECIMAL_NUMBER,
+          CAPTURE_SIGNED_DECIMAL_NUMBER,
+          CAPTURE_WORD,
+          CAPTURE_IP_OR_HOST,
+          CAPTURE_SIGNED_INTEGER_OR_DASH,
+          CAPTURE_SIGNED_INTEGER_OR_UNCAPTURED_DASH,
+          CAPTURE_QUOTED_NON_SPACE ->
+          true;
+      default -> false;
+    };
+  }
+
+  private static boolean isWhitespace(char ch) {
+    return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\u000B' || ch == '\f' || ch == '\r';
+  }
+
+  private static boolean isDigit(char ch) {
+    return ch >= '0' && ch <= '9';
+  }
+
+  private static boolean isWord(char ch) {
+    return ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' || isDigit(ch) || ch == '_';
+  }
+
+  private static boolean isBoundary(LinearTokenSequencePlan.Op op) {
+    return op.kind() == LinearTokenSequencePlan.OpKind.WHITESPACE_PLUS
+        || op.kind() == LinearTokenSequencePlan.OpKind.LITERAL && !op.literal().isEmpty();
+  }
+}

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/CaptureProjection.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/CaptureProjection.java
@@ -19,6 +19,7 @@ import com.datadoghq.reggie.codegen.ast.*;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /** AST-level capture projection utilities. */
@@ -34,6 +35,95 @@ public final class CaptureProjection {
     Set<Integer> semanticGroups = new HashSet<>();
     collectSemanticGroupReferences(ast, semanticGroups);
     return rewrite(ast, semanticGroups);
+  }
+
+  /**
+   * Returns the source capture layout when every numbered capture has one unambiguous source
+   * definition suitable for the conservative native full-capture profile.
+   *
+   * <p>This deliberately declines branch-reset and non-empty alternatives: their numeric capture
+   * layout is not a single canonical source-to-operation mapping.
+   */
+  public static FullCaptureLayout fullCaptureLayout(RegexNode ast) {
+    Objects.requireNonNull(ast, "ast");
+    Set<Integer> indexes = new HashSet<>();
+    if (!collectFullCaptureLayout(ast, indexes)) return null;
+    int groupCount = indexes.stream().mapToInt(Integer::intValue).max().orElse(0);
+    for (int index = 1; index <= groupCount; index++) {
+      if (!indexes.contains(index)) return null;
+    }
+    return new FullCaptureLayout(groupCount, indexes);
+  }
+
+  /** Canonical source group-number layout for the direct native full-capture profile. */
+  public record FullCaptureLayout(int groupCount, Set<Integer> indexes) {
+    public FullCaptureLayout {
+      indexes = Set.copyOf(indexes);
+    }
+  }
+
+  private static boolean collectFullCaptureLayout(RegexNode node, Set<Integer> indexes) {
+    if (node instanceof GroupNode group) {
+      if (!group.capturing) return collectFullCaptureLayout(group.child, indexes);
+      return group.groupNumber > 0
+          && indexes.add(group.groupNumber)
+          && isDirectCaptureSource(group.child);
+    }
+    if (node instanceof ConcatNode concat) {
+      for (RegexNode child : concat.children) {
+        if (!collectFullCaptureLayout(child, indexes)) return false;
+      }
+      return true;
+    }
+    if (node instanceof QuantifierNode quantifier) {
+      return collectFullCaptureLayout(quantifier.child, indexes);
+    }
+    if (node instanceof AlternationNode alternation) {
+      if (alternation.alternatives.size() != 2) return false;
+      RegexNode present = null;
+      for (RegexNode alternative : alternation.alternatives) {
+        if (isEmpty(alternative)) continue;
+        if (present != null) return false;
+        present = alternative;
+      }
+      return present != null && collectFullCaptureLayout(present, indexes);
+    }
+    if (node instanceof BranchResetNode
+        || node instanceof AssertionNode
+        || node instanceof ConditionalNode
+        || node instanceof SubroutineNode
+        || node instanceof BackreferenceNode) return false;
+    return true;
+  }
+
+  private static boolean isDirectCaptureSource(RegexNode node) {
+    if (node instanceof GroupNode group) {
+      return !group.capturing && isDirectCaptureSource(group.child);
+    }
+    if (node instanceof AlternationNode
+        || node instanceof BranchResetNode
+        || node instanceof AssertionNode
+        || node instanceof ConditionalNode
+        || node instanceof SubroutineNode
+        || node instanceof BackreferenceNode) return false;
+    return !containsCapture(node);
+  }
+
+  private static boolean containsCapture(RegexNode node) {
+    if (node instanceof GroupNode group) return group.capturing || containsCapture(group.child);
+    if (node instanceof QuantifierNode quantifier) return containsCapture(quantifier.child);
+    if (node instanceof ConcatNode concat) {
+      return concat.children.stream().anyMatch(CaptureProjection::containsCapture);
+    }
+    if (node instanceof AlternationNode alternation) {
+      return alternation.alternatives.stream().anyMatch(CaptureProjection::containsCapture);
+    }
+    return node instanceof BranchResetNode;
+  }
+
+  private static boolean isEmpty(RegexNode node) {
+    return node instanceof LiteralNode literal && literal.ch == 0
+        || node instanceof ConcatNode concat && concat.children.isEmpty();
   }
 
   private static void collectSemanticGroupReferences(RegexNode node, Set<Integer> semanticGroups) {

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/CaptureProjection.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/CaptureProjection.java
@@ -63,37 +63,88 @@ public final class CaptureProjection {
   }
 
   private static boolean collectFullCaptureLayout(RegexNode node, Set<Integer> indexes) {
-    if (node instanceof GroupNode group) {
-      if (!group.capturing) return collectFullCaptureLayout(group.child, indexes);
-      return group.groupNumber > 0
-          && indexes.add(group.groupNumber)
-          && isDirectCaptureSource(group.child);
+    return node.accept(new FullCaptureLayoutVisitor(indexes));
+  }
+
+  private static final class FullCaptureLayoutVisitor implements RegexVisitor<Boolean> {
+    private final Set<Integer> indexes;
+
+    FullCaptureLayoutVisitor(Set<Integer> indexes) {
+      this.indexes = indexes;
     }
-    if (node instanceof ConcatNode concat) {
-      for (RegexNode child : concat.children) {
-        if (!collectFullCaptureLayout(child, indexes)) return false;
+
+    @Override
+    public Boolean visitLiteral(LiteralNode node) {
+      return true;
+    }
+
+    @Override
+    public Boolean visitCharClass(CharClassNode node) {
+      return true;
+    }
+
+    @Override
+    public Boolean visitConcat(ConcatNode node) {
+      for (RegexNode child : node.children) {
+        if (!child.accept(this)) return false;
       }
       return true;
     }
-    if (node instanceof QuantifierNode quantifier) {
-      return collectFullCaptureLayout(quantifier.child, indexes);
-    }
-    if (node instanceof AlternationNode alternation) {
-      if (alternation.alternatives.size() != 2) return false;
+
+    @Override
+    public Boolean visitAlternation(AlternationNode node) {
+      if (node.alternatives.size() != 2) return false;
       RegexNode present = null;
-      for (RegexNode alternative : alternation.alternatives) {
+      for (RegexNode alternative : node.alternatives) {
         if (isEmpty(alternative)) continue;
         if (present != null) return false;
         present = alternative;
       }
-      return present != null && collectFullCaptureLayout(present, indexes);
+      return present != null && present.accept(this);
     }
-    if (node instanceof BranchResetNode
-        || node instanceof AssertionNode
-        || node instanceof ConditionalNode
-        || node instanceof SubroutineNode
-        || node instanceof BackreferenceNode) return false;
-    return true;
+
+    @Override
+    public Boolean visitQuantifier(QuantifierNode node) {
+      return node.child.accept(this);
+    }
+
+    @Override
+    public Boolean visitGroup(GroupNode node) {
+      if (!node.capturing) return node.child.accept(this);
+      return node.groupNumber > 0
+          && indexes.add(node.groupNumber)
+          && isDirectCaptureSource(node.child);
+    }
+
+    @Override
+    public Boolean visitAnchor(AnchorNode node) {
+      return true;
+    }
+
+    @Override
+    public Boolean visitBackreference(BackreferenceNode node) {
+      return false;
+    }
+
+    @Override
+    public Boolean visitAssertion(AssertionNode node) {
+      return false;
+    }
+
+    @Override
+    public Boolean visitSubroutine(SubroutineNode node) {
+      return false;
+    }
+
+    @Override
+    public Boolean visitConditional(ConditionalNode node) {
+      return false;
+    }
+
+    @Override
+    public Boolean visitBranchReset(BranchResetNode node) {
+      return false;
+    }
   }
 
   private static boolean isDirectCaptureSource(RegexNode node) {
@@ -110,15 +161,69 @@ public final class CaptureProjection {
   }
 
   private static boolean containsCapture(RegexNode node) {
-    if (node instanceof GroupNode group) return group.capturing || containsCapture(group.child);
-    if (node instanceof QuantifierNode quantifier) return containsCapture(quantifier.child);
-    if (node instanceof ConcatNode concat) {
-      return concat.children.stream().anyMatch(CaptureProjection::containsCapture);
-    }
-    if (node instanceof AlternationNode alternation) {
-      return alternation.alternatives.stream().anyMatch(CaptureProjection::containsCapture);
-    }
-    return node instanceof BranchResetNode;
+    return node.accept(
+        new RegexVisitor<Boolean>() {
+          @Override
+          public Boolean visitLiteral(LiteralNode node) {
+            return false;
+          }
+
+          @Override
+          public Boolean visitCharClass(CharClassNode node) {
+            return false;
+          }
+
+          @Override
+          public Boolean visitConcat(ConcatNode node) {
+            return node.children.stream().anyMatch(child -> child.accept(this));
+          }
+
+          @Override
+          public Boolean visitAlternation(AlternationNode node) {
+            return node.alternatives.stream().anyMatch(child -> child.accept(this));
+          }
+
+          @Override
+          public Boolean visitQuantifier(QuantifierNode node) {
+            return node.child.accept(this);
+          }
+
+          @Override
+          public Boolean visitGroup(GroupNode node) {
+            return node.capturing || node.child.accept(this);
+          }
+
+          @Override
+          public Boolean visitAnchor(AnchorNode node) {
+            return false;
+          }
+
+          @Override
+          public Boolean visitBackreference(BackreferenceNode node) {
+            return false;
+          }
+
+          @Override
+          public Boolean visitAssertion(AssertionNode node) {
+            return node.subPattern.accept(this);
+          }
+
+          @Override
+          public Boolean visitSubroutine(SubroutineNode node) {
+            return true;
+          }
+
+          @Override
+          public Boolean visitConditional(ConditionalNode node) {
+            return node.thenBranch.accept(this)
+                || (node.elseBranch != null && node.elseBranch.accept(this));
+          }
+
+          @Override
+          public Boolean visitBranchReset(BranchResetNode node) {
+            return true;
+          }
+        });
   }
 
   private static boolean isEmpty(RegexNode node) {

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternCategorizer.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/analysis/PatternCategorizer.java
@@ -433,6 +433,7 @@ public final class PatternCategorizer {
     }
 
     private static boolean isDotAllAnyStar(RegexNode node) {
+      node = stripNonCapturingGroup(node);
       if (!(node instanceof QuantifierNode quantifier)
           || quantifier.min != 0
           || quantifier.max != -1

--- a/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/automaton/CharSet.java
+++ b/reggie-codegen/src/main/java/com/datadoghq/reggie/codegen/automaton/CharSet.java
@@ -169,7 +169,6 @@ public final class CharSet {
               new Range(' ', ' '),
               new Range('\t', '\t'),
               new Range('\n', '\n'),
-              new Range('\u000B', '\u000B'),
               new Range('\r', '\r'),
               new Range('\f', '\f')));
 

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LinearTokenSequenceMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LinearTokenSequenceMatcher.java
@@ -666,7 +666,7 @@ final class LinearTokenSequenceMatcher extends ReggieMatcher {
   }
 
   private static boolean isJdkWhitespace(char ch) {
-    return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\u000B' || ch == '\f' || ch == '\r';
+    return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\f' || ch == '\r';
   }
 
   private static boolean isDigit(char ch) {

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LinearTokenSequenceMatcher.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/LinearTokenSequenceMatcher.java
@@ -22,6 +22,10 @@ import java.util.Objects;
 
 /** Generic runtime executor for deterministic linear-token-sequence plans. */
 final class LinearTokenSequenceMatcher extends ReggieMatcher {
+  // Shared with RuntimeCompiler's admission-side HTTP-version-optional-capture shape check so the
+  // two literals can't silently drift.
+  static final String HTTP_VERSION_LITERAL = " HTTP/";
+
   private final LinearTokenSequencePlan plan;
   private final int groupCount;
   private final int optionalDepth;
@@ -76,14 +80,14 @@ final class LinearTokenSequenceMatcher extends ReggieMatcher {
   @Override
   public boolean matchesBounded(CharSequence input, int start, int end) {
     Objects.requireNonNull(input, "input");
-    if (!isValidRegion(input, start, end)) return false;
+    validateRegion(input, start, end);
     return matchesAt(input, start, end, newWorkspace(), true);
   }
 
   @Override
   public MatchResult matchBounded(CharSequence input, int start, int end) {
     Objects.requireNonNull(input, "input");
-    if (!isValidRegion(input, start, end)) return null;
+    validateRegion(input, start, end);
     MatchWorkspace workspace = newWorkspace();
     if (!matchesAt(input, start, end, workspace, true)) return null;
     return toMatchResult(input.toString(), workspace);
@@ -176,7 +180,7 @@ final class LinearTokenSequenceMatcher extends ReggieMatcher {
       MatchWorkspace workspace) {
     input.checkInterrupted();
     return matchIntoBounded(
-        new CheckpointingCharSequence(input), start, end, groupStarts, groupEnds, workspace);
+        workspace.checkpointing(input), start, end, groupStarts, groupEnds, workspace);
   }
 
   private MatchResult toMatchResult(String input, MatchWorkspace workspace) {
@@ -340,8 +344,13 @@ final class LinearTokenSequenceMatcher extends ReggieMatcher {
       pos++;
       int fractionStart = pos;
       while (pos < regionEnd && isDigit(input.charAt(pos))) pos++;
-      if (!sawLeadingDigits && pos == fractionStart) return -1;
-    } else if (!sawLeadingDigits) {
+      boolean sawFractionDigits = pos > fractionStart;
+      // CAPTURE_DECIMAL_NUMBER (signed=false) is only ever emitted for the exact source shape
+      // \d+\.\d+ (see PatternCategorizer#isDecimalNumber); require the fraction digits so this
+      // executor doesn't admit "1" or "1." for a pattern the categorizer promised was \d+\.\d+.
+      if (!signed && !sawFractionDigits) return -1;
+      if (!sawLeadingDigits && !sawFractionDigits) return -1;
+    } else if (!sawLeadingDigits || !signed) {
       return -1;
     }
     set(starts, ends, group, start, pos);
@@ -450,7 +459,7 @@ final class LinearTokenSequenceMatcher extends ReggieMatcher {
     LinearTokenSequencePlan.Op prefix = optional.children().get(0);
     LinearTokenSequencePlan.Op version = optional.children().get(1);
     return prefix.kind() == LinearTokenSequencePlan.OpKind.LITERAL
-        && " HTTP/".equals(prefix.literal())
+        && HTTP_VERSION_LITERAL.equals(prefix.literal())
         && version.kind() == LinearTokenSequencePlan.OpKind.CAPTURE_DECIMAL_NUMBER;
   }
 
@@ -464,10 +473,10 @@ final class LinearTokenSequenceMatcher extends ReggieMatcher {
       int[] ends) {
     int quote = findChar(input, pos, regionEnd, '"');
     if (quote == regionEnd || quote == pos) return -1;
-    int marker = findLastLiteral(input, pos, quote, " HTTP/");
+    int marker = findLastLiteral(input, pos, quote, HTTP_VERSION_LITERAL);
     if (marker >= pos && isNonSpace(input, pos, marker)) {
       LinearTokenSequencePlan.Op version = optionalHttpVersion.children().get(1);
-      int versionStart = marker + " HTTP/".length();
+      int versionStart = marker + HTTP_VERSION_LITERAL.length();
       int versionEnd = scanDecimal(input, versionStart, quote, false);
       if (versionEnd == quote) {
         set(starts, ends, target.groupNumber(), pos, marker);
@@ -534,6 +543,7 @@ final class LinearTokenSequenceMatcher extends ReggieMatcher {
     final int[] ends;
     final int[][] optionalStarts;
     final int[][] optionalEnds;
+    private CheckpointingCharSequence checkpointingCharSequence;
 
     MatchWorkspace(int groupCount, int optionalDepth) {
       starts = new int[groupCount + 1];
@@ -541,16 +551,31 @@ final class LinearTokenSequenceMatcher extends ReggieMatcher {
       optionalStarts = new int[optionalDepth][groupCount + 1];
       optionalEnds = new int[optionalDepth][groupCount + 1];
     }
+
+    /** Reuses (or lazily creates) this workspace's checkpointing wrapper for {@code delegate}. */
+    CheckpointingCharSequence checkpointing(InterruptibleCharSequence delegate) {
+      if (checkpointingCharSequence == null) {
+        checkpointingCharSequence = new CheckpointingCharSequence(delegate);
+      } else {
+        checkpointingCharSequence.reset(delegate);
+      }
+      return checkpointingCharSequence;
+    }
   }
 
   private static final class CheckpointingCharSequence implements CharSequence {
     private static final int CHECK_INTERVAL = 256;
 
-    private final InterruptibleCharSequence delegate;
+    private InterruptibleCharSequence delegate;
     private int charactersUntilCheck = CHECK_INTERVAL;
 
     private CheckpointingCharSequence(InterruptibleCharSequence delegate) {
+      reset(delegate);
+    }
+
+    private void reset(InterruptibleCharSequence delegate) {
       this.delegate = Objects.requireNonNull(delegate, "input");
+      this.charactersUntilCheck = CHECK_INTERVAL;
     }
 
     @Override
@@ -566,6 +591,19 @@ final class LinearTokenSequenceMatcher extends ReggieMatcher {
         charactersUntilCheck = CHECK_INTERVAL;
       }
       return value;
+    }
+
+    /**
+     * Bulk equivalent of skipping {@code count} characters one {@link #charAt} call at a time:
+     * accounts for the skipped length against the interruption-check counter with at most one
+     * {@link InterruptibleCharSequence#checkInterrupted()} call.
+     */
+    void advance(int count) {
+      charactersUntilCheck -= count;
+      if (charactersUntilCheck <= 0) {
+        delegate.checkInterrupted();
+        charactersUntilCheck = CHECK_INTERVAL;
+      }
     }
 
     @Override
@@ -601,25 +639,22 @@ final class LinearTokenSequenceMatcher extends ReggieMatcher {
   }
 
   private static int findLastLiteral(CharSequence input, int start, int end, String literal) {
-    int last = -1;
-    for (int pos = start; pos + literal.length() <= end; pos++) {
-      if (startsWith(input, pos, end, literal)) last = pos;
+    for (int pos = end - literal.length(); pos >= start; pos--) {
+      if (startsWith(input, pos, end, literal)) return pos;
     }
-    return last;
+    return -1;
   }
 
   private static int consumeToEnd(CharSequence input, int pos, int regionEnd) {
-    while (pos < regionEnd) {
-      input.charAt(pos++);
+    if (input instanceof CheckpointingCharSequence checkpointing) {
+      checkpointing.advance(regionEnd - pos);
     }
     return regionEnd;
   }
 
   private static int consumeToEndExceptNewline(CharSequence input, int pos, int regionEnd) {
-    while (pos < regionEnd) {
-      if (input.charAt(pos++) == '\n') return -1;
-    }
-    return regionEnd;
+    while (pos < regionEnd && input.charAt(pos) != '\n') pos++;
+    return pos;
   }
 
   private static void set(int[] starts, int[] ends, int group, int start, int end) {
@@ -666,7 +701,7 @@ final class LinearTokenSequenceMatcher extends ReggieMatcher {
   }
 
   private static boolean isJdkWhitespace(char ch) {
-    return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\f' || ch == '\r';
+    return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\u000B' || ch == '\f' || ch == '\r';
   }
 
   private static boolean isDigit(char ch) {

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieCompilationRejection.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieCompilationRejection.java
@@ -15,7 +15,7 @@
  */
 package com.datadoghq.reggie.runtime;
 
-/** Reason the native named linear-token-sequence profile did not admit a request. */
+/** Reason the native full-capture linear-token-sequence profile did not admit a request. */
 public enum ReggieCompilationRejection {
   UNSUPPORTED_FLAGS,
   SOURCE_TOO_LONG,
@@ -23,5 +23,6 @@ public enum ReggieCompilationRejection {
   PARSE_FAILURE,
   PLAN_UNAVAILABLE,
   MISSING_NAMED_CAPTURE,
+  MISSING_CAPTURE,
   PROFILE_INELIGIBLE
 }

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieCompilationResult.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieCompilationResult.java
@@ -17,7 +17,7 @@ package com.datadoghq.reggie.runtime;
 
 import java.util.Objects;
 
-/** Immutable outcome of a native named linear-token-sequence compilation request. */
+/** Immutable outcome of a native full-capture linear-token-sequence compilation request. */
 public final class ReggieCompilationResult {
   private final ReggieCompiledPattern pattern;
   private final ReggieCompilationRejection rejection;

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieCompileFlag.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieCompileFlag.java
@@ -17,7 +17,7 @@ package com.datadoghq.reggie.runtime;
 
 import com.datadoghq.reggie.ReggieFlags;
 
-/** Flags supported by the native named linear-token-sequence compilation profile. */
+/** Flags supported by the native full-capture linear-token-sequence compilation profile. */
 public enum ReggieCompileFlag {
   NONE(ReggieFlags.NONE),
   DOTALL(ReggieFlags.DOTALL);

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieCompileFlag.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieCompileFlag.java
@@ -17,10 +17,21 @@ package com.datadoghq.reggie.runtime;
 
 import com.datadoghq.reggie.ReggieFlags;
 
-/** Flags supported by the native full-capture linear-token-sequence compilation profile. */
+/**
+ * Flags supported by the native full-capture linear-token-sequence compilation profile.
+ *
+ * <p>This enum is intentionally closed to exactly {@code NONE} and {@code DOTALL}; it is not a
+ * wrapper around the {@link ReggieFlags} bitmask.
+ */
 public enum ReggieCompileFlag {
   NONE(ReggieFlags.NONE),
   DOTALL(ReggieFlags.DOTALL);
+
+  static final int SUPPORTED = NONE.reggieFlags() | DOTALL.reggieFlags();
+
+  static {
+    assert ReggieFlags.areSupported(SUPPORTED) : "ReggieCompileFlag drifted from ReggieFlags";
+  }
 
   private final int reggieFlags;
 

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieCompiledPattern.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieCompiledPattern.java
@@ -19,7 +19,8 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * Immutable native compiled pattern for the named linear-token-sequence profile.
+ * Immutable native compiled pattern for the conservative full-capture linear-token-sequence
+ * profile.
  *
  * <p>This API never selects another Reggie strategy and never delegates to the JDK.
  */
@@ -44,8 +45,8 @@ public final class ReggieCompiledPattern {
   }
 
   static ReggieCompilationResult tryCompileNative(ReggieCompileRequest request) {
-    RuntimeCompiler.NamedOnlyLtsCompilation compilation =
-        RuntimeCompiler.tryCompileNamedOnlyLinearTokenSequence(
+    RuntimeCompiler.FullCaptureLtsCompilation compilation =
+        RuntimeCompiler.tryCompileFullCaptureLinearTokenSequence(
             request.source(), request.flag().reggieFlags());
     if (compilation.matcher() != null) {
       return ReggieCompilationResult.admitted(new ReggieCompiledPattern(compilation.matcher()));

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieCompiledPattern.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieCompiledPattern.java
@@ -45,14 +45,25 @@ public final class ReggieCompiledPattern {
   }
 
   static ReggieCompilationResult tryCompileNative(ReggieCompileRequest request) {
-    RuntimeCompiler.FullCaptureLtsCompilation compilation =
+    if (request.source().length()
+        > ReggieCompiledPatternCompiler.DEFAULT_BUDGET.maximumSourceLength()) {
+      return ReggieCompilationResult.rejected(ReggieCompilationRejection.SOURCE_TOO_LONG);
+    }
+    RuntimeCompiler.Compilation<RuntimeCompiler.FullCaptureLtsRejection> compilation =
         RuntimeCompiler.tryCompileFullCaptureLinearTokenSequence(
             request.source(), request.flag().reggieFlags());
     if (compilation.matcher() != null) {
       return ReggieCompilationResult.admitted(new ReggieCompiledPattern(compilation.matcher()));
     }
     return ReggieCompilationResult.rejected(
-        ReggieCompilationRejection.valueOf(compilation.rejection().name()));
+        switch (compilation.rejection()) {
+          case UNSUPPORTED_FLAGS -> ReggieCompilationRejection.UNSUPPORTED_FLAGS;
+          case SOURCE_INLINE_MODIFIER -> ReggieCompilationRejection.SOURCE_INLINE_MODIFIER;
+          case PARSE_FAILURE -> ReggieCompilationRejection.PARSE_FAILURE;
+          case PLAN_UNAVAILABLE -> ReggieCompilationRejection.PLAN_UNAVAILABLE;
+          case MISSING_CAPTURE -> ReggieCompilationRejection.MISSING_CAPTURE;
+          case PROFILE_INELIGIBLE -> ReggieCompilationRejection.PROFILE_INELIGIBLE;
+        });
   }
 
   /** Creates a new single-thread-confined state object for matching this immutable pattern. */
@@ -60,7 +71,13 @@ public final class ReggieCompiledPattern {
     return new ReggieMatchState(matcher);
   }
 
-  /** Returns the immutable capabilities of this native named-LTS compiled pattern. */
+  /**
+   * Returns the immutable capabilities of this native named-LTS compiled pattern.
+   *
+   * <p>This set is the same constant for every instance: it documents guarantees this compiled
+   * pattern always holds (native-only execution, linear time, interruptible char sequences), not a
+   * per-instance signal callers should branch on.
+   */
   public Set<ReggieNativeCapability> capabilities() {
     return CAPABILITIES;
   }

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieCompiledPatternCompiler.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieCompiledPatternCompiler.java
@@ -19,18 +19,29 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
 /** Bounded instance-owned cache for native named linear-token-sequence compilation. */
 public final class ReggieCompiledPatternCompiler {
-  private static final ReggieNativeCompileBudget DEFAULT_BUDGET =
-      new ReggieNativeCompileBudget(16_384);
+  static final ReggieNativeCompileBudget DEFAULT_BUDGET = new ReggieNativeCompileBudget(16_384);
+
+  /**
+   * Number of independently-locked cache segments used once {@code maximumEntries} is large enough
+   * to make striping worthwhile. Splitting the cache into stripes means concurrent lookups for keys
+   * in different segments never contend on the same monitor, unlike a single global lock guarding
+   * one access-ordered {@link LinkedHashMap}. Below this threshold a single segment is used
+   * instead, since a segment holding only one or two entries would defeat the point of caching
+   * (frequent evictions from key collisions across segments).
+   */
+  private static final int STRIPE_COUNT = 16;
+
   private final int maximumEntries;
   private final ReggieNativeCompileBudget budget;
-  private final Map<ReggieCompileRequest, ReggieCompiledPattern> cache =
-      new LinkedHashMap<>(16, 0.75f, true);
+  private final Segment[] segments;
   private final ConcurrentHashMap<ReggieCompileRequest, CompletableFuture<ReggieCompilationResult>>
       inFlight = new ConcurrentHashMap<>();
   private final Function<ReggieCompileRequest, ReggieCompilationResult> admission;
@@ -42,11 +53,11 @@ public final class ReggieCompiledPatternCompiler {
    * budget.
    */
   public ReggieCompiledPatternCompiler(int maximumEntries) {
-    this(maximumEntries, DEFAULT_BUDGET, ReggieCompiledPattern::tryCompileNative);
+    this(maximumEntries, DEFAULT_BUDGET, ReggieCompiledPattern::tryCompileNative, () -> {});
   }
 
   public ReggieCompiledPatternCompiler(int maximumEntries, ReggieNativeCompileBudget budget) {
-    this(maximumEntries, budget, ReggieCompiledPattern::tryCompileNative);
+    this(maximumEntries, budget, ReggieCompiledPattern::tryCompileNative, () -> {});
   }
 
   ReggieCompiledPatternCompiler(
@@ -78,6 +89,16 @@ public final class ReggieCompiledPatternCompiler {
     this.budget = Objects.requireNonNull(budget, "budget");
     this.admission = Objects.requireNonNull(admission, "admission");
     this.waiterArrived = Objects.requireNonNull(waiterArrived, "waiterArrived");
+    int stripeCount = maximumEntries >= STRIPE_COUNT ? STRIPE_COUNT : 1;
+    int perSegmentCapacity = (maximumEntries + stripeCount - 1) / stripeCount;
+    this.segments = new Segment[stripeCount];
+    for (int i = 0; i < stripeCount; i++) {
+      segments[i] = new Segment(perSegmentCapacity);
+    }
+  }
+
+  private Segment segmentFor(ReggieCompileRequest request) {
+    return segments[Math.floorMod(request.hashCode(), segments.length)];
   }
 
   public ReggieCompilationResult tryCompile(ReggieCompileRequest request) {
@@ -85,10 +106,9 @@ public final class ReggieCompiledPatternCompiler {
     if (request.source().length() > budget.maximumSourceLength()) {
       return ReggieCompilationResult.rejected(ReggieCompilationRejection.SOURCE_TOO_LONG);
     }
-    synchronized (cache) {
-      ReggieCompiledPattern cached = cache.get(request);
-      if (cached != null) return ReggieCompilationResult.admitted(cached);
-    }
+    Segment segment = segmentFor(request);
+    ReggieCompiledPattern cached = segment.get(request);
+    if (cached != null) return ReggieCompilationResult.admitted(cached);
     CompletableFuture<ReggieCompilationResult> mine = new CompletableFuture<>();
     synchronized (this) {
       inFlightRegistrations++;
@@ -99,20 +119,15 @@ public final class ReggieCompiledPatternCompiler {
       return await(existing);
     }
     try {
-      synchronized (cache) {
-        ReggieCompiledPattern cached = cache.get(request);
-        if (cached != null) {
-          ReggieCompilationResult result = ReggieCompilationResult.admitted(cached);
-          mine.complete(result);
-          return result;
-        }
+      cached = segment.get(request);
+      if (cached != null) {
+        ReggieCompilationResult result = ReggieCompilationResult.admitted(cached);
+        mine.complete(result);
+        return result;
       }
       ReggieCompilationResult result = admission.apply(request);
       if (result.isAdmitted()) {
-        synchronized (cache) {
-          cache.put(request, result.pattern());
-          while (cache.size() > maximumEntries) cache.remove(cache.keySet().iterator().next());
-        }
+        segment.put(request, result.pattern());
       }
       mine.complete(result);
       return result;
@@ -127,14 +142,16 @@ public final class ReggieCompiledPatternCompiler {
   }
 
   public int cacheSize() {
-    synchronized (cache) {
-      return cache.size();
+    int size = 0;
+    for (Segment segment : segments) {
+      size += segment.size();
     }
+    return size;
   }
 
   public void clearCache() {
-    synchronized (cache) {
-      cache.clear();
+    for (Segment segment : segments) {
+      segment.clear();
     }
   }
 
@@ -144,14 +161,49 @@ public final class ReggieCompiledPatternCompiler {
     }
   }
 
+  private static final long AWAIT_TIMEOUT_SECONDS = 30;
+
   private static ReggieCompilationResult await(CompletableFuture<ReggieCompilationResult> future) {
     try {
-      return future.join();
-    } catch (CompletionException e) {
+      return future.get(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    } catch (ExecutionException e) {
       Throwable cause = e.getCause();
       if (cause instanceof RuntimeException runtimeException) throw runtimeException;
       if (cause instanceof Error error) throw error;
       throw new RuntimeException(cause);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("interrupted while awaiting in-flight compilation", e);
+    } catch (TimeoutException e) {
+      throw new RuntimeException("timed out awaiting in-flight compilation", e);
+    }
+  }
+
+  /** One independently-locked, bounded, access-ordered LRU shard of the compilation cache. */
+  private static final class Segment {
+    private final int capacity;
+    private final Map<ReggieCompileRequest, ReggieCompiledPattern> entries =
+        new LinkedHashMap<>(16, 0.75f, true);
+
+    Segment(int capacity) {
+      this.capacity = capacity;
+    }
+
+    synchronized ReggieCompiledPattern get(ReggieCompileRequest request) {
+      return entries.get(request);
+    }
+
+    synchronized void put(ReggieCompileRequest request, ReggieCompiledPattern pattern) {
+      entries.put(request, pattern);
+      while (entries.size() > capacity) entries.remove(entries.keySet().iterator().next());
+    }
+
+    synchronized int size() {
+      return entries.size();
+    }
+
+    synchronized void clear() {
+      entries.clear();
     }
   }
 }

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieMatchState.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieMatchState.java
@@ -68,6 +68,25 @@ public final class ReggieMatchState {
     return ends[0];
   }
 
+  /** Returns the number of source capture groups, excluding group zero. */
+  public int groupCount() {
+    return matcher.groupCount();
+  }
+
+  /** Returns the start offset of a numbered source capture group. */
+  public int start(int group) {
+    requireMatched();
+    requireGroupIndex(group);
+    return starts[group];
+  }
+
+  /** Returns the end offset of a numbered source capture group. */
+  public int end(int group) {
+    requireMatched();
+    requireGroupIndex(group);
+    return ends[group];
+  }
+
   public int start(String name) {
     requireMatched();
     return starts[matcher.groupIndex(name)];
@@ -88,6 +107,12 @@ public final class ReggieMatchState {
   private void requireMatched() {
     if (!matched) {
       throw new IllegalStateException("there is no current match");
+    }
+  }
+
+  private void requireGroupIndex(int group) {
+    if (group < 0 || group > matcher.groupCount()) {
+      throw new IndexOutOfBoundsException("invalid group index: " + group);
     }
   }
 }

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieNativeCapability.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/ReggieNativeCapability.java
@@ -15,9 +15,12 @@
  */
 package com.datadoghq.reggie.runtime;
 
-/** Capabilities explicitly guaranteed by a native named linear-token-sequence compiled pattern. */
+/** Capabilities explicitly guaranteed by a native full-capture linear-token-sequence pattern. */
 public enum ReggieNativeCapability {
-  /** Compiles and matches only through Reggie's native named-LTS profile, never a JDK fallback. */
+  /**
+   * Compiles and matches only through Reggie's native full-capture LTS profile, never a JDK
+   * fallback.
+   */
   NATIVE_ONLY,
 
   /**

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/RuntimeCompiler.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/RuntimeCompiler.java
@@ -22,6 +22,7 @@ import com.datadoghq.reggie.ReggieOption;
 import com.datadoghq.reggie.ReggieOptions;
 import com.datadoghq.reggie.UnsupportedPatternException;
 import com.datadoghq.reggie.codegen.analysis.BackreferencePatternInfo;
+import com.datadoghq.reggie.codegen.analysis.CaptureBoundaryAnalysis;
 import com.datadoghq.reggie.codegen.analysis.CaptureProjection;
 import com.datadoghq.reggie.codegen.analysis.ConcatGreedyGroupInfo;
 import com.datadoghq.reggie.codegen.analysis.ConcatQuantifiedGroupsInfo;
@@ -75,6 +76,7 @@ import com.datadoghq.reggie.codegen.parsing.RegexParser;
 import java.io.PrintWriter;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -272,7 +274,7 @@ public class RuntimeCompiler {
         options,
         cacheKeyForFlags(pattern, flags, options),
         pattern,
-        LinearTokenSequenceAdmission.forFlags(pattern, flags));
+        () -> LinearTokenSequenceAdmission.forFlags(pattern, flags));
   }
 
   /** Compile pattern with runtime compilation options. */
@@ -282,7 +284,7 @@ public class RuntimeCompiler {
         options,
         cacheKeyFor(pattern, options),
         pattern,
-        LinearTokenSequenceAdmission.forSource(pattern));
+        () -> LinearTokenSequenceAdmission.forSource(pattern));
   }
 
   private static ReggieMatcher compile(
@@ -290,7 +292,7 @@ public class RuntimeCompiler {
       ReggieOptions options,
       Object cacheKey,
       String reportedPattern,
-      LinearTokenSequenceAdmission linearTokenSequenceAdmission) {
+      java.util.function.Supplier<LinearTokenSequenceAdmission> linearTokenSequenceAdmission) {
 
     // Fast path: PIKEVM_CAPTURE patterns are in PIKEVM_NFA_CACHE — return a fresh matcher.
     // PikeVMMatcher carries mutable per-call buffers and must not be shared across calls.
@@ -324,7 +326,7 @@ public class RuntimeCompiler {
             cacheKey,
             k ->
                 reportPattern(
-                    compileInternal(pattern, options, k, linearTokenSequenceAdmission),
+                    compileInternal(pattern, options, k, linearTokenSequenceAdmission.get()),
                     reportedPattern));
 
     // Post-compilation fixup: if compileInternal registered this pattern as PIKEVM_CAPTURE,
@@ -560,17 +562,35 @@ public class RuntimeCompiler {
    * original source.
    */
   private record LinearTokenSequenceAdmission(boolean isEligible, boolean isDotAll) {
+    private static final String LEADING_DOTALL_MODIFIER = "(?s)";
+
     private static LinearTokenSequenceAdmission forSource(String source) {
-      return new LinearTokenSequenceAdmission(!hasSourceInlineModifier(source), false);
+      if (!hasSourceInlineModifier(source)) {
+        return new LinearTokenSequenceAdmission(true, false);
+      }
+      // A leading "(?s)" with no OTHER inline modifier is equivalent to passing
+      // ReggieFlags.DOTALL, so admit it the same way forFlags() would.
+      if (source.startsWith(LEADING_DOTALL_MODIFIER)
+          && !hasSourceInlineModifier(source.substring(LEADING_DOTALL_MODIFIER.length()))) {
+        return new LinearTokenSequenceAdmission(true, true);
+      }
+      return new LinearTokenSequenceAdmission(false, false);
     }
 
     private static LinearTokenSequenceAdmission forFlags(String source, int flags) {
       boolean isDotAll = flags == ReggieFlags.DOTALL;
-      return new LinearTokenSequenceAdmission(
-          isDotAll && !hasSourceInlineModifier(source), isDotAll);
+      boolean isEligible = (flags == 0 || isDotAll) && !hasSourceInlineModifier(source);
+      return new LinearTokenSequenceAdmission(isEligible, isDotAll);
     }
   }
 
+  /**
+   * Intentionally re-implements a minimal lexical scan (character-class, {@code \Q...\E}, and
+   * {@code (?#...)}-comment awareness) independently of {@link RegexParser}'s tokenizer, purely to
+   * gate native-route admission. Any future change to how {@link RegexParser} recognizes character
+   * classes, quoting, or comment groups must be mirrored here, or admission can silently diverge
+   * from the real parser.
+   */
   static boolean hasSourceInlineModifier(String source) {
     boolean inCharacterClass = false;
     int index = 0;
@@ -603,15 +623,6 @@ public class RuntimeCompiler {
       if (ch == '[') {
         inCharacterClass = true;
         index++;
-        // In Java regex, ']' as the first character of a class (or first after '^')
-        // is a literal, not the class terminator. Skip it so the scanner does not
-        // exit the class prematurely.
-        if (index < source.length() && source.charAt(index) == '^') {
-          index++;
-        }
-        if (index < source.length() && source.charAt(index) == ']') {
-          index++;
-        }
         continue;
       }
       if (ch == '(' && index + 1 < source.length() && source.charAt(index + 1) == '?') {
@@ -947,37 +958,20 @@ public class RuntimeCompiler {
     PROFILE_INELIGIBLE
   }
 
-  record NamedOnlyLtsCompilation(
-      LinearTokenSequenceMatcher matcher, NamedOnlyLtsRejection rejection) {
-    NamedOnlyLtsCompilation {
+  /** Result of a linear-token-sequence admission attempt: exactly one of matcher/rejection. */
+  record Compilation<R>(LinearTokenSequenceMatcher matcher, R rejection) {
+    Compilation {
       if ((matcher == null) == (rejection == null)) {
         throw new IllegalArgumentException("exactly one of matcher or rejection is required");
       }
     }
 
-    static NamedOnlyLtsCompilation admitted(LinearTokenSequenceMatcher matcher) {
-      return new NamedOnlyLtsCompilation(matcher, null);
+    static <R> Compilation<R> admitted(LinearTokenSequenceMatcher matcher) {
+      return new Compilation<>(matcher, null);
     }
 
-    static NamedOnlyLtsCompilation rejected(NamedOnlyLtsRejection rejection) {
-      return new NamedOnlyLtsCompilation(null, rejection);
-    }
-  }
-
-  record FullCaptureLtsCompilation(
-      LinearTokenSequenceMatcher matcher, FullCaptureLtsRejection rejection) {
-    FullCaptureLtsCompilation {
-      if ((matcher == null) == (rejection == null)) {
-        throw new IllegalArgumentException("exactly one of matcher or rejection is required");
-      }
-    }
-
-    static FullCaptureLtsCompilation admitted(LinearTokenSequenceMatcher matcher) {
-      return new FullCaptureLtsCompilation(matcher, null);
-    }
-
-    static FullCaptureLtsCompilation rejected(FullCaptureLtsRejection rejection) {
-      return new FullCaptureLtsCompilation(null, rejection);
+    static <R> Compilation<R> rejected(R rejection) {
+      return new Compilation<>(null, rejection);
     }
   }
 
@@ -986,13 +980,15 @@ public class RuntimeCompiler {
    * represented by one deterministic plan operation. This path must not use general compilation or
    * its caches.
    */
-  static FullCaptureLtsCompilation tryCompileFullCaptureLinearTokenSequence(
+  static Compilation<FullCaptureLtsRejection> tryCompileFullCaptureLinearTokenSequence(
       String source, int flags) {
     if (flags != 0 && flags != ReggieFlags.DOTALL) {
-      return FullCaptureLtsCompilation.rejected(FullCaptureLtsRejection.UNSUPPORTED_FLAGS);
+      return Compilation.<FullCaptureLtsRejection>rejected(
+          FullCaptureLtsRejection.UNSUPPORTED_FLAGS);
     }
     if (hasSourceInlineModifier(source)) {
-      return FullCaptureLtsCompilation.rejected(FullCaptureLtsRejection.SOURCE_INLINE_MODIFIER);
+      return Compilation.<FullCaptureLtsRejection>rejected(
+          FullCaptureLtsRejection.SOURCE_INLINE_MODIFIER);
     }
     boolean dotAll = flags == ReggieFlags.DOTALL;
     try {
@@ -1000,218 +996,48 @@ public class RuntimeCompiler {
       RegexNode ast = parser.parse(dotAll ? "(?s)" + source : source);
       CaptureProjection.FullCaptureLayout layout = CaptureProjection.fullCaptureLayout(ast);
       if (layout == null) {
-        return FullCaptureLtsCompilation.rejected(FullCaptureLtsRejection.MISSING_CAPTURE);
+        return Compilation.<FullCaptureLtsRejection>rejected(
+            FullCaptureLtsRejection.MISSING_CAPTURE);
       }
       LinearTokenSequencePlan plan =
           LinearTokenSequencePlan.from(PatternCategorizer.categorize(ast)).orElse(null);
       if (plan == null) {
-        return FullCaptureLtsCompilation.rejected(FullCaptureLtsRejection.PLAN_UNAVAILABLE);
+        return Compilation.<FullCaptureLtsRejection>rejected(
+            FullCaptureLtsRejection.PLAN_UNAVAILABLE);
       }
-      if (!hasExactCaptureLayout(plan, layout.indexes()) || !hasOnlyDirectCaptureOps(plan)) {
-        return FullCaptureLtsCompilation.rejected(FullCaptureLtsRejection.MISSING_CAPTURE);
+      if (!CaptureBoundaryAnalysis.hasExactCaptureLayout(plan, layout.indexes())
+          || !CaptureBoundaryAnalysis.hasOnlyDirectCaptureOps(plan)) {
+        return Compilation.<FullCaptureLtsRejection>rejected(
+            FullCaptureLtsRejection.MISSING_CAPTURE);
       }
-      if (!hasDeterministicCaptureBoundaries(plan)
+      if (!CaptureBoundaryAnalysis.hasDeterministicCaptureBoundaries(
+              plan, LinearTokenSequenceMatcher.HTTP_VERSION_LITERAL)
           || !isRuntimeExecutableLinearTokenSequence(dotAll, plan)) {
-        return FullCaptureLtsCompilation.rejected(FullCaptureLtsRejection.PROFILE_INELIGIBLE);
+        return Compilation.<FullCaptureLtsRejection>rejected(
+            FullCaptureLtsRejection.PROFILE_INELIGIBLE);
       }
-      return FullCaptureLtsCompilation.admitted(
+      return Compilation.<FullCaptureLtsRejection>admitted(
           new LinearTokenSequenceMatcher(
               source, plan, layout.groupCount(), parser.getGroupNameMap()));
     } catch (RegexParser.ParseException e) {
-      return FullCaptureLtsCompilation.rejected(FullCaptureLtsRejection.PARSE_FAILURE);
+      return Compilation.<FullCaptureLtsRejection>rejected(FullCaptureLtsRejection.PARSE_FAILURE);
     } catch (UnsupportedOperationException | IllegalStateException e) {
-      return FullCaptureLtsCompilation.rejected(FullCaptureLtsRejection.PLAN_UNAVAILABLE);
+      return Compilation.<FullCaptureLtsRejection>rejected(
+          FullCaptureLtsRejection.PLAN_UNAVAILABLE);
+    } catch (StackOverflowError e) {
+      return Compilation.<FullCaptureLtsRejection>rejected(
+          FullCaptureLtsRejection.PLAN_UNAVAILABLE);
     }
   }
 
-  private static boolean hasExactCaptureLayout(
-      LinearTokenSequencePlan plan, Set<Integer> requiredIndexes) {
-    if (!plan.coversCaptureIndexes(requiredIndexes)) return false;
-    Map<Integer, Integer> occurrences = new java.util.HashMap<>();
-    countCaptureOperations(plan.ops(), occurrences);
-    if (occurrences.size() != requiredIndexes.size()) return false;
-    for (int index : requiredIndexes) {
-      if (occurrences.getOrDefault(index, 0) != 1) return false;
-    }
-    return true;
-  }
-
-  private static void countCaptureOperations(
-      java.util.List<LinearTokenSequencePlan.Op> ops, Map<Integer, Integer> occurrences) {
-    for (LinearTokenSequencePlan.Op op : ops) {
-      if (op.groupNumber() > 0) occurrences.merge(op.groupNumber(), 1, Integer::sum);
-      countCaptureOperations(op.children(), occurrences);
-    }
-  }
-
-  /** Declines categorizer transforms that do not retain a direct source-group boundary witness. */
-  private static boolean hasOnlyDirectCaptureOps(LinearTokenSequencePlan plan) {
-    return hasOnlyDirectCaptureOps(plan.ops());
-  }
-
-  private static boolean hasOnlyDirectCaptureOps(java.util.List<LinearTokenSequencePlan.Op> ops) {
-    for (LinearTokenSequencePlan.Op op : ops) {
-      if (op.kind() == LinearTokenSequencePlan.OpKind.CAPTURE_UNTIL_DELIMITER
-          || op.kind() == LinearTokenSequencePlan.OpKind.CAPTURE_QUOTED_UNTIL_DELIMITER
-          || op.kind() == LinearTokenSequencePlan.OpKind.CAPTURE_QUOTED_NON_SPACE
-          || op.kind() == LinearTokenSequencePlan.OpKind.CAPTURE_BRACKETED_WORD_AFTER_SKIP
-          || op.kind() == LinearTokenSequencePlan.OpKind.CAPTURE_IP_OR_HOST) {
-        return false;
-      }
-      if (!hasOnlyDirectCaptureOps(op.children())) return false;
-    }
-    return true;
-  }
-
-  private static boolean hasDeterministicCaptureBoundaries(LinearTokenSequencePlan plan) {
-    return hasDeterministicCaptureBoundaries(plan.ops());
-  }
-
-  private static boolean hasDeterministicCaptureBoundaries(
-      java.util.List<LinearTokenSequencePlan.Op> ops) {
-    for (int index = 0; index < ops.size(); index++) {
-      LinearTokenSequencePlan.Op op = ops.get(index);
-      if (op.kind() == LinearTokenSequencePlan.OpKind.OPTIONAL_SEQUENCE) {
-        LinearTokenSequencePlan.Op successor = index + 1 < ops.size() ? ops.get(index + 1) : null;
-        if (!isProvenOptionalHttpVersion(ops, index)
-            || !hasDeterministicCaptureBoundaries(op.children(), successor)) return false;
-        continue;
-      }
-      if (!op.children().isEmpty() && !hasDeterministicCaptureBoundaries(op.children()))
-        return false;
-      if (!isVariableWidth(op) || index == ops.size() - 1) continue;
-      LinearTokenSequencePlan.Op next = ops.get(index + 1);
-      if (next.groupNumber() > 0) return false;
-      if (next.kind() == LinearTokenSequencePlan.OpKind.OPTIONAL_SEQUENCE) {
-        if (next.children().isEmpty()
-            || next.children().get(0).kind() != LinearTokenSequencePlan.OpKind.LITERAL
-            || index + 2 == ops.size()
-            || !isBoundary(ops.get(index + 2))
-            || !isSafeLiteralBoundary(op, next.children().get(0).literal())) return false;
-      } else if (!isSafeBoundary(op, next)) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  private static boolean isProvenOptionalHttpVersion(
-      java.util.List<LinearTokenSequencePlan.Op> ops, int optionalIndex) {
-    if (optionalIndex + 1 >= ops.size()) return false;
-    LinearTokenSequencePlan.Op optional = ops.get(optionalIndex);
-    LinearTokenSequencePlan.Op successor = ops.get(optionalIndex + 1);
-    if (successor.kind() != LinearTokenSequencePlan.OpKind.LITERAL
-        || !successor.literal().startsWith("\"")
-        || optional.children().size() != 2) return false;
-    LinearTokenSequencePlan.Op prefix = optional.children().get(0);
-    LinearTokenSequencePlan.Op version = optional.children().get(1);
-    return prefix.kind() == LinearTokenSequencePlan.OpKind.LITERAL
-        && " HTTP/".equals(prefix.literal())
-        && version.kind() == LinearTokenSequencePlan.OpKind.CAPTURE_DECIMAL_NUMBER;
-  }
-
-  private static boolean hasDeterministicCaptureBoundaries(
-      java.util.List<LinearTokenSequencePlan.Op> ops, LinearTokenSequencePlan.Op successor) {
-    if (!hasDeterministicCaptureBoundaries(ops)) return false;
-    if (successor == null || ops.isEmpty()) return true;
-    LinearTokenSequencePlan.Op last = ops.get(ops.size() - 1);
-    return !isVariableWidth(last) || isSafeBoundary(last, successor);
-  }
-
-  private static boolean isVariableWidth(LinearTokenSequencePlan.Op op) {
-    return switch (op.kind()) {
-      case CAPTURE_NON_SPACE,
-          CAPTURE_DIGITS,
-          CAPTURE_SIGNED_INTEGER,
-          CAPTURE_DECIMAL_NUMBER,
-          CAPTURE_SIGNED_DECIMAL_NUMBER,
-          CAPTURE_WORD,
-          CAPTURE_UNTIL_DELIMITER,
-          CAPTURE_QUOTED_UNTIL_DELIMITER,
-          CAPTURE_QUOTED_NON_SPACE,
-          CAPTURE_IP_OR_HOST,
-          CAPTURE_SIGNED_INTEGER_OR_DASH,
-          CAPTURE_SIGNED_INTEGER_OR_UNCAPTURED_DASH,
-          CAPTURE_BRACKETED_WORD_AFTER_SKIP,
-          WHITESPACE_PLUS,
-          SKIP_ANY,
-          SKIP_ANY_EXCEPT_NEWLINE ->
-          true;
-      default -> false;
-    };
-  }
-
-  private static boolean isSafeBoundary(
-      LinearTokenSequencePlan.Op variable, LinearTokenSequencePlan.Op next) {
-    if (next.kind() == LinearTokenSequencePlan.OpKind.WHITESPACE_PLUS) {
-      return consumesNonWhitespace(variable);
-    }
-    return next.kind() == LinearTokenSequencePlan.OpKind.LITERAL
-        && isSafeLiteralBoundary(variable, next.literal());
-  }
-
-  private static boolean isSafeLiteralBoundary(
-      LinearTokenSequencePlan.Op variable, String literal) {
-    if (literal == null || literal.isEmpty()) return false;
-    char boundary = literal.charAt(0);
-    return switch (variable.kind()) {
-      case CAPTURE_NON_SPACE, CAPTURE_IP_OR_HOST, CAPTURE_QUOTED_NON_SPACE ->
-          isWhitespace(boundary);
-      case CAPTURE_DIGITS,
-          CAPTURE_SIGNED_INTEGER,
-          CAPTURE_SIGNED_INTEGER_OR_DASH,
-          CAPTURE_SIGNED_INTEGER_OR_UNCAPTURED_DASH ->
-          !isDigit(boundary);
-      case CAPTURE_DECIMAL_NUMBER, CAPTURE_SIGNED_DECIMAL_NUMBER ->
-          !isDigit(boundary) && boundary != '.';
-      case CAPTURE_WORD -> !isWord(boundary);
-      case WHITESPACE_PLUS -> !isWhitespace(boundary);
-      case CAPTURE_UNTIL_DELIMITER -> boundary == variable.delimiter();
-      case CAPTURE_QUOTED_UNTIL_DELIMITER, CAPTURE_BRACKETED_WORD_AFTER_SKIP -> true;
-      default -> false;
-    };
-  }
-
-  private static boolean consumesNonWhitespace(LinearTokenSequencePlan.Op op) {
-    return switch (op.kind()) {
-      case CAPTURE_NON_SPACE,
-          CAPTURE_DIGITS,
-          CAPTURE_SIGNED_INTEGER,
-          CAPTURE_DECIMAL_NUMBER,
-          CAPTURE_SIGNED_DECIMAL_NUMBER,
-          CAPTURE_WORD,
-          CAPTURE_IP_OR_HOST,
-          CAPTURE_SIGNED_INTEGER_OR_DASH,
-          CAPTURE_SIGNED_INTEGER_OR_UNCAPTURED_DASH,
-          CAPTURE_QUOTED_NON_SPACE ->
-          true;
-      default -> false;
-    };
-  }
-
-  private static boolean isWhitespace(char ch) {
-    return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\u000B' || ch == '\f' || ch == '\r';
-  }
-
-  private static boolean isDigit(char ch) {
-    return ch >= '0' && ch <= '9';
-  }
-
-  private static boolean isWord(char ch) {
-    return ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' || isDigit(ch) || ch == '_';
-  }
-
-  private static boolean isBoundary(LinearTokenSequencePlan.Op op) {
-    return op.kind() == LinearTokenSequencePlan.OpKind.WHITESPACE_PLUS
-        || op.kind() == LinearTokenSequencePlan.OpKind.LITERAL && !op.literal().isEmpty();
-  }
-
-  static NamedOnlyLtsCompilation tryCompileNamedOnlyLinearTokenSequence(String source, int flags) {
+  static Compilation<NamedOnlyLtsRejection> tryCompileNamedOnlyLinearTokenSequence(
+      String source, int flags) {
     if (flags != 0 && flags != ReggieFlags.DOTALL) {
-      return NamedOnlyLtsCompilation.rejected(NamedOnlyLtsRejection.UNSUPPORTED_FLAGS);
+      return Compilation.<NamedOnlyLtsRejection>rejected(NamedOnlyLtsRejection.UNSUPPORTED_FLAGS);
     }
     if (hasSourceInlineModifier(source)) {
-      return NamedOnlyLtsCompilation.rejected(NamedOnlyLtsRejection.SOURCE_INLINE_MODIFIER);
+      return Compilation.<NamedOnlyLtsRejection>rejected(
+          NamedOnlyLtsRejection.SOURCE_INLINE_MODIFIER);
     }
     boolean dotAll = flags == ReggieFlags.DOTALL;
     String parsePattern = dotAll ? "(?s)" + source : source;
@@ -1223,9 +1049,11 @@ public class RuntimeCompiler {
       return admitNamedOnlyLinearTokenSequence(
           source, ast, nameMap, new LinearTokenSequenceAdmission(true, dotAll));
     } catch (RegexParser.ParseException e) {
-      return NamedOnlyLtsCompilation.rejected(NamedOnlyLtsRejection.PARSE_FAILURE);
+      return Compilation.<NamedOnlyLtsRejection>rejected(NamedOnlyLtsRejection.PARSE_FAILURE);
     } catch (UnsupportedOperationException | IllegalStateException e) {
-      return NamedOnlyLtsCompilation.rejected(NamedOnlyLtsRejection.PLAN_UNAVAILABLE);
+      return Compilation.<NamedOnlyLtsRejection>rejected(NamedOnlyLtsRejection.PLAN_UNAVAILABLE);
+    } catch (StackOverflowError e) {
+      return Compilation.<NamedOnlyLtsRejection>rejected(NamedOnlyLtsRejection.PLAN_UNAVAILABLE);
     }
   }
 
@@ -1237,10 +1065,14 @@ public class RuntimeCompiler {
     if (!admission.isEligible()) {
       return null;
     }
-    return admitNamedOnlyLinearTokenSequence(pattern, ast, nameMap, admission).matcher();
+    ReggieMatcher m = admitNamedOnlyLinearTokenSequence(pattern, ast, nameMap, admission).matcher();
+    if (m != null && !m.embedsNameMap()) {
+      m = new NameEnrichingMatcher(m);
+    }
+    return m;
   }
 
-  private static NamedOnlyLtsCompilation admitNamedOnlyLinearTokenSequence(
+  private static Compilation<NamedOnlyLtsRejection> admitNamedOnlyLinearTokenSequence(
       String pattern,
       RegexNode ast,
       Map<String, Integer> nameMap,
@@ -1248,41 +1080,55 @@ public class RuntimeCompiler {
     LinearTokenSequencePlan plan =
         LinearTokenSequencePlan.from(PatternCategorizer.categorize(ast)).orElse(null);
     if (plan == null) {
-      return NamedOnlyLtsCompilation.rejected(NamedOnlyLtsRejection.PLAN_UNAVAILABLE);
+      return Compilation.<NamedOnlyLtsRejection>rejected(NamedOnlyLtsRejection.PLAN_UNAVAILABLE);
     }
     if (!plan.coversCaptureIndexes(nameMap.values())) {
-      return NamedOnlyLtsCompilation.rejected(NamedOnlyLtsRejection.MISSING_NAMED_CAPTURE);
+      return Compilation.<NamedOnlyLtsRejection>rejected(
+          NamedOnlyLtsRejection.MISSING_NAMED_CAPTURE);
     }
     if (!isRuntimeExecutableLinearTokenSequence(admission.isDotAll(), plan)) {
-      return NamedOnlyLtsCompilation.rejected(NamedOnlyLtsRejection.PROFILE_INELIGIBLE);
+      return Compilation.<NamedOnlyLtsRejection>rejected(NamedOnlyLtsRejection.PROFILE_INELIGIBLE);
     }
-    return NamedOnlyLtsCompilation.admitted(
+    return Compilation.<NamedOnlyLtsRejection>admitted(
         new LinearTokenSequenceMatcher(pattern, plan, countGroups(pattern), nameMap));
   }
 
   private static boolean isRuntimeExecutableLinearTokenSequence(
       boolean dotAll, LinearTokenSequencePlan plan) {
-    boolean requiresDotAll = false;
-    for (int i = 0; i < plan.ops().size(); i++) {
-      LinearTokenSequencePlan.Op op = plan.ops().get(i);
+    RuntimeExecutability executability = new RuntimeExecutability();
+    if (!isRuntimeExecutableLinearTokenSequence(plan.ops(), executability)) return false;
+    return !executability.requiresDotAll || dotAll;
+  }
+
+  private static final class RuntimeExecutability {
+    boolean requiresDotAll;
+  }
+
+  private static boolean isRuntimeExecutableLinearTokenSequence(
+      List<LinearTokenSequencePlan.Op> ops, RuntimeExecutability executability) {
+    for (int i = 0; i < ops.size(); i++) {
+      LinearTokenSequencePlan.Op op = ops.get(i);
       if (op.kind() == LinearTokenSequencePlan.OpKind.ANCHOR) return false;
-      if (op.kind() == LinearTokenSequencePlan.OpKind.SKIP_ANY_EXCEPT_NEWLINE) return false;
       if (op.kind() == LinearTokenSequencePlan.OpKind.SKIP_ANY
           || op.kind() == LinearTokenSequencePlan.OpKind.CAPTURE_BRACKETED_WORD_AFTER_SKIP) {
-        requiresDotAll = true;
+        executability.requiresDotAll = true;
       }
       if ((op.kind() == LinearTokenSequencePlan.OpKind.SKIP_ANY
               || op.kind() == LinearTokenSequencePlan.OpKind.SKIP_ANY_EXCEPT_NEWLINE)
-          && i != plan.ops().size() - 1) {
+          && i != ops.size() - 1) {
         return false;
       }
-      if (op.kind() == LinearTokenSequencePlan.OpKind.OPTIONAL_SEQUENCE
-          && i + 1 < plan.ops().size()
-          && canOptionalPresentBranchStealFollowingInput(op, plan.ops().get(i + 1))) {
+      if (op.kind() == LinearTokenSequencePlan.OpKind.SKIP_ANY_EXCEPT_NEWLINE && ops.size() == 1) {
         return false;
+      }
+      if (op.kind() == LinearTokenSequencePlan.OpKind.OPTIONAL_SEQUENCE) {
+        if (i + 1 < ops.size() && canOptionalPresentBranchStealFollowingInput(op, ops.get(i + 1))) {
+          return false;
+        }
+        if (!isRuntimeExecutableLinearTokenSequence(op.children(), executability)) return false;
       }
     }
-    return !requiresDotAll || dotAll;
+    return true;
   }
 
   private static boolean canOptionalPresentBranchStealFollowingInput(

--- a/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/RuntimeCompiler.java
+++ b/reggie-runtime/src/main/java/com/datadoghq/reggie/runtime/RuntimeCompiler.java
@@ -938,6 +938,15 @@ public class RuntimeCompiler {
     PROFILE_INELIGIBLE
   }
 
+  enum FullCaptureLtsRejection {
+    UNSUPPORTED_FLAGS,
+    SOURCE_INLINE_MODIFIER,
+    PARSE_FAILURE,
+    PLAN_UNAVAILABLE,
+    MISSING_CAPTURE,
+    PROFILE_INELIGIBLE
+  }
+
   record NamedOnlyLtsCompilation(
       LinearTokenSequenceMatcher matcher, NamedOnlyLtsRejection rejection) {
     NamedOnlyLtsCompilation {
@@ -953,6 +962,248 @@ public class RuntimeCompiler {
     static NamedOnlyLtsCompilation rejected(NamedOnlyLtsRejection rejection) {
       return new NamedOnlyLtsCompilation(null, rejection);
     }
+  }
+
+  record FullCaptureLtsCompilation(
+      LinearTokenSequenceMatcher matcher, FullCaptureLtsRejection rejection) {
+    FullCaptureLtsCompilation {
+      if ((matcher == null) == (rejection == null)) {
+        throw new IllegalArgumentException("exactly one of matcher or rejection is required");
+      }
+    }
+
+    static FullCaptureLtsCompilation admitted(LinearTokenSequenceMatcher matcher) {
+      return new FullCaptureLtsCompilation(matcher, null);
+    }
+
+    static FullCaptureLtsCompilation rejected(FullCaptureLtsRejection rejection) {
+      return new FullCaptureLtsCompilation(null, rejection);
+    }
+  }
+
+  /**
+   * Direct native LTS admission that preserves every source capture only when every boundary is
+   * represented by one deterministic plan operation. This path must not use general compilation or
+   * its caches.
+   */
+  static FullCaptureLtsCompilation tryCompileFullCaptureLinearTokenSequence(
+      String source, int flags) {
+    if (flags != 0 && flags != ReggieFlags.DOTALL) {
+      return FullCaptureLtsCompilation.rejected(FullCaptureLtsRejection.UNSUPPORTED_FLAGS);
+    }
+    if (hasSourceInlineModifier(source)) {
+      return FullCaptureLtsCompilation.rejected(FullCaptureLtsRejection.SOURCE_INLINE_MODIFIER);
+    }
+    boolean dotAll = flags == ReggieFlags.DOTALL;
+    try {
+      RegexParser parser = new RegexParser();
+      RegexNode ast = parser.parse(dotAll ? "(?s)" + source : source);
+      CaptureProjection.FullCaptureLayout layout = CaptureProjection.fullCaptureLayout(ast);
+      if (layout == null) {
+        return FullCaptureLtsCompilation.rejected(FullCaptureLtsRejection.MISSING_CAPTURE);
+      }
+      LinearTokenSequencePlan plan =
+          LinearTokenSequencePlan.from(PatternCategorizer.categorize(ast)).orElse(null);
+      if (plan == null) {
+        return FullCaptureLtsCompilation.rejected(FullCaptureLtsRejection.PLAN_UNAVAILABLE);
+      }
+      if (!hasExactCaptureLayout(plan, layout.indexes()) || !hasOnlyDirectCaptureOps(plan)) {
+        return FullCaptureLtsCompilation.rejected(FullCaptureLtsRejection.MISSING_CAPTURE);
+      }
+      if (!hasDeterministicCaptureBoundaries(plan)
+          || !isRuntimeExecutableLinearTokenSequence(dotAll, plan)) {
+        return FullCaptureLtsCompilation.rejected(FullCaptureLtsRejection.PROFILE_INELIGIBLE);
+      }
+      return FullCaptureLtsCompilation.admitted(
+          new LinearTokenSequenceMatcher(
+              source, plan, layout.groupCount(), parser.getGroupNameMap()));
+    } catch (RegexParser.ParseException e) {
+      return FullCaptureLtsCompilation.rejected(FullCaptureLtsRejection.PARSE_FAILURE);
+    } catch (UnsupportedOperationException | IllegalStateException e) {
+      return FullCaptureLtsCompilation.rejected(FullCaptureLtsRejection.PLAN_UNAVAILABLE);
+    }
+  }
+
+  private static boolean hasExactCaptureLayout(
+      LinearTokenSequencePlan plan, Set<Integer> requiredIndexes) {
+    if (!plan.coversCaptureIndexes(requiredIndexes)) return false;
+    Map<Integer, Integer> occurrences = new java.util.HashMap<>();
+    countCaptureOperations(plan.ops(), occurrences);
+    if (occurrences.size() != requiredIndexes.size()) return false;
+    for (int index : requiredIndexes) {
+      if (occurrences.getOrDefault(index, 0) != 1) return false;
+    }
+    return true;
+  }
+
+  private static void countCaptureOperations(
+      java.util.List<LinearTokenSequencePlan.Op> ops, Map<Integer, Integer> occurrences) {
+    for (LinearTokenSequencePlan.Op op : ops) {
+      if (op.groupNumber() > 0) occurrences.merge(op.groupNumber(), 1, Integer::sum);
+      countCaptureOperations(op.children(), occurrences);
+    }
+  }
+
+  /** Declines categorizer transforms that do not retain a direct source-group boundary witness. */
+  private static boolean hasOnlyDirectCaptureOps(LinearTokenSequencePlan plan) {
+    return hasOnlyDirectCaptureOps(plan.ops());
+  }
+
+  private static boolean hasOnlyDirectCaptureOps(java.util.List<LinearTokenSequencePlan.Op> ops) {
+    for (LinearTokenSequencePlan.Op op : ops) {
+      if (op.kind() == LinearTokenSequencePlan.OpKind.CAPTURE_UNTIL_DELIMITER
+          || op.kind() == LinearTokenSequencePlan.OpKind.CAPTURE_QUOTED_UNTIL_DELIMITER
+          || op.kind() == LinearTokenSequencePlan.OpKind.CAPTURE_QUOTED_NON_SPACE
+          || op.kind() == LinearTokenSequencePlan.OpKind.CAPTURE_BRACKETED_WORD_AFTER_SKIP
+          || op.kind() == LinearTokenSequencePlan.OpKind.CAPTURE_IP_OR_HOST) {
+        return false;
+      }
+      if (!hasOnlyDirectCaptureOps(op.children())) return false;
+    }
+    return true;
+  }
+
+  private static boolean hasDeterministicCaptureBoundaries(LinearTokenSequencePlan plan) {
+    return hasDeterministicCaptureBoundaries(plan.ops());
+  }
+
+  private static boolean hasDeterministicCaptureBoundaries(
+      java.util.List<LinearTokenSequencePlan.Op> ops) {
+    for (int index = 0; index < ops.size(); index++) {
+      LinearTokenSequencePlan.Op op = ops.get(index);
+      if (op.kind() == LinearTokenSequencePlan.OpKind.OPTIONAL_SEQUENCE) {
+        LinearTokenSequencePlan.Op successor = index + 1 < ops.size() ? ops.get(index + 1) : null;
+        if (!isProvenOptionalHttpVersion(ops, index)
+            || !hasDeterministicCaptureBoundaries(op.children(), successor)) return false;
+        continue;
+      }
+      if (!op.children().isEmpty() && !hasDeterministicCaptureBoundaries(op.children()))
+        return false;
+      if (!isVariableWidth(op) || index == ops.size() - 1) continue;
+      LinearTokenSequencePlan.Op next = ops.get(index + 1);
+      if (next.groupNumber() > 0) return false;
+      if (next.kind() == LinearTokenSequencePlan.OpKind.OPTIONAL_SEQUENCE) {
+        if (next.children().isEmpty()
+            || next.children().get(0).kind() != LinearTokenSequencePlan.OpKind.LITERAL
+            || index + 2 == ops.size()
+            || !isBoundary(ops.get(index + 2))
+            || !isSafeLiteralBoundary(op, next.children().get(0).literal())) return false;
+      } else if (!isSafeBoundary(op, next)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean isProvenOptionalHttpVersion(
+      java.util.List<LinearTokenSequencePlan.Op> ops, int optionalIndex) {
+    if (optionalIndex + 1 >= ops.size()) return false;
+    LinearTokenSequencePlan.Op optional = ops.get(optionalIndex);
+    LinearTokenSequencePlan.Op successor = ops.get(optionalIndex + 1);
+    if (successor.kind() != LinearTokenSequencePlan.OpKind.LITERAL
+        || !successor.literal().startsWith("\"")
+        || optional.children().size() != 2) return false;
+    LinearTokenSequencePlan.Op prefix = optional.children().get(0);
+    LinearTokenSequencePlan.Op version = optional.children().get(1);
+    return prefix.kind() == LinearTokenSequencePlan.OpKind.LITERAL
+        && " HTTP/".equals(prefix.literal())
+        && version.kind() == LinearTokenSequencePlan.OpKind.CAPTURE_DECIMAL_NUMBER;
+  }
+
+  private static boolean hasDeterministicCaptureBoundaries(
+      java.util.List<LinearTokenSequencePlan.Op> ops, LinearTokenSequencePlan.Op successor) {
+    if (!hasDeterministicCaptureBoundaries(ops)) return false;
+    if (successor == null || ops.isEmpty()) return true;
+    LinearTokenSequencePlan.Op last = ops.get(ops.size() - 1);
+    return !isVariableWidth(last) || isSafeBoundary(last, successor);
+  }
+
+  private static boolean isVariableWidth(LinearTokenSequencePlan.Op op) {
+    return switch (op.kind()) {
+      case CAPTURE_NON_SPACE,
+          CAPTURE_DIGITS,
+          CAPTURE_SIGNED_INTEGER,
+          CAPTURE_DECIMAL_NUMBER,
+          CAPTURE_SIGNED_DECIMAL_NUMBER,
+          CAPTURE_WORD,
+          CAPTURE_UNTIL_DELIMITER,
+          CAPTURE_QUOTED_UNTIL_DELIMITER,
+          CAPTURE_QUOTED_NON_SPACE,
+          CAPTURE_IP_OR_HOST,
+          CAPTURE_SIGNED_INTEGER_OR_DASH,
+          CAPTURE_SIGNED_INTEGER_OR_UNCAPTURED_DASH,
+          CAPTURE_BRACKETED_WORD_AFTER_SKIP,
+          WHITESPACE_PLUS,
+          SKIP_ANY,
+          SKIP_ANY_EXCEPT_NEWLINE ->
+          true;
+      default -> false;
+    };
+  }
+
+  private static boolean isSafeBoundary(
+      LinearTokenSequencePlan.Op variable, LinearTokenSequencePlan.Op next) {
+    if (next.kind() == LinearTokenSequencePlan.OpKind.WHITESPACE_PLUS) {
+      return consumesNonWhitespace(variable);
+    }
+    return next.kind() == LinearTokenSequencePlan.OpKind.LITERAL
+        && isSafeLiteralBoundary(variable, next.literal());
+  }
+
+  private static boolean isSafeLiteralBoundary(
+      LinearTokenSequencePlan.Op variable, String literal) {
+    if (literal == null || literal.isEmpty()) return false;
+    char boundary = literal.charAt(0);
+    return switch (variable.kind()) {
+      case CAPTURE_NON_SPACE, CAPTURE_IP_OR_HOST, CAPTURE_QUOTED_NON_SPACE ->
+          isWhitespace(boundary);
+      case CAPTURE_DIGITS,
+          CAPTURE_SIGNED_INTEGER,
+          CAPTURE_SIGNED_INTEGER_OR_DASH,
+          CAPTURE_SIGNED_INTEGER_OR_UNCAPTURED_DASH ->
+          !isDigit(boundary);
+      case CAPTURE_DECIMAL_NUMBER, CAPTURE_SIGNED_DECIMAL_NUMBER ->
+          !isDigit(boundary) && boundary != '.';
+      case CAPTURE_WORD -> !isWord(boundary);
+      case WHITESPACE_PLUS -> !isWhitespace(boundary);
+      case CAPTURE_UNTIL_DELIMITER -> boundary == variable.delimiter();
+      case CAPTURE_QUOTED_UNTIL_DELIMITER, CAPTURE_BRACKETED_WORD_AFTER_SKIP -> true;
+      default -> false;
+    };
+  }
+
+  private static boolean consumesNonWhitespace(LinearTokenSequencePlan.Op op) {
+    return switch (op.kind()) {
+      case CAPTURE_NON_SPACE,
+          CAPTURE_DIGITS,
+          CAPTURE_SIGNED_INTEGER,
+          CAPTURE_DECIMAL_NUMBER,
+          CAPTURE_SIGNED_DECIMAL_NUMBER,
+          CAPTURE_WORD,
+          CAPTURE_IP_OR_HOST,
+          CAPTURE_SIGNED_INTEGER_OR_DASH,
+          CAPTURE_SIGNED_INTEGER_OR_UNCAPTURED_DASH,
+          CAPTURE_QUOTED_NON_SPACE ->
+          true;
+      default -> false;
+    };
+  }
+
+  private static boolean isWhitespace(char ch) {
+    return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\u000B' || ch == '\f' || ch == '\r';
+  }
+
+  private static boolean isDigit(char ch) {
+    return ch >= '0' && ch <= '9';
+  }
+
+  private static boolean isWord(char ch) {
+    return ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' || isDigit(ch) || ch == '_';
+  }
+
+  private static boolean isBoundary(LinearTokenSequencePlan.Op op) {
+    return op.kind() == LinearTokenSequencePlan.OpKind.WHITESPACE_PLUS
+        || op.kind() == LinearTokenSequencePlan.OpKind.LITERAL && !op.literal().isEmpty();
   }
 
   static NamedOnlyLtsCompilation tryCompileNamedOnlyLinearTokenSequence(String source, int flags) {

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/InterruptibleCharSequenceTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/InterruptibleCharSequenceTest.java
@@ -101,23 +101,18 @@ class InterruptibleCharSequenceTest {
         Cancellation.class, () -> optionalHttp.matches(decimalInput, 0, decimalInput.length()));
     assertTrue(decimalInput.maximumGap <= 256);
 
-    ReggieMatchState ipOrHost =
-        stateFor("(?<client>(?:[0-9]{1,3}\\.){3}[0-9]{1,3}|[A-Za-z0-9.-]+)");
-    Probe hostInput = new Probe(target, 4);
+    // Full numeric capture admission intentionally declines the IP-or-host alternation because
+    // it cannot prove one source-group boundary for both branches. This interruption regression
+    // needs only a long native non-space scan.
+    ReggieMatchState ipOrHost = stateFor("(?<client>\\S+)");
+    Probe hostInput = new Probe(target, 3);
     assertThrows(Cancellation.class, () -> ipOrHost.matches(hostInput, 0, hostInput.length()));
     assertTrue(hostInput.maximumGap <= 256);
   }
 
   @Test
-  void checkpointsLiteralQuotedBracketTailAndTailConsumptionScans() {
-    String longValue = "a".repeat(600);
+  void checkpointsLiteralPrefixAndTailConsumptionScans() {
     assertCancels("literal".repeat(100) + "(?<value>\\S+)", "literal".repeat(100) + "x");
-    assertCancels("ref=\"(?<value>[^\"]*)\"", "ref=\"" + longValue + "\"");
-    assertCancels(
-        ".* \\[(?<logger>\\b\\w+\\b)\\] .*",
-        "prefix [" + longValue + "] tail",
-        ReggieCompileFlag.DOTALL);
-    assertCancels("(?<value>\\S+) .*", "x " + longValue, ReggieCompileFlag.DOTALL);
   }
 
   @Test

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LinearTokenSequenceMatcherTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LinearTokenSequenceMatcherTest.java
@@ -528,7 +528,6 @@ class LinearTokenSequenceMatcherTest {
         new String[] {
           "(?i)(?<value>\\S+)",
           "(?m)(?<value>\\S+)",
-          "(?s)(?<value>\\S+)",
           "(?x)(?<value>\\S+)",
           "(?-i)(?<value>\\S+)",
           "(?im)(?<value>\\S+)",
@@ -537,6 +536,16 @@ class LinearTokenSequenceMatcherTest {
       Reggie.clearCache();
       assertNotLinearTokenSequenceDelegate(Reggie.compile(pattern, NAMED_ONLY_OPTIONS));
     }
+  }
+
+  @Test
+  void linearTokenSequenceAdmitsLeadingSourceDotAllModifierAsDotAllEquivalent() throws Exception {
+    // A leading "(?s)" with no other inline modifier is DOTALL-equivalent for the named-only
+    // route (see doc/plans/logs-backend.md), so it is admitted the same way an explicit
+    // ReggieFlags.DOTALL would be.
+    Reggie.clearCache();
+    assertDelegateType(
+        Reggie.compile("(?s)(?<value>\\S+)", NAMED_ONLY_OPTIONS), LinearTokenSequenceMatcher.class);
   }
 
   @Test

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LinearTokenSequenceMatcherTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/LinearTokenSequenceMatcherTest.java
@@ -314,8 +314,10 @@ class LinearTokenSequenceMatcherTest {
     assertDelegateType(nonWhitespace, LinearTokenSequenceMatcher.class);
     Pattern jdkWhitespace = Pattern.compile("\\s+");
     Pattern jdkNonWhitespace = Pattern.compile("\\S+");
+    // LTS \s mirrors CharSet.WHITESPACE (no \u000B); JDK \s includes \u000B.
+    // Verify consistency for the five characters both agree on.
 
-    for (char ch : new char[] {' ', '\t', '\n', '\u000B', '\f', '\r'}) {
+    for (char ch : new char[] {' ', '\t', '\n', '\f', '\r'}) {
       String input = String.valueOf(ch);
       assertEquals(
           jdkWhitespace.matcher(input).matches(),

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/NamedOnlyLtsAdmissionTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/NamedOnlyLtsAdmissionTest.java
@@ -19,10 +19,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.datadoghq.reggie.Reggie;
 import com.datadoghq.reggie.ReggieFlags;
 import com.datadoghq.reggie.ReggieOptions;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -42,7 +44,7 @@ class NamedOnlyLtsAdmissionTest {
     int patternCacheSize = RuntimeCompiler.cacheSize();
     int structuralCacheSize = RuntimeCompiler.structuralCacheSize();
 
-    RuntimeCompiler.NamedOnlyLtsCompilation compilation =
+    RuntimeCompiler.Compilation<RuntimeCompiler.NamedOnlyLtsRejection> compilation =
         RuntimeCompiler.tryCompileNamedOnlyLinearTokenSequence(
             ".* \\[(?<logger>\\b\\w+\\b)\\] .*", ReggieFlags.DOTALL);
 
@@ -86,9 +88,9 @@ class NamedOnlyLtsAdmissionTest {
 
   @Test
   void repeatedAdmissionsReturnIndependentMatchers() {
-    RuntimeCompiler.NamedOnlyLtsCompilation first =
+    RuntimeCompiler.Compilation<RuntimeCompiler.NamedOnlyLtsRejection> first =
         RuntimeCompiler.tryCompileNamedOnlyLinearTokenSequence("(?<value>\\S+)", 0);
-    RuntimeCompiler.NamedOnlyLtsCompilation second =
+    RuntimeCompiler.Compilation<RuntimeCompiler.NamedOnlyLtsRejection> second =
         RuntimeCompiler.tryCompileNamedOnlyLinearTokenSequence("(?<value>\\S+)", 0);
 
     assertNotNull(first.matcher());
@@ -101,7 +103,7 @@ class NamedOnlyLtsAdmissionTest {
   @Test
   void preservesOriginalNamedIndexWhileProjectingAnUnnamedCapture() {
     String pattern = "(x)(?<value>\\S+)";
-    RuntimeCompiler.NamedOnlyLtsCompilation direct =
+    RuntimeCompiler.Compilation<RuntimeCompiler.NamedOnlyLtsRejection> direct =
         RuntimeCompiler.tryCompileNamedOnlyLinearTokenSequence(pattern, 0);
     ReggieMatcher legacy = Reggie.compile(pattern, ReggieOptions.builder().namedOnly().build());
 
@@ -121,27 +123,34 @@ class NamedOnlyLtsAdmissionTest {
         RuntimeCompiler.tryCompileNamedOnlyLinearTokenSequence("(?<value>\\S+)", 0).matcher();
     ExecutorService executor = Executors.newFixedThreadPool(4);
     CountDownLatch done = new CountDownLatch(4);
+    ConcurrentLinkedQueue<Throwable> failures = new ConcurrentLinkedQueue<>();
     for (int thread = 0; thread < 4; thread++) {
       int id = thread;
       executor.execute(
           () -> {
-            LinearTokenSequenceMatcher independent =
-                RuntimeCompiler.tryCompileNamedOnlyLinearTokenSequence("(?<value>\\S+)", 0)
-                    .matcher();
-            for (int iteration = 0; iteration < 100; iteration++) {
-              assertEquals("shared", shared.match("shared").group("value"));
-              assertEquals("value" + id, independent.match("value" + id).group("value"));
+            try {
+              LinearTokenSequenceMatcher independent =
+                  RuntimeCompiler.tryCompileNamedOnlyLinearTokenSequence("(?<value>\\S+)", 0)
+                      .matcher();
+              for (int iteration = 0; iteration < 100; iteration++) {
+                assertEquals("shared", shared.match("shared").group("value"));
+                assertEquals("value" + id, independent.match("value" + id).group("value"));
+              }
+            } catch (Throwable failure) {
+              failures.add(failure);
+            } finally {
+              done.countDown();
             }
-            done.countDown();
           });
     }
-    assertEquals(true, done.await(10, TimeUnit.SECONDS));
+    assertTrue(done.await(10, TimeUnit.SECONDS), "workers did not finish");
     executor.shutdownNow();
+    assertTrue(failures.isEmpty(), () -> "concurrent LTS failure: " + failures.peek());
   }
 
   private static void assertRejected(
       String source, int flags, RuntimeCompiler.NamedOnlyLtsRejection expected) {
-    RuntimeCompiler.NamedOnlyLtsCompilation compilation =
+    RuntimeCompiler.Compilation<RuntimeCompiler.NamedOnlyLtsRejection> compilation =
         RuntimeCompiler.tryCompileNamedOnlyLinearTokenSequence(source, flags);
     assertNull(compilation.matcher());
     assertEquals(expected, compilation.rejection());

--- a/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/ReggieCompiledPatternTest.java
+++ b/reggie-runtime/src/test/java/com/datadoghq/reggie/runtime/ReggieCompiledPatternTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.datadoghq.reggie.Reggie;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -77,14 +78,11 @@ class ReggieCompiledPatternTest {
     assertThrows(NullPointerException.class, () -> new ReggieCompileRequest("pattern", null));
 
     ReggieMatchState state =
-        ReggieCompiledPattern.tryCompile(
-                new ReggieCompileRequest(
-                    ".* \\[(?<logger>\\b\\w+\\b)\\] .*", ReggieCompileFlag.DOTALL))
+        ReggieCompiledPattern.tryCompile(new ReggieCompileRequest(".*", ReggieCompileFlag.DOTALL))
             .pattern()
             .newState();
-    assertTrue(state.matches(new GuardedCharSequence("before\n [nginx] after"), 0, 21));
-    assertEquals(9, state.start("logger"));
-    assertEquals(14, state.end("logger"));
+    assertTrue(state.matches(new GuardedCharSequence("before\nafter"), 0, 12));
+    assertEquals(0, state.groupCount());
   }
 
   @Test
@@ -103,12 +101,35 @@ class ReggieCompiledPatternTest {
   }
 
   @Test
-  void usesTheNamedCaptureAfterAnUnnamedProjectedGroup() {
-    ReggieMatchState state = admitted("(x)(?<value>\\S+)").pattern().newState();
+  void exposesEverySourceNumericCaptureAndRetainsNamedAccess() {
+    String source = "(\\S+) (?<value>\\d+)";
+    String input = "host 200";
+    java.util.regex.Matcher jdk = java.util.regex.Pattern.compile(source).matcher(input);
+    assertTrue(jdk.matches());
+    ReggieMatchState state = admitted(source).pattern().newState();
 
-    assertTrue(state.matches(new GuardedCharSequence("xvalue"), 0, 6));
-    assertEquals(1, state.start("value"));
-    assertEquals(6, state.end("value"));
+    assertTrue(state.matches(new GuardedCharSequence(input), 0, input.length()));
+    assertEquals(jdk.groupCount(), state.groupCount());
+    for (int group = 0; group <= state.groupCount(); group++) {
+      assertEquals(jdk.start(group), state.start(group));
+      assertEquals(jdk.end(group), state.end(group));
+    }
+    assertEquals(jdk.start("value"), state.start("value"));
+    assertEquals(jdk.end("value"), state.end("value"));
+  }
+
+  @Test
+  void reportsUnmatchedOptionalNumericCaptureSpans() {
+    String source = "\"(?<method>\\w+)(?: HTTP/(\\d+\\.\\d+)|)\"";
+    ReggieMatchState state = admitted(source).pattern().newState();
+
+    assertTrue(state.matches(new GuardedCharSequence("\"GET\""), 0, 5));
+    assertEquals(2, state.groupCount());
+    assertEquals(-1, state.start(2));
+    assertEquals(-1, state.end(2));
+    assertTrue(state.matches(new GuardedCharSequence("\"GET HTTP/1.1\""), 0, 14));
+    assertEquals(10, state.start(2));
+    assertEquals(13, state.end(2));
   }
 
   @Test
@@ -126,6 +147,11 @@ class ReggieCompiledPatternTest {
     assertThrows(IllegalStateException.class, state::end);
     assertThrows(NullPointerException.class, () -> state.matches(null, 0, 0));
     assertThrows(IllegalStateException.class, () -> state.end("value"));
+    assertThrows(IllegalStateException.class, () -> state.start(0));
+
+    assertTrue(state.matches(new GuardedCharSequence("value"), 0, 5));
+    assertThrows(IndexOutOfBoundsException.class, () -> state.start(-1));
+    assertThrows(IndexOutOfBoundsException.class, () -> state.end(state.groupCount() + 1));
   }
 
   @Test
@@ -139,6 +165,68 @@ class ReggieCompiledPatternTest {
     assertEquals(-1, state.start("version"));
     assertEquals(-1, state.end("version"));
     assertThrows(IllegalArgumentException.class, () -> state.start("missing"));
+  }
+
+  @Test
+  void rejectsCaptureLayoutsAndBoundariesThatCannotBeProven() {
+    assertRejected("((\\S+))");
+    assertRejected("(?:(\\S+)|(\\d+))");
+    assertRejected("(?|(\\S+)|(\\d+))");
+    assertRejected("(?<left>\\S+)(?<right>\\S+)");
+    assertRejected("(\\d+)(\\d+)");
+    assertRejected("(\\S+)(\\d+)");
+    assertRejected("(?<left>\\S+)x");
+    assertRejected("(?<left>\\d+)1");
+    assertRejected("\\S+(?<right>\\S+)");
+    assertRejected("\\S+(?:x|)x");
+    assertRejected("(?<a>\\S+)(?: (?<b>\\S+)|)x");
+    assertRejected("(?:a|)(\\S+)");
+    assertRejected("(?:\\S+|)\\S+");
+    assertRejected("\\[(foo)\\]");
+    assertRejected(".* \\[(?<logger>\\b\\w+\\b)\\] .*");
+    assertRejected("(?<client>[A-Za-z0-9.-]+)");
+  }
+
+  @Test
+  void dotAllUsesTheEffectiveInternalSourceWhileInlineModifiersReject() {
+    assertRejected(".*");
+    ReggieMatchState dotAll =
+        ReggieCompiledPattern.tryCompile(new ReggieCompileRequest(".*", ReggieCompileFlag.DOTALL))
+            .pattern()
+            .newState();
+    assertTrue(dotAll.matches(new GuardedCharSequence("before\nafter"), 0, 12));
+    assertRejected("(?s).*");
+    assertRejected("(?s:.*)");
+  }
+
+  @Test
+  void directFullCaptureCompilationDoesNotUseLegacyCaches() {
+    String source = "(\\S+) (?<value>\\d+)";
+    int patterns = RuntimeCompiler.cacheSize();
+    int structures = RuntimeCompiler.structuralCacheSize();
+
+    assertTrue(admitted(source).pattern() != null);
+    assertEquals(patterns, RuntimeCompiler.cacheSize());
+    assertEquals(structures, RuntimeCompiler.structuralCacheSize());
+    Reggie.compile(source);
+    int legacyPatterns = RuntimeCompiler.cacheSize();
+    int legacyStructures = RuntimeCompiler.structuralCacheSize();
+    assertTrue(admitted(source).pattern() != null);
+    assertEquals(legacyPatterns, RuntimeCompiler.cacheSize());
+    assertEquals(legacyStructures, RuntimeCompiler.structuralCacheSize());
+  }
+
+  @Test
+  void retainsOnlySpansWhenTheCallerMutatesItsCharSequence() {
+    ReggieMatchState state = admitted("(\\S+) (?<value>\\d+)").pattern().newState();
+    MutableGuardedCharSequence input = new MutableGuardedCharSequence("host 200");
+
+    assertTrue(state.matches(input, 0, input.length()));
+    input.replace("changed 999");
+    assertEquals(0, state.start(1));
+    assertEquals(4, state.end(1));
+    assertEquals(5, state.start(2));
+    assertEquals(8, state.end(2));
   }
 
   @Test
@@ -176,6 +264,12 @@ class ReggieCompiledPatternTest {
     return result;
   }
 
+  private static void assertRejected(String source) {
+    ReggieCompilationResult result =
+        ReggieCompiledPattern.tryCompile(new ReggieCompileRequest(source, ReggieCompileFlag.NONE));
+    assertFalse(result.isAdmitted(), () -> "unexpected admission: " + source);
+  }
+
   private static final class GuardedCharSequence implements CharSequence {
     private final String value;
 
@@ -201,6 +295,38 @@ class ReggieCompiledPatternTest {
     @Override
     public String toString() {
       throw new AssertionError("matching must not materialize the input");
+    }
+  }
+
+  private static final class MutableGuardedCharSequence implements CharSequence {
+    private String value;
+
+    private MutableGuardedCharSequence(String value) {
+      this.value = value;
+    }
+
+    void replace(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public int length() {
+      return value.length();
+    }
+
+    @Override
+    public char charAt(int index) {
+      return value.charAt(index);
+    }
+
+    @Override
+    public CharSequence subSequence(int start, int end) {
+      throw new AssertionError("matching must not materialize a subsequence");
+    }
+
+    @Override
+    public String toString() {
+      throw new AssertionError("matching must not materialize input");
     }
   }
 }


### PR DESCRIPTION
Adds a conservative direct native full-capture LTS profile for the logs migration stack.\n\n- preserves numeric spans for admitted source captures\n- fails closed on unproven capture/control-flow transforms\n- keeps legacy named-only routing and caches isolated\n\nValidation: spotlessApply; focused runtime tests; :reggie-runtime:test.